### PR TITLE
feat(core): implement real functionality for stubs

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -58,8 +58,8 @@ Ask: Search for TODO|FIXME across the repo with 2 lines of context in .rs files
 
 - `list_files(path, max_items?, include_hidden?)`
 - `read_file(path, max_bytes?)`
-- `write_file(path, content, overwrite?)`
-- `edit_file(path, old_str, new_str)`
+- `write_file(path, content, mode?)` — mode: `overwrite`, `append`, or `skip_if_exists`
+- `edit_file(path, old_str, new_str)` — tolerant to whitespace differences
 
 ## Tips
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -59,7 +59,7 @@ Ask: Search for TODO|FIXME across the repo with 2 lines of context in .rs files
 - `list_files(path, max_items?, include_hidden?)`
 - `read_file(path, max_bytes?)`
 - `write_file(path, content, mode?)` — mode: `overwrite`, `append`, or `skip_if_exists`
-- `edit_file(path, old_str, new_str)` — tolerant to whitespace differences
+- `edit_file(path, old_str, new_str)` — tolerant to whitespace differences and detects rename conflicts
 
 ## stats (session metrics)
 
@@ -72,3 +72,4 @@ tool.
 - The agent respects `.vtagentgitignore` to exclude files from search and I/O.
 - Prefer `rp_search` for fast, focused searches with glob filters and context.
 - Ask for “N lines of context” when searching to understand usage in-place.
+- Shell commands are filtered by allow/deny lists and can be extended via `VTAGENT_<AGENT>_COMMANDS_*` environment variables.

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -61,6 +61,12 @@ Ask: Search for TODO|FIXME across the repo with 2 lines of context in .rs files
 - `write_file(path, content, mode?)` — mode: `overwrite`, `append`, or `skip_if_exists`
 - `edit_file(path, old_str, new_str)` — tolerant to whitespace differences
 
+## stats (session metrics)
+
+Display current configuration, available tools, and live performance metrics for the running
+session. Use `--format` to choose `text`, `json`, or `html` output and `--detailed` to list each
+tool.
+
 ## Tips
 
 - The agent respects `.vtagentgitignore` to exclude files from search and I/O.

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -20,9 +20,9 @@ Your capabilities:
 Within this context, VTAgent refers to the open-source agentic coding interface created by vinhnx, not any other coding tools or models.
 
 ## AVAILABLE TOOLS
-- **File Operations**: list_files, read_file, write_file, edit_file
+- **File Operations**: list_files, read_file, write_file, edit_file (rename conflict detection and safe writes)
 - **Search & Analysis**: grep_search (modes: exact, fuzzy, multi, similarity) and ast_grep_search
-- **Terminal Access**: run_terminal_cmd (modes: terminal, pty, streaming)
+- **Terminal Access**: run_terminal_cmd (modes: terminal, pty, streaming) with per-agent allow/deny policies
 
 ### Advanced Code Analysis
 VTAgent provides intelligent code analysis tools that understand code structure:

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -462,12 +462,15 @@ Before yielding to user:
 - **Verify file existence** before operations using list_files or search tools
 - **Read files first** to understand current state before making changes
 - **Test changes** after making modifications to ensure correctness
+- **`write_file` supports modes**: overwrite, append, and skip_if_exists
+- **`edit_file` matches text** exactly but tolerates whitespace differences
 
 ### Search Operations
 - **Choose appropriate search tools** based on query type and scope
 - **Use ripgrep (rp_search)** for fast, broad text searches
 - **Use AST grep** for syntax-aware code pattern matching
 - **Combine search tools** when comprehensive analysis is needed
+- **Retrieve latest rp_search results** via tool registry when needed
 
 ### Terminal Operations
 - **Select execution mode** based on command requirements (terminal, pty, streaming)

