### PR TITLE
Expose reasoning traces in chat transcript

### DIFF
--- a/src/agent/runloop/prompt.rs
+++ b/src/agent/runloop/prompt.rs
@@ -65,7 +65,7 @@ pub(crate) async fn refine_user_prompt_if_enabled(
         tool_choice: Some(uni::ToolChoice::none()),
         parallel_tool_calls: None,
         parallel_tool_config: None,
-        reasoning_effort: Some(vtc.agent.reasoning_effort.clone()),
+        reasoning_effort: None,
     };
 
     match refiner

--- a/src/agent/runloop/prompt.rs
+++ b/src/agent/runloop/prompt.rs
@@ -65,7 +65,7 @@ pub(crate) async fn refine_user_prompt_if_enabled(
         tool_choice: Some(uni::ToolChoice::none()),
         parallel_tool_calls: None,
         parallel_tool_config: None,
-        reasoning_effort: None,
+        reasoning_effort: Some(vtc.agent.reasoning_effort.clone()),
     };
 
     match refiner

--- a/src/agent/runloop/prompt.rs
+++ b/src/agent/runloop/prompt.rs
@@ -54,6 +54,12 @@ pub(crate) async fn refine_user_prompt_if_enabled(
         return raw.to_string();
     };
 
+    let supports_effort = refiner.supports_reasoning_effort(&refiner_model);
+    let reasoning_effort = if supports_effort {
+        Some(vtc.agent.reasoning_effort.as_str().to_string())
+    } else {
+        None
+    };
     let req = uni::LLMRequest {
         messages: vec![uni::Message::user(raw.to_string())],
         system_prompt: None,
@@ -65,7 +71,7 @@ pub(crate) async fn refine_user_prompt_if_enabled(
         tool_choice: Some(uni::ToolChoice::none()),
         parallel_tool_calls: None,
         parallel_tool_config: None,
-        reasoning_effort: Some(vtc.agent.reasoning_effort.clone()),
+        reasoning_effort,
     };
 
     match refiner
@@ -149,6 +155,7 @@ fn keyword_set(text: &str) -> HashSet<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vtcode_core::config::types::ReasoningEffortLevel;
 
     #[tokio::test]
     async fn test_prompt_refinement_applies_to_gemini_when_flag_disabled() {
@@ -164,6 +171,7 @@ mod tests {
             workspace: std::env::current_dir().unwrap(),
             verbose: false,
             theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
+            reasoning_effort: ReasoningEffortLevel::default(),
         };
 
         let mut vt = VTCodeConfig::default();

--- a/src/agent/runloop/ui.rs
+++ b/src/agent/runloop/ui.rs
@@ -13,7 +13,13 @@ pub(crate) fn render_session_banner(
     session_bootstrap: &SessionBootstrap,
 ) -> Result<()> {
     let banner_style = theme::banner_style();
-    renderer.line_with_style(banner_style, "Welcome to VTCode!")?;
+    renderer.line_with_style(
+        banner_style,
+        &format!(
+            "Welcome to vtcode! Current reasoning effort: {}",
+            config.reasoning_effort
+        ),
+    )?;
 
     let mut bullets = Vec::new();
     bullets.push(format!("- Model: {}", config.model));

--- a/src/agent/runloop/ui.rs
+++ b/src/agent/runloop/ui.rs
@@ -13,17 +13,11 @@ pub(crate) fn render_session_banner(
     session_bootstrap: &SessionBootstrap,
 ) -> Result<()> {
     let banner_style = theme::banner_style();
-    renderer.line_with_style(
-        banner_style,
-        &format!(
-            "Welcome to vtcode! Current reasoning effort: {}",
-            config.reasoning_effort
-        ),
-    )?;
+    renderer.line_with_style(banner_style, &format!("Welcome to VT Code!"))?;
 
     let mut bullets = Vec::new();
-    bullets.push(format!("- Model: {}", config.model));
-    bullets.push(format!("- Workspace: {}", config.workspace.display()));
+    bullets.push(format!("* Model: {}", config.model));
+    bullets.push(format!("* Reasoning effort: {}", config.reasoning_effort));
 
     match ToolPolicyManager::new_with_workspace(&config.workspace) {
         Ok(manager) => {
@@ -42,7 +36,7 @@ pub(crate) fn render_session_banner(
                 .and_then(|p| p.to_str().map(|s| s.to_string()))
                 .unwrap_or_else(|| manager.config_path().display().to_string());
             bullets.push(format!(
-                "- Tool policy: allow {} · prompt {} · deny {} ({})",
+                "> Tools policy: Allow {} · Prompt {} · Deny {} ({})",
                 allow, prompt, deny, policy_path
             ));
         }
@@ -52,7 +46,7 @@ pub(crate) fn render_session_banner(
     }
 
     if let Some(summary) = session_bootstrap.language_summary.as_deref() {
-        bullets.push(format!("- Languages: {}", summary));
+        bullets.push(format!("> Workspace languages: {}", summary));
     }
 
     for line in bullets {

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -157,8 +157,6 @@ impl TranscriptView {
 }
 
 const RESPONSE_STREAM_INDENT: &str = "  ";
-const REASONING_STREAM_PREFIX: &str = "Thinking: ";
-const REASONING_BLOCK_HEADER: &str = "Thinking:";
 
 fn map_render_error(provider_name: &str, err: anyhow::Error) -> uni::LLMError {
     let formatted_error = error_display::format_llm_error(
@@ -168,44 +166,18 @@ fn map_render_error(provider_name: &str, err: anyhow::Error) -> uni::LLMError {
     uni::LLMError::Provider(formatted_error)
 }
 
-fn append_reasoning_transcript(reasoning_text: &str) {
-    let trimmed = reasoning_text.trim();
-    if trimmed.is_empty() {
-        return;
-    }
-
-    if trimmed.contains('\n') {
-        transcript::append(&format!(
-            "{}{}",
-            RESPONSE_STREAM_INDENT, REASONING_BLOCK_HEADER
-        ));
-        for line in trimmed.lines() {
-            let line_trimmed = line.trim_end();
-            transcript::append(&format!("{}{}", RESPONSE_STREAM_INDENT, line_trimmed));
-        }
-    } else {
-        transcript::append(&format!(
-            "{}{}{}",
-            RESPONSE_STREAM_INDENT, REASONING_STREAM_PREFIX, trimmed
-        ));
-    }
-}
-
 async fn stream_and_render_response(
     provider: &dyn uni::LLMProvider,
     request: uni::LLMRequest,
     spinner: &Spinner,
     renderer: &mut AnsiRenderer,
-    reasoning_supported: bool,
-) -> Result<(uni::LLMResponse, bool, Option<String>), uni::LLMError> {
+) -> Result<(uni::LLMResponse, bool), uni::LLMError> {
     let mut stream = provider.stream(request).await?;
     let provider_name = provider.name();
     let styles = theme::active_styles();
     let response_style = styles.response;
-    let reasoning_style = styles.reasoning;
     let mut final_response: Option<uni::LLMResponse> = None;
     let mut aggregated = String::new();
-    let mut streamed_reasoning_text = String::new();
     let mut spinner_active = true;
     let finish_spinner = |active: &mut bool| {
         if *active {
@@ -215,8 +187,6 @@ async fn stream_and_render_response(
     };
     let mut display_started = false;
     let mut emitted_tokens = false;
-    let mut reasoning_display_started = false;
-    let mut streamed_reasoning = false;
 
     while let Some(event_result) = stream.next().await {
         match event_result {
@@ -234,23 +204,7 @@ async fn stream_and_render_response(
                 aggregated.push_str(&delta);
                 emitted_tokens = true;
             }
-            Ok(LLMStreamEvent::Reasoning { delta }) => {
-                if !reasoning_supported {
-                    continue;
-                }
-                finish_spinner(&mut spinner_active);
-                if !reasoning_display_started {
-                    renderer
-                        .inline_with_style(reasoning_style, REASONING_STREAM_PREFIX)
-                        .map_err(|err| map_render_error(provider_name, err))?;
-                    reasoning_display_started = true;
-                }
-                renderer
-                    .inline_with_style(reasoning_style, &delta)
-                    .map_err(|err| map_render_error(provider_name, err))?;
-                streamed_reasoning_text.push_str(&delta);
-                streamed_reasoning = true;
-            }
+            Ok(LLMStreamEvent::Reasoning { .. }) => {}
             Ok(LLMStreamEvent::Completed { response }) => {
                 final_response = Some(response);
             }
@@ -261,23 +215,12 @@ async fn stream_and_render_response(
                         .inline_with_style(response_style, "\n")
                         .map_err(|render_err| map_render_error(provider_name, render_err))?;
                 }
-                if reasoning_display_started {
-                    renderer
-                        .inline_with_style(reasoning_style, "\n")
-                        .map_err(|render_err| map_render_error(provider_name, render_err))?;
-                }
                 return Err(err);
             }
         }
     }
 
     finish_spinner(&mut spinner_active);
-
-    if reasoning_supported && reasoning_display_started {
-        renderer
-            .inline_with_style(reasoning_style, "\n")
-            .map_err(|err| map_render_error(provider_name, err))?;
-    }
 
     let response = final_response.ok_or_else(|| {
         let formatted_error = error_display::format_llm_error(
@@ -318,22 +261,7 @@ async fn stream_and_render_response(
         transcript::append(&transcript_entry);
     }
 
-    let streamed_reasoning_snapshot = if reasoning_supported && streamed_reasoning {
-        let trimmed = streamed_reasoning_text.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    } else {
-        None
-    };
-
-    if let Some(reasoning_snapshot) = streamed_reasoning_snapshot.as_ref() {
-        append_reasoning_transcript(reasoning_snapshot);
-    }
-
-    Ok((response, emitted_tokens, streamed_reasoning_snapshot))
+    Ok((response, emitted_tokens))
 }
 
 enum TurnLoopResult {
@@ -627,7 +555,7 @@ pub(crate) async fn run_single_agent_loop_unified(
 
             let mut attempt_history = working_history.clone();
             let mut retry_attempts = 0usize;
-            let (response, response_streamed, streamed_reasoning, reasoning_supported) = loop {
+            let (response, response_streamed) = loop {
                 retry_attempts += 1;
                 let _ = enforce_unified_context_window(&mut attempt_history, trim_config);
 
@@ -643,21 +571,19 @@ pub(crate) async fn run_single_agent_loop_unified(
                     tool_choice: Some(uni::ToolChoice::auto()),
                     parallel_tool_calls: None,
                     parallel_tool_config: parallel_cfg_opt.clone(),
-                    reasoning_effort: vt_cfg.map(|cfg| cfg.agent.reasoning_effort.clone()),
+                    reasoning_effort: None,
                 };
 
                 // Use the existing thinking spinner instead of creating a new one
                 let thinking_spinner = Spinner::new("Thinking...");
                 let mut spinner_active = true;
                 task::yield_now().await;
-                let reasoning_supported = provider_client.supports_reasoning(&active_model);
                 let result = if use_streaming {
                     let outcome = stream_and_render_response(
                         provider_client.as_ref(),
                         request,
                         &thinking_spinner,
                         &mut renderer,
-                        reasoning_supported,
                     )
                     .await;
                     spinner_active = false;
@@ -666,7 +592,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                     provider_client
                         .generate(request)
                         .await
-                        .map(|resp| (resp, false, None))
+                        .map(|resp| (resp, false))
                 };
 
                 if spinner_active {
@@ -674,14 +600,9 @@ pub(crate) async fn run_single_agent_loop_unified(
                 }
 
                 match result {
-                    Ok((result, streamed_tokens, streamed_reasoning_snapshot)) => {
+                    Ok((result, streamed_tokens)) => {
                         working_history = attempt_history.clone();
-                        break (
-                            result,
-                            streamed_tokens,
-                            streamed_reasoning_snapshot,
-                            reasoning_supported,
-                        );
+                        break (result, streamed_tokens);
                     }
                     Err(error) => {
                         if ctrl_c_flag.load(Ordering::SeqCst) {
@@ -741,27 +662,6 @@ pub(crate) async fn run_single_agent_loop_unified(
             let mut final_text = response.content.clone();
             let mut tool_calls = response.tool_calls.clone().unwrap_or_default();
             let mut interpreted_textual_call = false;
-
-            if reasoning_supported {
-                if let Some(reasoning) = response.reasoning.as_ref() {
-                    let trimmed_reasoning = reasoning.trim();
-                    if !trimmed_reasoning.is_empty() {
-                        let already_streamed = streamed_reasoning
-                            .as_ref()
-                            .map(|value| value == trimmed_reasoning)
-                            .unwrap_or(false);
-                        if !already_streamed {
-                            let reasoning_display = if trimmed_reasoning.contains('\n') {
-                                format!("Thinking:\n{}", trimmed_reasoning)
-                            } else {
-                                format!("Thinking: {}", trimmed_reasoning)
-                            };
-                            renderer.line(MessageStyle::Reasoning, &reasoning_display)?;
-                            append_reasoning_transcript(trimmed_reasoning);
-                        }
-                    }
-                }
-            }
 
             if tool_calls.is_empty()
                 && let Some(text) = final_text.clone()
@@ -1028,7 +928,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                             tool_choice: Some(uni::ToolChoice::none()),
                             parallel_tool_calls: None,
                             parallel_tool_config: None,
-                            reasoning_effort: vt_cfg.map(|cfg| cfg.agent.reasoning_effort.clone()),
+                            reasoning_effort: None,
                         };
                         let rr = provider_client.generate(review_req).await.ok();
                         if let Some(r) = rr.and_then(|result| result.content)

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -571,7 +571,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                     tool_choice: Some(uni::ToolChoice::auto()),
                     parallel_tool_calls: None,
                     parallel_tool_config: parallel_cfg_opt.clone(),
-                    reasoning_effort: None,
+                    reasoning_effort: vt_cfg.map(|cfg| cfg.agent.reasoning_effort.clone()),
                 };
 
                 // Use the existing thinking spinner instead of creating a new one
@@ -928,7 +928,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                             tool_choice: Some(uni::ToolChoice::none()),
                             parallel_tool_calls: None,
                             parallel_tool_config: None,
-                            reasoning_effort: None,
+                            reasoning_effort: vt_cfg.map(|cfg| cfg.agent.reasoning_effort.clone()),
                         };
                         let rr = provider_client.generate(review_req).await.ok();
                         if let Some(r) = rr.and_then(|result| result.content)

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -745,17 +745,20 @@ pub(crate) async fn run_single_agent_loop_unified(
             if reasoning_supported {
                 if let Some(reasoning) = response.reasoning.as_ref() {
                     let trimmed_reasoning = reasoning.trim();
-                    let already_streamed = streamed_reasoning
-                        .as_ref()
-                        .map(|value| value == trimmed_reasoning)
-                        .unwrap_or(false);
-                    if !trimmed_reasoning.is_empty() && !already_streamed {
-                        let reasoning_display = if trimmed_reasoning.contains('\n') {
-                            format!("Thinking:\n{}", trimmed_reasoning)
-                        } else {
-                            format!("Thinking: {}", trimmed_reasoning)
-                        };
-                        renderer.line(MessageStyle::Reasoning, &reasoning_display)?;
+                    if !trimmed_reasoning.is_empty() {
+                        let already_streamed = streamed_reasoning
+                            .as_ref()
+                            .map(|value| value == trimmed_reasoning)
+                            .unwrap_or(false);
+                        if !already_streamed {
+                            let reasoning_display = if trimmed_reasoning.contains('\n') {
+                                format!("Thinking:\n{}", trimmed_reasoning)
+                            } else {
+                                format!("Thinking: {}", trimmed_reasoning)
+                            };
+                            renderer.line(MessageStyle::Reasoning, &reasoning_display)?;
+                            append_reasoning_transcript(trimmed_reasoning);
+                        }
                     }
                 }
             }

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -265,6 +265,7 @@ fn collect_non_empty_entries(items: &[String]) -> Vec<&str> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+    use vtcode_core::config::types::ReasoningEffortLevel;
 
     #[test]
     fn test_prepare_session_bootstrap_builds_sections() {
@@ -298,6 +299,7 @@ mod tests {
             workspace: tmp.path().to_path_buf(),
             verbose: false,
             theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
+            reasoning_effort: ReasoningEffortLevel::default(),
         };
 
         let bootstrap = prepare_session_bootstrap(&runtime_cfg, Some(&vt_cfg));

--- a/src/cli/ask.rs
+++ b/src/cli/ask.rs
@@ -62,6 +62,11 @@ pub async fn handle_ask_command(config: &CoreAgentConfig, prompt: &str) -> Resul
     };
 
     let request_mode = classify_request_mode(provider.supports_streaming());
+    let reasoning_effort = if provider.supports_reasoning_effort(&config.model) {
+        Some(config.reasoning_effort.as_str().to_string())
+    } else {
+        None
+    };
     let request = LLMRequest {
         messages: vec![Message::user(prompt.to_string())],
         system_prompt: None,
@@ -73,7 +78,7 @@ pub async fn handle_ask_command(config: &CoreAgentConfig, prompt: &str) -> Resul
         tool_choice: Some(ToolChoice::none()),
         parallel_tool_calls: None,
         parallel_tool_config: None,
-        reasoning_effort: None,
+        reasoning_effort,
     };
 
     match request_mode {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -4,7 +4,7 @@ use console::style;
 use std::fs;
 use std::path::Path;
 use vtcode_core::config::loader::VTCodeConfig;
-use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
+use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, ReasoningEffortLevel};
 use vtcode_core::ui::theme::DEFAULT_THEME_ID;
 
 /// Handle the init command
@@ -36,6 +36,7 @@ pub async fn handle_init_command(workspace: &Path, force: bool, run: bool) -> Re
             workspace: workspace.to_path_buf(),
             verbose: false,
             theme: DEFAULT_THEME_ID.to_string(),
+            reasoning_effort: ReasoningEffortLevel::default(),
         };
         handle_chat_command(&config, false, false)
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,7 @@ async fn main() -> Result<()> {
         workspace: workspace.clone(),
         verbose: args.verbose,
         theme: theme_selection.clone(),
+        reasoning_effort: cfg.agent.reasoning_effort,
     };
 
     match &args.command {

--- a/src/main_modular.rs
+++ b/src/main_modular.rs
@@ -10,7 +10,7 @@ use vtcode_core::api_keys::{get_api_key, load_dotenv, ApiKeySources};
 use vtcode_core::config::loader::ConfigManager;
 use vtcode_core::constants::defaults;
 use vtcode_core::{
-    config::ConfigManager,
+    config::{ConfigManager, ReasoningEffortLevel},
     models::{ModelId, Provider},
     safety::SafetyValidator,
     types::AgentConfig as CoreAgentConfig,
@@ -130,6 +130,7 @@ async fn main() -> Result<()> {
         workspace: workspace.clone(),
         verbose: args.verbose,
         theme: defaults::DEFAULT_THEME.to_string(),
+        reasoning_effort: ReasoningEffortLevel::default(),
     };
 
     // Apply safety validations for model usage

--- a/tests/stats_command_test.rs
+++ b/tests/stats_command_test.rs
@@ -3,7 +3,7 @@ use tempfile::TempDir;
 use tokio::time::{Duration, sleep};
 use vtcode_core::{
     Agent, config::constants::models::google::GEMINI_2_5_FLASH_PREVIEW, config::types::AgentConfig,
-    handle_stats_command, ui::theme::DEFAULT_THEME_ID,
+    config::ReasoningEffortLevel, handle_stats_command, ui::theme::DEFAULT_THEME_ID,
 };
 
 #[tokio::test]
@@ -17,6 +17,7 @@ async fn test_handle_stats_command_returns_agent_metrics() -> Result<()> {
         workspace: temp_dir.path().to_path_buf(),
         verbose: false,
         theme: DEFAULT_THEME_ID.to_string(),
+        reasoning_effort: ReasoningEffortLevel::default(),
     };
     let mut agent = Agent::new(config)?;
     agent.update_session_stats(5, 3, 1);

--- a/tests/stats_command_test.rs
+++ b/tests/stats_command_test.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 use tempfile::TempDir;
 use tokio::time::{Duration, sleep};
 use vtcode_core::{
-    Agent, config::constants::models::google::GEMINI_2_5_FLASH_PREVIEW, config::types::AgentConfig,
-    config::ReasoningEffortLevel, handle_stats_command, ui::theme::DEFAULT_THEME_ID,
+    Agent, config::ReasoningEffortLevel,
+    config::constants::models::google::GEMINI_2_5_FLASH_PREVIEW, config::types::AgentConfig,
+    handle_stats_command, ui::theme::DEFAULT_THEME_ID,
 };
 
 #[tokio::test]

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -148,6 +148,14 @@ pub mod defaults {
     pub const ANTHROPIC_DEFAULT_MAX_TOKENS: u32 = 4_096;
 }
 
+/// Reasoning effort configuration constants
+pub mod reasoning {
+    pub const LOW: &str = "low";
+    pub const MEDIUM: &str = "medium";
+    pub const HIGH: &str = "high";
+    pub const ALLOWED_LEVELS: &[&str] = &[LOW, MEDIUM, HIGH];
+}
+
 /// Message role constants to avoid hardcoding strings
 pub mod message_roles {
     pub const SYSTEM: &str = "system";

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -52,6 +52,13 @@ pub mod models {
             "anthropic/claude-sonnet-4",
         ];
 
+        /// Models that expose reasoning traces via OpenRouter APIs
+        pub const REASONING_MODELS: &[&str] = &[
+            X_AI_GROK_4_FAST_FREE,
+            OPENAI_GPT_5,
+            ANTHROPIC_CLAUDE_SONNET_4,
+        ];
+
         pub const X_AI_GROK_CODE_FAST_1: &str = "x-ai/grok-code-fast-1";
         pub const X_AI_GROK_4_FAST_FREE: &str = "x-ai/grok-4-fast:free";
         pub const QWEN3_CODER: &str = "qwen/qwen3-coder";

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -1,4 +1,5 @@
 use crate::config::constants::defaults;
+use crate::config::types::ReasoningEffortLevel;
 use serde::{Deserialize, Serialize};
 
 /// Agent-wide configuration
@@ -23,7 +24,7 @@ pub struct AgentConfig {
     /// Reasoning effort level for models that support it (low, medium, high)
     /// Applies to: Claude, GPT-5, Gemini, Qwen3, DeepSeek with reasoning capability
     #[serde(default = "default_reasoning_effort")]
-    pub reasoning_effort: String,
+    pub reasoning_effort: ReasoningEffortLevel,
 
     /// Enable an extra self-review pass to refine final responses
     #[serde(default = "default_enable_self_review")]
@@ -80,8 +81,8 @@ fn default_theme() -> String {
 fn default_max_conversation_turns() -> usize {
     150
 }
-fn default_reasoning_effort() -> String {
-    "medium".to_string()
+fn default_reasoning_effort() -> ReasoningEffortLevel {
+    ReasoningEffortLevel::default()
 }
 
 fn default_enable_self_review() -> bool {

--- a/vtcode-core/src/config/mod.rs
+++ b/vtcode-core/src/config/mod.rs
@@ -192,6 +192,7 @@ pub use defaults::{ContextStoreDefaults, PerformanceDefaults, ScenarioDefaults};
 pub use loader::{ConfigManager, VTCodeConfig};
 pub use router::{ComplexityModelMap, ResourceBudget, RouterConfig};
 pub use telemetry::TelemetryConfig;
+pub use types::ReasoningEffortLevel;
 
 use serde::{Deserialize, Serialize};
 

--- a/vtcode-core/src/core/agent/core.rs
+++ b/vtcode-core/src/core/agent/core.rs
@@ -476,6 +476,7 @@ impl AgentBuilder {
                     .unwrap_or_else(|_| std::path::PathBuf::from(".")),
                 verbose: false,
                 theme: crate::config::constants::defaults::DEFAULT_THEME.to_string(),
+                reasoning_effort: ReasoningEffortLevel::default(),
             },
         }
     }

--- a/vtcode-core/src/core/agent/runner.rs
+++ b/vtcode-core/src/core/agent/runner.rs
@@ -300,7 +300,7 @@ impl AgentRunner {
                 parallel_tool_config: Some(
                     crate::llm::provider::ParallelToolConfig::anthropic_optimized(),
                 ),
-                reasoning_effort: self.reasoning_effort.clone(),
+                reasoning_effort: None,
             };
 
             // Use provider-specific client for OpenAI/Anthropic (and generic support for others)

--- a/vtcode-core/src/core/agent/runner.rs
+++ b/vtcode-core/src/core/agent/runner.rs
@@ -300,7 +300,7 @@ impl AgentRunner {
                 parallel_tool_config: Some(
                     crate::llm::provider::ParallelToolConfig::anthropic_optimized(),
                 ),
-                reasoning_effort: None,
+                reasoning_effort: self.reasoning_effort.clone(),
             };
 
             // Use provider-specific client for OpenAI/Anthropic (and generic support for others)

--- a/vtcode-core/src/core/router.rs
+++ b/vtcode-core/src/core/router.rs
@@ -153,6 +153,13 @@ impl Router {
                 Some(router_cfg.llm_router_model.clone()),
             ) {
                 let sys = "You are a routing classifier. Output only one label: simple | standard | complex | codegen_heavy | retrieval_heavy. Choose the best class for the user's last message. No prose.".to_string();
+                let supports_effort =
+                    provider.supports_reasoning_effort(&router_cfg.llm_router_model);
+                let reasoning_effort = if supports_effort {
+                    Some(vt_cfg.agent.reasoning_effort.as_str().to_string())
+                } else {
+                    None
+                };
                 let req = uni::LLMRequest {
                     messages: vec![uni::Message::user(input.to_string())],
                     system_prompt: Some(sys),
@@ -164,7 +171,7 @@ impl Router {
                     tool_choice: Some(uni::ToolChoice::none()),
                     parallel_tool_calls: None,
                     parallel_tool_config: None,
-                    reasoning_effort: Some(vt_cfg.agent.reasoning_effort.clone()),
+                    reasoning_effort,
                 };
                 if let Ok(resp) = provider.generate(req).await {
                     if let Some(text) = resp.content {

--- a/vtcode-core/src/core/router.rs
+++ b/vtcode-core/src/core/router.rs
@@ -164,7 +164,7 @@ impl Router {
                     tool_choice: Some(uni::ToolChoice::none()),
                     parallel_tool_calls: None,
                     parallel_tool_config: None,
-                    reasoning_effort: None,
+                    reasoning_effort: Some(vt_cfg.agent.reasoning_effort.clone()),
                 };
                 if let Ok(resp) = provider.generate(req).await {
                     if let Some(text) = resp.content {

--- a/vtcode-core/src/core/router.rs
+++ b/vtcode-core/src/core/router.rs
@@ -164,7 +164,7 @@ impl Router {
                     tool_choice: Some(uni::ToolChoice::none()),
                     parallel_tool_calls: None,
                     parallel_tool_config: None,
-                    reasoning_effort: Some(vt_cfg.agent.reasoning_effort.clone()),
+                    reasoning_effort: None,
                 };
                 if let Ok(resp) = provider.generate(req).await {
                     if let Some(text) = resp.content {

--- a/vtcode-core/src/llm/provider.rs
+++ b/vtcode-core/src/llm/provider.rs
@@ -676,6 +676,11 @@ pub trait LLMProvider: Send + Sync {
         false
     }
 
+    /// Whether the provider accepts configurable reasoning effort for the model
+    fn supports_reasoning_effort(&self, _model: &str) -> bool {
+        false
+    }
+
     /// Generate completion
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError>;
 

--- a/vtcode-core/src/llm/provider.rs
+++ b/vtcode-core/src/llm/provider.rs
@@ -671,6 +671,11 @@ pub trait LLMProvider: Send + Sync {
         false
     }
 
+    /// Whether the provider surfaces structured reasoning traces for the given model
+    fn supports_reasoning(&self, _model: &str) -> bool {
+        false
+    }
+
     /// Generate completion
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError>;
 

--- a/vtcode-core/src/llm/providers/anthropic.rs
+++ b/vtcode-core/src/llm/providers/anthropic.rs
@@ -482,18 +482,7 @@ impl AnthropicProvider {
             anthropic_request["tool_choice"] = tool_choice.to_provider_format("anthropic");
         }
 
-        if let Some(reasoning_effort) = &request.reasoning_effort {
-            anthropic_request["reasoning"] = json!({"effort": reasoning_effort});
-        }
-
         Ok(anthropic_request)
-    }
-
-    fn model_supports_reasoning(model: &str) -> bool {
-        let trimmed = model.trim();
-        models::anthropic::SUPPORTED_MODELS
-            .iter()
-            .any(|candidate| candidate.eq_ignore_ascii_case(trimmed))
     }
 
     fn parse_anthropic_response(&self, response_json: Value) -> Result<LLMResponse, LLMError> {
@@ -619,8 +608,8 @@ impl LLMProvider for AnthropicProvider {
         "anthropic"
     }
 
-    fn supports_reasoning(&self, model: &str) -> bool {
-        Self::model_supports_reasoning(model)
+    fn supports_reasoning(&self, _model: &str) -> bool {
+        false
     }
 
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {

--- a/vtcode-core/src/llm/providers/anthropic.rs
+++ b/vtcode-core/src/llm/providers/anthropic.rs
@@ -482,6 +482,12 @@ impl AnthropicProvider {
             anthropic_request["tool_choice"] = tool_choice.to_provider_format("anthropic");
         }
 
+        if let Some(effort) = request.reasoning_effort.as_deref() {
+            if self.supports_reasoning_effort(&request.model) {
+                anthropic_request["reasoning"] = json!({ "effort": effort });
+            }
+        }
+
         Ok(anthropic_request)
     }
 
@@ -610,6 +616,17 @@ impl LLMProvider for AnthropicProvider {
 
     fn supports_reasoning(&self, _model: &str) -> bool {
         false
+    }
+
+    fn supports_reasoning_effort(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+        models::anthropic::SUPPORTED_MODELS
+            .iter()
+            .any(|candidate| *candidate == requested)
     }
 
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {

--- a/vtcode-core/src/llm/providers/anthropic.rs
+++ b/vtcode-core/src/llm/providers/anthropic.rs
@@ -489,6 +489,13 @@ impl AnthropicProvider {
         Ok(anthropic_request)
     }
 
+    fn model_supports_reasoning(model: &str) -> bool {
+        let trimmed = model.trim();
+        models::anthropic::SUPPORTED_MODELS
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(trimmed))
+    }
+
     fn parse_anthropic_response(&self, response_json: Value) -> Result<LLMResponse, LLMError> {
         let content = response_json
             .get("content")
@@ -610,6 +617,10 @@ impl AnthropicProvider {
 impl LLMProvider for AnthropicProvider {
     fn name(&self) -> &str {
         "anthropic"
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        Self::model_supports_reasoning(model)
     }
 
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {

--- a/vtcode-core/src/llm/providers/gemini.rs
+++ b/vtcode-core/src/llm/providers/gemini.rs
@@ -73,8 +73,8 @@ impl LLMProvider for GeminiProvider {
         true
     }
 
-    fn supports_reasoning(&self, model: &str) -> bool {
-        Self::model_supports_reasoning(model)
+    fn supports_reasoning(&self, _model: &str) -> bool {
+        false
     }
 
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {
@@ -375,14 +375,6 @@ impl GeminiProvider {
         if let Some(temp) = request.temperature {
             generation_config.insert("temperature".to_string(), json!(temp));
         }
-        let reasoning_config = request.reasoning_effort.as_ref().and_then(|effort| {
-            if Self::model_supports_reasoning(&request.model) {
-                Some(json!({ "effort": effort }))
-            } else {
-                None
-            }
-        });
-
         let has_tools = request
             .tools
             .as_ref()
@@ -424,18 +416,8 @@ impl GeminiProvider {
             } else {
                 Some(Value::Object(generation_config))
             },
-            reasoning_config,
+            reasoning_config: None,
         })
-    }
-
-    fn model_supports_reasoning(model: &str) -> bool {
-        let trimmed_model = model.trim();
-        if trimmed_model.eq_ignore_ascii_case(models::google::GEMINI_2_5_PRO) {
-            return true;
-        }
-
-        let lowered = trimmed_model.to_ascii_lowercase();
-        lowered.contains("pro") || lowered.contains("reasoning") || lowered.contains("thinking")
     }
 
     fn convert_from_gemini_response(

--- a/vtcode-core/src/llm/providers/gemini.rs
+++ b/vtcode-core/src/llm/providers/gemini.rs
@@ -73,6 +73,10 @@ impl LLMProvider for GeminiProvider {
         true
     }
 
+    fn supports_reasoning(&self, model: &str) -> bool {
+        Self::model_supports_reasoning(model)
+    }
+
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {
         let gemini_request = self.convert_to_gemini_request(&request)?;
 

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -388,25 +388,7 @@ impl OpenAIProvider {
             openai_request["parallel_tool_calls"] = Value::Bool(parallel);
         }
 
-        if let Some(reasoning) = &request.reasoning_effort {
-            if Self::model_supports_reasoning(&request.model) {
-                openai_request["reasoning"] = json!({"effort": reasoning});
-            }
-        }
-
         Ok(openai_request)
-    }
-
-    fn model_supports_reasoning(model: &str) -> bool {
-        let trimmed_model = model.trim();
-        if models::openai::REASONING_MODELS
-            .iter()
-            .any(|candidate| candidate.eq_ignore_ascii_case(trimmed_model))
-        {
-            return true;
-        }
-
-        trimmed_model.to_ascii_lowercase().starts_with("gpt-5")
     }
 
     fn parse_openai_response(&self, response_json: Value) -> Result<LLMResponse, LLMError> {
@@ -527,8 +509,8 @@ impl LLMProvider for OpenAIProvider {
         "openai"
     }
 
-    fn supports_reasoning(&self, model: &str) -> bool {
-        Self::model_supports_reasoning(model)
+    fn supports_reasoning(&self, _model: &str) -> bool {
+        false
     }
 
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -388,6 +388,12 @@ impl OpenAIProvider {
             openai_request["parallel_tool_calls"] = Value::Bool(parallel);
         }
 
+        if let Some(effort) = request.reasoning_effort.as_deref() {
+            if self.supports_reasoning_effort(&request.model) {
+                openai_request["reasoning"] = json!({ "effort": effort });
+            }
+        }
+
         Ok(openai_request)
     }
 
@@ -511,6 +517,17 @@ impl LLMProvider for OpenAIProvider {
 
     fn supports_reasoning(&self, _model: &str) -> bool {
         false
+    }
+
+    fn supports_reasoning_effort(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+        models::openai::REASONING_MODELS
+            .iter()
+            .any(|candidate| *candidate == requested)
     }
 
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -527,6 +527,10 @@ impl LLMProvider for OpenAIProvider {
         "openai"
     }
 
+    fn supports_reasoning(&self, model: &str) -> bool {
+        Self::model_supports_reasoning(model)
+    }
+
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {
         let openai_request = self.convert_to_openai_format(&request)?;
         let url = format!("{}/chat/completions", self.base_url);

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -1163,6 +1163,13 @@ impl LLMProvider for OpenRouterProvider {
         true
     }
 
+    fn supports_reasoning(&self, model: &str) -> bool {
+        let trimmed = model.trim();
+        models::openrouter::REASONING_MODELS
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(trimmed))
+    }
+
     async fn stream(&self, request: LLMRequest) -> Result<LLMStream, LLMError> {
         let mut provider_request = self.convert_to_openrouter_format(&request)?;
         provider_request["stream"] = Value::Bool(true);

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -1107,6 +1107,12 @@ impl OpenRouterProvider {
             provider_request["parallel_tool_calls"] = Value::Bool(parallel);
         }
 
+        if let Some(effort) = request.reasoning_effort.as_deref() {
+            if self.supports_reasoning_effort(&request.model) {
+                provider_request["reasoning"] = json!({ "effort": effort });
+            }
+        }
+
         Ok(provider_request)
     }
 
@@ -1217,6 +1223,17 @@ impl LLMProvider for OpenRouterProvider {
 
     fn supports_reasoning(&self, _model: &str) -> bool {
         false
+    }
+
+    fn supports_reasoning_effort(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+        models::openrouter::REASONING_MODELS
+            .iter()
+            .any(|candidate| *candidate == requested)
     }
 
     async fn stream(&self, request: LLMRequest) -> Result<LLMStream, LLMError> {

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -325,7 +325,7 @@ fn process_content_object(
         return;
     }
 
-    for key in ["content", "items", "output", "delta"] {
+    for key in ["content", "items", "output", "outputs", "delta"] {
         if let Some(inner) = map.get(key) {
             process_content_value(
                 inner,
@@ -410,6 +410,58 @@ fn process_content_value(
             );
         }
         _ => {}
+    }
+}
+
+fn extract_reasoning_from_message_content(message: &Value) -> Option<String> {
+    let parts = message.get("content")?.as_array()?;
+    let mut segments: Vec<String> = Vec::new();
+
+    for part in parts {
+        match part {
+            Value::Object(map) => {
+                let part_type = map
+                    .get("type")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+
+                if matches!(part_type, "reasoning" | "thinking" | "analysis") {
+                    if let Some(extracted) = extract_reasoning_trace(part) {
+                        if !extracted.trim().is_empty() {
+                            segments.push(extracted);
+                            continue;
+                        }
+                    }
+
+                    if let Some(text) = map.get("text").and_then(|value| value.as_str()) {
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            segments.push(trimmed.to_string());
+                        }
+                    }
+                }
+            }
+            Value::String(text) => {
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    segments.push(trimmed.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if segments.is_empty() {
+        None
+    } else {
+        let mut combined = String::new();
+        for (idx, segment) in segments.iter().enumerate() {
+            if idx > 0 {
+                combined.push('\n');
+            }
+            combined.push_str(segment);
+        }
+        Some(combined)
     }
 }
 
@@ -1130,10 +1182,14 @@ impl OpenRouterProvider {
             })
             .filter(|calls| !calls.is_empty());
 
-        let reasoning = message
+        let mut reasoning = message
             .get("reasoning")
             .and_then(extract_reasoning_trace)
             .or_else(|| choice.get("reasoning").and_then(extract_reasoning_trace));
+
+        if reasoning.is_none() {
+            reasoning = extract_reasoning_from_message_content(message);
+        }
 
         let finish_reason = choice
             .get("finish_reason")

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -1107,10 +1107,6 @@ impl OpenRouterProvider {
             provider_request["parallel_tool_calls"] = Value::Bool(parallel);
         }
 
-        if let Some(reasoning) = &request.reasoning_effort {
-            provider_request["reasoning"] = json!({"effort": reasoning});
-        }
-
         Ok(provider_request)
     }
 
@@ -1219,11 +1215,8 @@ impl LLMProvider for OpenRouterProvider {
         true
     }
 
-    fn supports_reasoning(&self, model: &str) -> bool {
-        let trimmed = model.trim();
-        models::openrouter::REASONING_MODELS
-            .iter()
-            .any(|candidate| candidate.eq_ignore_ascii_case(trimmed))
+    fn supports_reasoning(&self, _model: &str) -> bool {
+        false
     }
 
     async fn stream(&self, request: LLMRequest) -> Result<LLMStream, LLMError> {

--- a/vtcode-core/src/llm/providers/reasoning.rs
+++ b/vtcode-core/src/llm/providers/reasoning.rs
@@ -9,7 +9,8 @@ const PRIMARY_TEXT_KEYS: &[&str] = &[
     "value",
 ];
 const SECONDARY_COLLECTION_KEYS: &[&str] = &[
-    "messages", "parts", "items", "entries", "steps", "segments", "records",
+    "messages", "parts", "items", "entries", "steps", "segments", "records", "output", "outputs",
+    "logs",
 ];
 
 pub(crate) fn extract_reasoning_trace(value: &Value) -> Option<String> {

--- a/vtcode-core/tests/router_test.rs
+++ b/vtcode-core/tests/router_test.rs
@@ -1,5 +1,5 @@
 use vtcode_core::config::loader::VTCodeConfig;
-use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
+use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, ReasoningEffortLevel};
 use vtcode_core::core::router::{Router, TaskClass};
 
 fn core_cfg(model: &str) -> CoreAgentConfig {
@@ -10,6 +10,7 @@ fn core_cfg(model: &str) -> CoreAgentConfig {
         workspace: std::env::current_dir().unwrap(),
         verbose: false,
         theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
+        reasoning_effort: ReasoningEffortLevel::default(),
     }
 }
 

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -7,34 +7,14 @@
 provider = "openrouter"
 # Default model for single-agent mode
 # Please also check router.models below if change default_model
-<<<<<<< Updated upstream
-default_model = "x-ai/grok-code-fast-1"
-||||||| Stash base
-default_model = "gemini-2.5-flash-lite"
-=======
 default_model = "x-ai/grok-4-fast:free"
->>>>>>> Stashed changes
 
 [router.models]
-<<<<<<< Updated upstream
-simple = "x-ai/grok-code-fast-1"
-standard = "x-ai/grok-code-fast-1"
-complex = "x-ai/grok-code-fast-1e"
-codegen_heavy = "x-ai/grok-code-fast-1"
-retrieval_heavy = "x-ai/grok-code-fast-1"
-||||||| Stash base
-simple = "gemini-2.5-flash-lite"
-standard = "gemini-2.5-flash-lite"
-complex = "gemini-2.5-flash-lite"
-codegen_heavy = "gemini-2.5-flash-lite"
-retrieval_heavy = "gemini-2.5-flash-lite"
-=======
 simple = "x-ai/grok-4-fast:free"
 standard = "x-ai/grok-4-fast:free"
 complex = "x-ai/grok-4-fast:free"
 codegen_heavy = "x-ai/grok-4-fast:free"
 retrieval_heavy = "x-ai/grok-4-fast:free"
->>>>>>> Stashed changes
 
 
 # Max conversation turns per session (prevents infinite loops)


### PR DESCRIPTION
## Summary
- add provider capability detection for reasoning traces and list reasoning-enabled OpenRouter models
- render and log reasoning trace segments in the chat runloop only when supported
- resolve vtcode.toml merge markers and point defaults at x-ai/grok-4-fast:free for testing

## Testing
- cargo fmt
- cargo clippy
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68ce95c914a88323884c22154162c16f