### PR TITLE
Fix Gemini streaming SSE parsing

### DIFF
--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.37", features = [
 ] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 futures = "0.3"
+async-stream = "0.3"
 walkdir = "2.5"
 glob = "0.3"
 thiserror = "1.0"

--- a/vtcode-core/src/llm/mod.rs
+++ b/vtcode-core/src/llm/mod.rs
@@ -173,5 +173,6 @@ mod error_display_test;
 // Re-export main types for backward compatibility
 pub use client::{AnyClient, make_client};
 pub use factory::{create_provider_with_config, get_factory};
+pub use provider::{LLMStream, LLMStreamEvent};
 pub use providers::{AnthropicProvider, GeminiProvider, OpenAIProvider};
 pub use types::{BackendKind, LLMError, LLMResponse};


### PR DESCRIPTION
## Summary
- normalize Gemini streaming SSE events so that token payloads are parsed and emitted incrementally
- ignore non-data SSE control lines and treat [DONE] markers as completion without surfacing empty tokens
- derive `PartialEq`/`Eq` for `FinishReason` to unblock existing tests

## Testing
- cargo test -p vtcode-core streaming::processor -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68ce3c5ba55483239eb947cbe7687be5