--- a/scripts/test_tools_e2e.sh
+++ b/scripts/test_tools_e2e.sh
@@ -44,12 +44,15 @@ test_tool_directly() {
 
     echo -e "\n${YELLOW}Testing $tool_name tool directly${NC}"
 
-    # Try to build and test the tool
+    # Build and execute the tool through the binary
     if cargo build --bin vtagent >/dev/null 2>&1; then
-        # If binary builds, we could test it directly
-        # For now, just check if it compiles
-        echo -e "${GREEN}Tool compiles successfully${NC}"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+        output=$(cargo run --quiet --bin vtagent -- "$tool_name" "$test_input" 2>/dev/null)
+        if echo "$output" | grep -q "$expected_contains"; then
+            echo -e "${GREEN}Tool output verified${NC}"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+        else
+            echo -e "${RED}❌ Unexpected tool output${NC}"
+        fi
     else
         echo -e "${RED}❌ Tool compilation failed${NC}"
     fi

--- a/src/cli/trajectory.rs
+++ b/src/cli/trajectory.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use console::style;
 use serde::Deserialize;
 use serde_json::Value;
@@ -177,12 +178,11 @@ pub async fn handle_trajectory_command(
 }
 
 fn format_timestamp(ts: i64) -> String {
-    if let Some(_dt) = SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_secs(ts as u64))
-    {
-        // For simplicity, just return a basic format. In a real implementation,
-        // you might want to use chrono for better date formatting.
-        format!("{}", ts)
+    if let Some(dt) = NaiveDateTime::from_timestamp_opt(ts, 0) {
+        DateTime::<Utc>::from_utc(dt, Utc)
+            .format("%Y-%m-%d %H:%M:%S UTC")
+            .to_string()
     } else {
-        format!("{}", ts)
+        ts.to_string()
     }
 }

--- a/tests/compaction_engine_test.rs
+++ b/tests/compaction_engine_test.rs
@@ -1,0 +1,26 @@
+use vtagent_core::core::agent::types::MessageType;
+use vtagent_core::core::agent::{CompactionConfig, CompactionEngine};
+use vtagent_core::gemini::Content;
+
+#[tokio::test]
+async fn compaction_engine_compacts_messages() {
+    let mut config = CompactionConfig::default();
+    config.max_uncompressed_messages = 1;
+    let engine = CompactionEngine::with_config(config);
+
+    let msg = Content::user_text("hello world");
+    engine
+        .add_message(&msg, MessageType::UserMessage)
+        .await
+        .unwrap();
+    engine
+        .add_message(&msg, MessageType::UserMessage)
+        .await
+        .unwrap();
+
+    assert!(engine.should_compact().await.unwrap());
+    let result = engine.compact_messages_intelligently().await.unwrap();
+    assert_eq!(result.messages_compacted, 1);
+    let stats = engine.get_statistics().await.unwrap();
+    assert_eq!(stats.total_messages, 1);
+}

--- a/tests/file_operations_test.rs
+++ b/tests/file_operations_test.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;
-use vtagent_core::tools::{ToolRegistry, build_function_declarations};
+use vtagent_core::tools::{build_function_declarations, ToolRegistry};
 
 #[tokio::test]
 async fn test_tool_availability() -> Result<()> {
@@ -88,6 +88,67 @@ async fn test_edit_file_with_whitespace_tolerance() -> Result<()> {
     let read_result = registry.read_file(read_args).await?;
     let content = read_result["content"].as_str().unwrap();
     assert!(content.contains("model3"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_write_file_append_and_skip() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let mut registry = ToolRegistry::new(temp_dir.path().to_path_buf());
+
+    // Write initial content
+    let args = json!({
+        "path": "log.txt",
+        "content": "Line1\n",
+        "mode": "overwrite"
+    });
+    registry.write_file(args).await?;
+
+    // Append content
+    let args = json!({
+        "path": "log.txt",
+        "content": "Line2\n",
+        "mode": "append"
+    });
+    registry.write_file(args).await?;
+
+    // Try skip_if_exists
+    let args = json!({
+        "path": "log.txt",
+        "content": "ShouldNotAppear",
+        "mode": "skip_if_exists"
+    });
+    let result = registry.write_file(args).await?;
+    assert_eq!(result["skipped"], true);
+
+    // Verify file content
+    let read_args = json!({ "path": "log.txt" });
+    let read_result = registry.read_file(read_args).await?;
+    let content = read_result["content"].as_str().unwrap();
+    assert!(content.contains("Line1"));
+    assert!(content.contains("Line2"));
+    assert!(!content.contains("ShouldNotAppear"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_edit_file_error_when_missing() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let mut registry = ToolRegistry::new(temp_dir.path().to_path_buf());
+
+    let test_file = temp_dir.path().join("sample.txt");
+    fs::write(&test_file, "original")?;
+
+    let args = json!({
+        "path": "sample.txt",
+        "old_str": "missing",
+        "new_str": "new"
+    });
+
+    let err = registry.edit_file(args).await.unwrap_err();
+    assert!(err.to_string().contains("Could not find"));
 
     Ok(())
 }

--- a/tests/refactoring_engine_test.rs
+++ b/tests/refactoring_engine_test.rs
@@ -1,0 +1,72 @@
+use std::fs;
+use tempfile::tempdir;
+use vtagent_core::tools::tree_sitter::analyzer::Position;
+use vtagent_core::tools::tree_sitter::refactoring::{
+    CodeChange, RefactoringEngine, RefactoringKind, RefactoringOperation, TextRange,
+};
+
+fn make_range(offset: usize, len: usize) -> TextRange {
+    TextRange {
+        start: Position {
+            row: 0,
+            column: offset,
+            byte_offset: offset,
+        },
+        end: Position {
+            row: 0,
+            column: offset + len,
+            byte_offset: offset + len,
+        },
+    }
+}
+
+#[test]
+fn rename_conflict_detected() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("conflict.rs");
+    let content = "let x = 1;\nlet y = 2;\nprintln!(\"{}\", x);\n";
+    fs::write(&file, content).unwrap();
+    let start = content.find("x = 1").unwrap();
+    let range = make_range(start, 1);
+    let op = RefactoringOperation {
+        kind: RefactoringKind::Rename,
+        description: "rename x to y".to_string(),
+        changes: vec![CodeChange {
+            file_path: file.to_string_lossy().into(),
+            old_range: range,
+            new_text: "y".to_string(),
+            description: String::new(),
+        }],
+        preview: vec![],
+    };
+    let mut engine = RefactoringEngine::new();
+    let result = engine.apply_refactoring(&op).unwrap();
+    assert!(!result.success);
+    assert!(!result.conflicts.is_empty());
+}
+
+#[test]
+fn rename_applies_change() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("rename.rs");
+    let content = "let x = 1;\nprintln!(\"{}\", x);\n";
+    fs::write(&file, content).unwrap();
+    let start = content.find("x = 1").unwrap();
+    let range = make_range(start, 1);
+    let op = RefactoringOperation {
+        kind: RefactoringKind::Rename,
+        description: "rename x to z".to_string(),
+        changes: vec![CodeChange {
+            file_path: file.to_string_lossy().into(),
+            old_range: range,
+            new_text: "z".to_string(),
+            description: String::new(),
+        }],
+        preview: vec![],
+    };
+    let mut engine = RefactoringEngine::new();
+    let result = engine.apply_refactoring(&op).unwrap();
+    assert!(result.success);
+    let updated = fs::read_to_string(&file).unwrap();
+    assert!(updated.contains("let z = 1"));
+}

--- a/tests/stats_command_test.rs
+++ b/tests/stats_command_test.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use tempfile::TempDir;
+use tokio::time::{Duration, sleep};
+use vtagent_core::{
+    Agent, config::constants::models::google::GEMINI_2_5_FLASH_LITE, config::types::AgentConfig,
+    handle_stats_command,
+};
+
+#[tokio::test]
+async fn test_handle_stats_command_returns_agent_metrics() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let config = AgentConfig {
+        model: GEMINI_2_5_FLASH_LITE.to_string(),
+        api_key: "test_key".to_string(),
+        workspace: temp_dir.path().to_path_buf(),
+        verbose: false,
+    };
+    let mut agent = Agent::new(config)?;
+    agent.update_session_stats(5, 3, 1);
+    sleep(Duration::from_millis(10)).await;
+    let metrics = handle_stats_command(&agent, false, "json".to_string()).await?;
+    assert_eq!(metrics.total_api_calls, 5);
+    assert_eq!(metrics.tool_execution_count, 3);
+    assert_eq!(metrics.error_count, 1);
+    assert!(metrics.session_duration_seconds > 0);
+    Ok(())
+}

--- a/tests/test_dot_folder_system.sh
+++ b/tests/test_dot_folder_system.sh
@@ -21,12 +21,7 @@ cd test-vtagent-project || exit 1
 
 # Initialize project structure
 echo "Initializing project structure..."
-# In a real implementation, we would run: vtagent init-project
-# For now, we'll simulate the directory structure
-mkdir -p "$HOME/.vtagent/projects/test-vtagent-project/config"
-mkdir -p "$HOME/.vtagent/projects/test-vtagent-project/cache"
-mkdir -p "$HOME/.vtagent/projects/test-vtagent-project/embeddings"
-mkdir -p "$HOME/.vtagent/projects/test-vtagent-project/retrieval"
+cargo run --quiet --manifest-path /workspace/vtagent/Cargo.toml -- init-project --name test-vtagent-project --force >/dev/null 2>&1
 
 # Create project metadata
 cat > "$HOME/.vtagent/projects/test-vtagent-project/.project" << EOF
@@ -82,13 +77,23 @@ fi
 
 # Test 5: Test configuration loading priority
 echo -e "\nTest 5: Testing configuration concepts..."
-# In a real implementation, this would test the actual configuration loading
-echo "PASS: Configuration concepts validated"
+CONFIG_FILE="$PROJECT_DIR/config/vtagent.toml"
+if [ -f "$CONFIG_FILE" ]; then
+    echo "PASS: Configuration file found"
+else
+    echo "FAIL: Configuration file missing"
+    exit 1
+fi
 
 # Test 6: Test project identification
 echo -e "\nTest 6: Testing project identification..."
-# In a real implementation, this would test the actual project identification
-echo "PASS: Project identification concepts validated"
+IDENTIFIED_PROJECT=$(grep -o '"name"[ ]*:[ ]*"[^"]*"' "$PROJECT_DIR/.project" | head -n1 | cut -d'"' -f4)
+if [ "$IDENTIFIED_PROJECT" = "test-vtagent-project" ]; then
+    echo "PASS: Project identified correctly"
+else
+    echo "FAIL: Project identification failed"
+    exit 1
+fi
 
 # Cleanup
 echo -e "\nCleaning up test files..."

--- a/vtagent-core/src/commands/stats.rs
+++ b/vtagent-core/src/commands/stats.rs
@@ -1,16 +1,17 @@
 //! Stats command implementation - show session statistics and performance metrics
 
 use crate::config::types::{AgentConfig, OutputFormat, PerformanceMetrics};
+use crate::core::agent::core::Agent;
 use crate::tools::build_function_declarations;
 use anyhow::Result;
 use console::style;
 
 /// Handle the stats command - display session statistics and performance metrics
 pub async fn handle_stats_command(
-    config: AgentConfig,
+    agent: &Agent,
     detailed: bool,
     format: String,
-) -> Result<()> {
+) -> Result<PerformanceMetrics> {
     let output_format = match format.to_lowercase().as_str() {
         "text" => OutputFormat::Text,
         "json" => OutputFormat::Json,
@@ -20,24 +21,15 @@ pub async fn handle_stats_command(
 
     println!("{}", style("Session Statistics").cyan().bold());
 
-    // Mock performance metrics (in a real implementation, these would come from the agent)
-    let metrics = PerformanceMetrics {
-        session_duration_seconds: 0, // Would be tracked
-        total_api_calls: 0,
-        total_tokens_used: None,
-        average_response_time_ms: 0.0,
-        tool_execution_count: 0,
-        error_count: 0,
-        recovery_success_rate: 0.0,
-    };
+    let metrics = agent.performance_metrics();
 
     match output_format {
-        OutputFormat::Text => display_text_stats(&config, &metrics, detailed),
-        OutputFormat::Json => display_json_stats(&config, &metrics),
-        OutputFormat::Html => display_html_stats(&config, &metrics),
+        OutputFormat::Text => display_text_stats(agent.config(), &metrics, detailed),
+        OutputFormat::Json => display_json_stats(agent.config(), &metrics),
+        OutputFormat::Html => display_html_stats(agent.config(), &metrics),
     }
 
-    Ok(())
+    Ok(metrics)
 }
 
 fn display_text_stats(config: &AgentConfig, metrics: &PerformanceMetrics, detailed: bool) {

--- a/vtagent-core/src/core/agent/compaction.rs
+++ b/vtagent-core/src/core/agent/compaction.rs
@@ -9,10 +9,10 @@ pub use crate::core::agent::engine::*;
 pub use crate::core::agent::semantic::*;
 
 // Re-export specific types to avoid ambiguity
-pub use crate::core::agent::stats::CompactionResult;
-pub use crate::core::agent::stats::CompactionStatistics;
 pub use crate::core::agent::types::CompactedContext;
 pub use crate::core::agent::types::CompactedMessage;
+pub use crate::core::agent::types::CompactionResult;
+pub use crate::core::agent::types::CompactionStatistics;
 pub use crate::core::agent::types::CompactionSuggestion;
 pub use crate::core::agent::types::EnhancedMessage;
 pub use crate::core::agent::types::MessagePriority;

--- a/vtagent-core/src/core/agent/snapshots.rs
+++ b/vtagent-core/src/core/agent/snapshots.rs
@@ -6,7 +6,7 @@
 //! - Manage snapshot lifecycle and cleanup
 //! - Support compression and encryption
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -388,7 +388,7 @@ impl SnapshotManager {
             .compaction_engine()
             .get_statistics()
             .await
-            .unwrap_or_else(|_| crate::core::agent::stats::CompactionStatistics {
+            .unwrap_or_else(|_| crate::core::agent::types::CompactionStatistics {
                 total_messages: 0,
                 messages_by_priority: std::collections::HashMap::new(),
                 total_memory_usage: 0,

--- a/vtagent-core/src/core/orchestrator_retry.rs
+++ b/vtagent-core/src/core/orchestrator_retry.rs
@@ -4,9 +4,8 @@
 //! including retry mechanisms with exponential backoff and fallback strategies.
 
 use crate::config::models::ModelId;
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 

--- a/vtagent-core/src/tools/registry.rs
+++ b/vtagent-core/src/tools/registry.rs
@@ -8,21 +8,21 @@ use super::file_ops::FileOpsTool;
 use super::search::SearchTool;
 use super::simple_search::SimpleSearchTool;
 use super::traits::Tool;
-use crate::config::PtyConfig;
 use crate::config::constants::tools;
 use crate::config::loader::ConfigManager;
 use crate::config::types::CapabilityLevel;
+use crate::config::PtyConfig;
 use crate::gemini::FunctionDeclaration;
 use crate::tool_policy::{ToolPolicy, ToolPolicyManager};
 use crate::tools::ast_grep::AstGrepEngine;
-use crate::tools::grep_search::GrepSearchManager;
-use anyhow::{Context, Result, anyhow};
+use crate::tools::grep_search::{GrepSearchManager, GrepSearchResult};
+use anyhow::{anyhow, Context, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// Enhanced error handling for tool execution following Anthropic's best practices
 /// Provides detailed error information and recovery suggestions
@@ -183,7 +183,7 @@ pub struct ToolRegistry {
     bash_tool: BashTool,
     file_ops_tool: FileOpsTool,
     command_tool: CommandTool,
-    // Removed stored grep_search (no longer needed as a field)
+    grep_search: Arc<GrepSearchManager>,
     ast_grep_engine: Option<Arc<AstGrepEngine>>,
     tool_policy: ToolPolicyManager,
     pty_config: PtyConfig,
@@ -251,6 +251,7 @@ impl ToolRegistry {
             bash_tool,
             file_ops_tool,
             command_tool,
+            grep_search,
             ast_grep_engine,
             tool_policy: policy_manager,
             pty_config,
@@ -699,6 +700,11 @@ impl ToolRegistry {
 
     pub async fn rp_search(&mut self, args: Value) -> Result<Value> {
         self.execute_tool(tools::GREP_SEARCH, args).await
+    }
+
+    /// Get last ripgrep search result
+    pub fn last_rp_search_result(&self) -> Option<GrepSearchResult> {
+        self.grep_search.last_result()
     }
 
     pub async fn list_files(&mut self, args: Value) -> Result<Value> {

--- a/vtagent-core/src/tools/registry.rs
+++ b/vtagent-core/src/tools/registry.rs
@@ -8,21 +8,21 @@ use super::file_ops::FileOpsTool;
 use super::search::SearchTool;
 use super::simple_search::SimpleSearchTool;
 use super::traits::Tool;
+use crate::config::PtyConfig;
 use crate::config::constants::tools;
 use crate::config::loader::ConfigManager;
 use crate::config::types::CapabilityLevel;
-use crate::config::PtyConfig;
 use crate::gemini::FunctionDeclaration;
 use crate::tool_policy::{ToolPolicy, ToolPolicyManager};
 use crate::tools::ast_grep::AstGrepEngine;
 use crate::tools::grep_search::{GrepSearchManager, GrepSearchResult};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Enhanced error handling for tool execution following Anthropic's best practices
 /// Provides detailed error information and recovery suggestions
@@ -737,8 +737,12 @@ impl ToolRegistry {
             String::new()
         };
 
+        let mut deny_regex = cfg.commands.deny_regex.clone();
+        if let Ok(extra) = std::env::var("VTAGENT_COMMANDS_DENY_REGEX") {
+            deny_regex.extend(extra.split(',').map(|s| s.trim().to_string()));
+        }
         // Deny regex
-        for pat in &cfg.commands.deny_regex {
+        for pat in &deny_regex {
             if Regex::new(pat)
                 .ok()
                 .map(|re| re.is_match(&cmd_text))
@@ -747,8 +751,12 @@ impl ToolRegistry {
                 return Err(anyhow!("Command denied by regex policy: {}", pat));
             }
         }
+        let mut deny_glob = cfg.commands.deny_glob.clone();
+        if let Ok(extra) = std::env::var("VTAGENT_COMMANDS_DENY_GLOB") {
+            deny_glob.extend(extra.split(',').map(|s| s.trim().to_string()));
+        }
         // Deny glob (convert basic * to .*)
-        for pat in &cfg.commands.deny_glob {
+        for pat in &deny_glob {
             let re = format!("^{}$", regex::escape(pat).replace(r"\*", ".*"));
             if Regex::new(&re)
                 .ok()
@@ -759,17 +767,28 @@ impl ToolRegistry {
             }
         }
         // Exact deny list
-        for d in &cfg.commands.deny_list {
+        let mut deny_list = cfg.commands.deny_list.clone();
+        if let Ok(extra) = std::env::var("VTAGENT_COMMANDS_DENY_LIST") {
+            deny_list.extend(extra.split(',').map(|s| s.trim().to_string()));
+        }
+        for d in &deny_list {
             if cmd_text.starts_with(d) {
                 return Err(anyhow!("Command denied by policy: {}", d));
             }
         }
 
         // Allow: if allow_regex/glob present, require one match
-        let mut allow_ok =
-            cfg.commands.allow_regex.is_empty() && cfg.commands.allow_glob.is_empty();
+        let mut allow_regex = cfg.commands.allow_regex.clone();
+        if let Ok(extra) = std::env::var("VTAGENT_COMMANDS_ALLOW_REGEX") {
+            allow_regex.extend(extra.split(',').map(|s| s.trim().to_string()));
+        }
+        let mut allow_glob = cfg.commands.allow_glob.clone();
+        if let Ok(extra) = std::env::var("VTAGENT_COMMANDS_ALLOW_GLOB") {
+            allow_glob.extend(extra.split(',').map(|s| s.trim().to_string()));
+        }
+        let mut allow_ok = allow_regex.is_empty() && allow_glob.is_empty();
         if !allow_ok {
-            if cfg.commands.allow_regex.iter().any(|pat| {
+            if allow_regex.iter().any(|pat| {
                 Regex::new(pat)
                     .ok()
                     .map(|re| re.is_match(&cmd_text))
@@ -778,7 +797,7 @@ impl ToolRegistry {
                 allow_ok = true;
             }
             if !allow_ok
-                && cfg.commands.allow_glob.iter().any(|pat| {
+                && allow_glob.iter().any(|pat| {
                     let re = format!("^{}$", regex::escape(pat).replace(r"\*", ".*"));
                     Regex::new(&re)
                         .ok()
@@ -791,12 +810,12 @@ impl ToolRegistry {
         }
         if !allow_ok {
             // Fall back to exact allow_list if provided
-            if !cfg.commands.allow_list.is_empty() {
-                allow_ok = cfg
-                    .commands
-                    .allow_list
-                    .iter()
-                    .any(|p| cmd_text.starts_with(p));
+            let mut allow_list = cfg.commands.allow_list.clone();
+            if let Ok(extra) = std::env::var("VTAGENT_COMMANDS_ALLOW_LIST") {
+                allow_list.extend(extra.split(',').map(|s| s.trim().to_string()));
+            }
+            if !allow_list.is_empty() {
+                allow_ok = allow_list.iter().any(|p| cmd_text.starts_with(p));
             }
         }
         if !allow_ok {

--- a/vtagent-core/src/tools/tree_sitter/analyzer.rs
+++ b/vtagent-core/src/tools/tree_sitter/analyzer.rs
@@ -733,10 +733,10 @@ impl TreeSitterAnalyzer {
 
         Ok(CodeAnalysis {
             file_path: self.current_file.clone(),
-            language: language,
-            symbols: symbols,
-            dependencies: dependencies,
-            metrics: metrics,
+            language,
+            symbols,
+            dependencies,
+            metrics,
             issues: vec![], // Would need to implement actual issue detection
             complexity: Default::default(), // Would need to implement actual complexity analysis
             structure: Default::default(), // Would need to implement actual structure analysis
@@ -810,16 +810,12 @@ mod tests {
     #[test]
     fn test_analyzer_creation() {
         let analyzer = create_test_analyzer();
-        assert!(
-            analyzer
-                .supported_languages
-                .contains(&LanguageSupport::Rust)
-        );
-        assert!(
-            analyzer
-                .supported_languages
-                .contains(&LanguageSupport::Python)
-        );
+        assert!(analyzer
+            .supported_languages
+            .contains(&LanguageSupport::Rust));
+        assert!(analyzer
+            .supported_languages
+            .contains(&LanguageSupport::Python));
     }
 
     #[test]
@@ -838,11 +834,9 @@ mod tests {
         }
 
         // Test unknown extension should return error
-        assert!(
-            analyzer
-                .detect_language_from_path(Path::new("file.unknown"))
-                .is_err()
-        );
+        assert!(analyzer
+            .detect_language_from_path(Path::new("file.unknown"))
+            .is_err());
     }
 
     #[test]

--- a/vtagent-core/src/tools/tree_sitter/navigation.rs
+++ b/vtagent-core/src/tools/tree_sitter/navigation.rs
@@ -233,17 +233,22 @@ impl CodeNavigator {
 
     /// Find related symbols (implementations, overrides, etc.)
     fn find_related_symbols(&self, symbol: &SymbolInfo) -> Vec<SymbolInfo> {
-        // This would implement sophisticated relationship analysis
-        // For now, return related symbols in the same scope
-        self.symbol_map
-            .values()
-            .filter(|other| {
-                other.scope == symbol.scope
-                    && other.name != symbol.name
-                    && other.kind == symbol.kind
-            })
-            .cloned()
-            .collect()
+        let mut related = Vec::new();
+
+        for other in self.symbol_map.values() {
+            if other.name == symbol.name && other.scope != symbol.scope {
+                // Same name in different scope - likely override or implementation
+                related.push(other.clone());
+            } else if other.scope == symbol.scope
+                && other.kind == symbol.kind
+                && other.name != symbol.name
+            {
+                // Same scope and kind but different name - sibling symbols
+                related.push(other.clone());
+            }
+        }
+
+        related
     }
 }
 

--- a/vtagent-core/src/tools/tree_sitter/navigation.rs
+++ b/vtagent-core/src/tools/tree_sitter/navigation.rs
@@ -289,13 +289,31 @@ impl NavigationUtils {
     }
 
     /// Get the path from root to a specific node
-    pub fn get_node_path(node: &SyntaxNode) -> Vec<String> {
-        let mut path = vec![node.kind.clone()];
+    pub fn get_node_path(root: &SyntaxNode, target: &SyntaxNode) -> Vec<String> {
+        fn traverse<'a>(
+            current: &'a SyntaxNode,
+            target: &SyntaxNode,
+            path: &mut Vec<String>,
+        ) -> bool {
+            path.push(current.kind.clone());
+            if std::ptr::eq(current, target) {
+                return true;
+            }
+            for child in &current.children {
+                if traverse(child, target, path) {
+                    return true;
+                }
+            }
+            path.pop();
+            false
+        }
 
-        // In a real implementation, you'd traverse up the tree
-        // This is a simplified version
-        path.reverse();
-        path
+        let mut path = Vec::new();
+        if traverse(root, target, &mut path) {
+            path
+        } else {
+            Vec::new()
+        }
     }
 
     /// Calculate distance between two positions
@@ -320,7 +338,7 @@ impl NavigationUtils {
     /// Get scope hierarchy at a position
     pub fn get_scope_hierarchy(node: &SyntaxNode, position: &Position) -> Vec<String> {
         if let Some(target_node) = Self::find_node_at_position(node, position) {
-            Self::get_node_path(target_node)
+            Self::get_node_path(node, target_node)
         } else {
             Vec::new()
         }

--- a/vtagent-core/src/ui/mod.rs
+++ b/vtagent-core/src/ui/mod.rs
@@ -11,8 +11,7 @@ pub mod terminal;
 pub mod user_confirmation;
 
 // Conditional modules for additional UI features
-#[allow(unexpected_cfgs)]
-#[cfg(feature = "anstyle-parse")]
+// Optional module for ANSI style parsing (feature gate not currently used)
 pub mod anstyle_parse_utils;
 
 pub use markdown::*;

--- a/vtagent-core/tests/config_loader_test.rs
+++ b/vtagent-core/tests/config_loader_test.rs
@@ -59,4 +59,3 @@ fn test_get_home_dir() {
     // This should return Some on most systems
     assert!(home_dir.is_some());
 }
-#![cfg(any())]

--- a/vtagent-core/tests/project_test.rs
+++ b/vtagent-core/tests/project_test.rs
@@ -134,4 +134,3 @@ fn test_file_cache() {
     assert_eq!(total, 2);
     assert_eq!(expired, 0);
 }
-#![cfg(any())]


### PR DESCRIPTION
## Summary
- hook performance command to real metrics handler
- improve timestamp formatting with chrono
- track and expose last rp_search results in tool registry
- scan files for pattern matches during init analysis
- add end-to-end write/edit file tests and update docs/prompts

## Testing
- `cargo check`
- `cargo clippy -- -D warnings` *(fails: unused imports and unexpected cfg)*
- `cargo test --quiet` *(partial output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b75916b8832391b5f202ba91dde1