### PR TITLE
fix(runloop): enforce context window budget

### DIFF
--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -7,14 +7,13 @@ defaut use syntext
 
 --
 
-The terminal UI has also been upgraded: tool calls and diffs are better formatted and easier to follow. Approval modes are simplified to three levels: read-only with explicit approvals, auto with full workspace access but requiring approvals outside the workspace, and full access with the ability to read files anywhere and run commands with network access. 
+The terminal UI has also been upgraded: tool calls and diffs are better formatted and easier to follow. Approval modes are simplified to three levels: read-only with explicit approvals, auto with full workspace access but requiring approvals outside the workspace, and full access with the ability to read files anywhere and run commands with network access.
 
 --
 
-
 https://openai.com/index/introducing-upgrades-to-codex/
 
-upgrade codex 
+upgrade codex
 
 --
 https://deepwiki.com/pawurb/hotpath
@@ -796,3 +795,11 @@ If you tell me which path you prefer (subprocess vs embedded vs service), I can 
 
 1. https://github.com/copilot/c/b0ffc926-cf0c-45bf-b6aa-e6d8b01744b0
 2. https://github.com/copilot/c/c8306ebb-788e-400d-a901-9e1ecfae2582
+
+--
+
+fix this, why it doesn't invoke tools call but only print:
+
+user: read the CLAUDE.md file
+agent: call
+print(default_api.read_file(path='CLAUDE.md'))

--- a/vtagent-core/src/config/constants.rs
+++ b/vtagent-core/src/config/constants.rs
@@ -148,6 +148,30 @@ pub mod tools {
     pub const WILDCARD_ALL: &str = "*";
 }
 
+/// Context window management defaults
+pub mod context {
+    /// Approximate character count per token when estimating context size
+    pub const CHAR_PER_TOKEN_APPROX: usize = 4;
+
+    /// Default maximum context window (in approximate tokens)
+    pub const DEFAULT_MAX_TOKENS: usize = 120_000;
+
+    /// Trim target as a percentage of the maximum token budget
+    pub const DEFAULT_TRIM_TO_PERCENT: u8 = 80;
+
+    /// Minimum allowed trim percentage (prevents overly aggressive retention)
+    pub const MIN_TRIM_RATIO_PERCENT: u8 = 60;
+
+    /// Maximum allowed trim percentage (prevents minimal trimming)
+    pub const MAX_TRIM_RATIO_PERCENT: u8 = 90;
+
+    /// Default number of recent turns to preserve verbatim
+    pub const DEFAULT_PRESERVE_RECENT_TURNS: usize = 12;
+
+    /// Minimum number of recent turns that must remain after trimming
+    pub const MIN_PRESERVE_RECENT_TURNS: usize = 6;
+}
+
 /// Chunking constants for large file handling
 pub mod chunking {
     /// Maximum lines before triggering chunking for read_file

--- a/vtagent-core/src/config/constants.rs
+++ b/vtagent-core/src/config/constants.rs
@@ -151,10 +151,10 @@ pub mod tools {
 /// Context window management defaults
 pub mod context {
     /// Approximate character count per token when estimating context size
-    pub const CHAR_PER_TOKEN_APPROX: usize = 4;
+    pub const CHAR_PER_TOKEN_APPROX: usize = 3;
 
     /// Default maximum context window (in approximate tokens)
-    pub const DEFAULT_MAX_TOKENS: usize = 120_000;
+    pub const DEFAULT_MAX_TOKENS: usize = 90_000;
 
     /// Trim target as a percentage of the maximum token budget
     pub const DEFAULT_TRIM_TO_PERCENT: u8 = 80;
@@ -170,6 +170,12 @@ pub mod context {
 
     /// Minimum number of recent turns that must remain after trimming
     pub const MIN_PRESERVE_RECENT_TURNS: usize = 6;
+
+    /// Maximum number of recent turns to keep when aggressively reducing context
+    pub const AGGRESSIVE_PRESERVE_RECENT_TURNS: usize = 8;
+
+    /// Maximum number of retry attempts when the provider signals context overflow
+    pub const CONTEXT_ERROR_RETRY_LIMIT: usize = 2;
 }
 
 /// Chunking constants for large file handling

--- a/vtagent-core/src/config/context.rs
+++ b/vtagent-core/src/config/context.rs
@@ -1,3 +1,4 @@
+use crate::config::constants::context as context_defaults;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -38,8 +39,37 @@ fn default_preserve_in_compression() -> bool {
     true
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContextFeaturesConfig {
     #[serde(default)]
     pub ledger: LedgerConfig,
+    #[serde(default = "default_max_context_tokens")]
+    pub max_context_tokens: usize,
+    #[serde(default = "default_trim_to_percent")]
+    pub trim_to_percent: u8,
+    #[serde(default = "default_preserve_recent_turns")]
+    pub preserve_recent_turns: usize,
+}
+
+impl Default for ContextFeaturesConfig {
+    fn default() -> Self {
+        Self {
+            ledger: LedgerConfig::default(),
+            max_context_tokens: default_max_context_tokens(),
+            trim_to_percent: default_trim_to_percent(),
+            preserve_recent_turns: default_preserve_recent_turns(),
+        }
+    }
+}
+
+fn default_max_context_tokens() -> usize {
+    context_defaults::DEFAULT_MAX_TOKENS
+}
+
+fn default_trim_to_percent() -> u8 {
+    context_defaults::DEFAULT_TRIM_TO_PERCENT
+}
+
+fn default_preserve_recent_turns() -> usize {
+    context_defaults::DEFAULT_PRESERVE_RECENT_TURNS
 }


### PR DESCRIPTION
## Summary
- add shared context window defaults to the config constants and expose tuning knobs in `ContextFeaturesConfig`
- enforce approximate token limits in the Gemini and unified agent loops with reusable trimming helpers
- surface informational notices whenever history trimming occurs to keep users aware of context management

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c8dfc1ef048323850ae9c8eb83c1cb