### PR TITLE
Add workspace trust prompt before chat sessions

### DIFF
--- a/src/agent/runloop/ui.rs
+++ b/src/agent/runloop/ui.rs
@@ -43,7 +43,7 @@ pub(crate) fn render_session_banner(
                 .and_then(|p| p.to_str().map(|s| s.to_string()))
                 .unwrap_or_else(|| manager.config_path().display().to_string());
             bullets.push(format!(
-                "> Tools policy: Allow {} · Prompt {} · Deny {} ({})",
+                "* Tools policy: Allow {} · Prompt {} · Deny {} ({})",
                 allow, prompt, deny, policy_path
             ));
         }
@@ -53,7 +53,7 @@ pub(crate) fn render_session_banner(
     }
 
     if let Some(summary) = session_bootstrap.language_summary.as_deref() {
-        bullets.push(format!("> Workspace languages: {}", summary));
+        bullets.push(format!("* Workspace languages: {}", summary));
     }
 
     for line in bullets {

--- a/src/cli/chat_tools.rs
+++ b/src/cli/chat_tools.rs
@@ -1,10 +1,23 @@
 use anyhow::Result;
+use vtcode_core::WorkspaceTrustLevel;
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
+
+use crate::workspace_trust::{WorkspaceTrustGateResult, ensure_workspace_trust};
 
 pub async fn handle_chat_command(
     config: &CoreAgentConfig,
     skip_confirmations: bool,
     full_auto: bool,
 ) -> Result<()> {
+    match ensure_workspace_trust(&config.workspace, full_auto)? {
+        WorkspaceTrustGateResult::Trusted(level) => {
+            if full_auto && level != WorkspaceTrustLevel::FullAuto {
+                return Ok(());
+            }
+        }
+        WorkspaceTrustGateResult::Aborted => {
+            return Ok(());
+        }
+    }
     crate::agent::runloop::run_single_agent_loop(config, skip_confirmations, full_auto).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use vtcode_core::{initialize_dot_folder, load_user_config, update_theme_preferen
 
 mod agent;
 mod cli; // local CLI handlers in src/cli // agent runloops (single-agent only)
+mod workspace_trust;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/workspace_trust.rs
+++ b/src/workspace_trust.rs
@@ -139,9 +139,16 @@ fn read_user_selection() -> Result<TrustSelection> {
         io::stdout()
             .flush()
             .context("Failed to flush stdout for trust prompt")?;
-        io::stdin()
+        let bytes_read = io::stdin()
             .read_line(&mut input)
             .context("Failed to read user selection for trust prompt")?;
+        if bytes_read == 0 {
+            print_prompt_line(
+                "No selection received (EOF). Aborting workspace trust flow.",
+                PromptTone::Heading,
+            );
+            return Ok(TrustSelection::Quit);
+        }
         match input.trim().to_lowercase().as_str() {
             "a" => return Ok(TrustSelection::FullAuto),
             "w" => return Ok(TrustSelection::ToolsPolicy),

--- a/src/workspace_trust.rs
+++ b/src/workspace_trust.rs
@@ -1,0 +1,213 @@
+use std::io::{self, Write};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use console::style;
+use vtcode_core::utils::dot_config::get_dot_manager;
+use vtcode_core::{WorkspaceTrustLevel, WorkspaceTrustRecord, load_user_config};
+
+const PROMPT_BORDER_TOP: &str =
+    "╭───────────────────────────────────────────────────────────────────────────────╮";
+const PROMPT_BORDER_BOTTOM: &str =
+    "╰───────────────────────────────────────────────────────────────────────────────╯";
+const PROMPT_EMPTY_LINE: &str =
+    "│                                                                               │";
+const PROMPT_CONTENT_WIDTH: usize = 79;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceTrustGateResult {
+    Trusted(WorkspaceTrustLevel),
+    Aborted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrustSelection {
+    FullAuto,
+    ToolsPolicy,
+    Quit,
+}
+
+pub fn ensure_workspace_trust(
+    workspace: &Path,
+    full_auto_requested: bool,
+) -> Result<WorkspaceTrustGateResult> {
+    let workspace_key = canonicalize_workspace(workspace)?;
+    let config = load_user_config().context("Failed to load user configuration for trust check")?;
+    let current_level = config
+        .workspace_trust
+        .entries
+        .get(&workspace_key)
+        .map(|record| record.level);
+
+    if let Some(level) = current_level
+        && (!full_auto_requested || level == WorkspaceTrustLevel::FullAuto)
+    {
+        return Ok(WorkspaceTrustGateResult::Trusted(level));
+    }
+
+    let require_full_auto_upgrade = full_auto_requested && current_level.is_some();
+    render_prompt(workspace, require_full_auto_upgrade);
+
+    match read_user_selection()? {
+        TrustSelection::FullAuto => {
+            persist_trust_decision(&workspace_key, WorkspaceTrustLevel::FullAuto)?;
+            println!(
+                "{}",
+                style("Workspace marked as trusted with full auto capabilities.").green()
+            );
+            Ok(WorkspaceTrustGateResult::Trusted(
+                WorkspaceTrustLevel::FullAuto,
+            ))
+        }
+        TrustSelection::ToolsPolicy => {
+            persist_trust_decision(&workspace_key, WorkspaceTrustLevel::ToolsPolicy)?;
+            println!(
+                "{}",
+                style("Workspace marked as trusted with tools policy safeguards.").green()
+            );
+            if full_auto_requested {
+                println!(
+                    "{}",
+                    style("Full-auto mode requires the full auto trust option.").yellow()
+                );
+                println!(
+                    "{}",
+                    style(
+                        "Rerun with --full-auto after upgrading trust or start without --full-auto."
+                    )
+                    .yellow()
+                );
+                return Ok(WorkspaceTrustGateResult::Aborted);
+            }
+            Ok(WorkspaceTrustGateResult::Trusted(
+                WorkspaceTrustLevel::ToolsPolicy,
+            ))
+        }
+        TrustSelection::Quit => {
+            println!(
+                "{}",
+                style("Workspace not trusted. Exiting chat session.").yellow()
+            );
+            Ok(WorkspaceTrustGateResult::Aborted)
+        }
+    }
+}
+
+fn render_prompt(workspace: &Path, require_full_auto_upgrade: bool) {
+    println!("{}", PROMPT_BORDER_TOP);
+    println!("{}", PROMPT_EMPTY_LINE);
+    println!("{}", format_line("⚠ Workspace Trust Required"));
+    println!("{}", PROMPT_EMPTY_LINE);
+    println!(
+        "{}",
+        format_line("VT Code can execute code and access files in your workspace."),
+    );
+    println!(
+        "{}",
+        format_line("Trusting this workspace also trusts all MCP servers configured here."),
+    );
+    println!("{}", PROMPT_EMPTY_LINE);
+    println!(
+        "{}",
+        format_line("Do you want to mark this workspace as trusted?"),
+    );
+    println!("{}", PROMPT_EMPTY_LINE);
+    println!("{}", format_line(&format!("{}", workspace.display())),);
+    println!("{}", PROMPT_EMPTY_LINE);
+    if require_full_auto_upgrade {
+        println!(
+            "{}",
+            format_line(
+                "Full-auto mode requested. Choose full auto trust to continue this session.",
+            ),
+        );
+        println!("{}", PROMPT_EMPTY_LINE);
+    }
+    println!(
+        "{}",
+        format_line("▶ [a] Trust this workspace with full auto"),
+    );
+    println!(
+        "{}",
+        format_line("[w] Trust this workspace with tools policy"),
+    );
+    println!("{}", format_line("[q] Quit"));
+    println!("{}", PROMPT_EMPTY_LINE);
+    println!(
+        "{}",
+        format_line("Press a, w, or q then Enter to choose an option."),
+    );
+    println!("{}", PROMPT_EMPTY_LINE);
+    println!("{}", PROMPT_BORDER_BOTTOM);
+}
+
+fn read_user_selection() -> Result<TrustSelection> {
+    loop {
+        let mut input = String::new();
+        print!("Selection [a/w/q]: ");
+        io::stdout()
+            .flush()
+            .context("Failed to flush stdout for trust prompt")?;
+        io::stdin()
+            .read_line(&mut input)
+            .context("Failed to read user selection for trust prompt")?;
+        match input.trim().to_lowercase().as_str() {
+            "a" => return Ok(TrustSelection::FullAuto),
+            "w" => return Ok(TrustSelection::ToolsPolicy),
+            "q" => return Ok(TrustSelection::Quit),
+            _ => {
+                println!(
+                    "{}",
+                    style("Invalid selection. Please enter 'a', 'w', or 'q'.").red()
+                );
+            }
+        }
+    }
+}
+
+fn persist_trust_decision(workspace_key: &str, level: WorkspaceTrustLevel) -> Result<()> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let manager = get_dot_manager();
+    let guard = manager
+        .lock()
+        .expect("Workspace trust manager mutex poisoned");
+    guard
+        .update_config(|cfg| {
+            cfg.workspace_trust.entries.insert(
+                workspace_key.to_string(),
+                WorkspaceTrustRecord {
+                    level,
+                    trusted_at: timestamp,
+                },
+            );
+        })
+        .context("Failed to persist workspace trust decision")
+}
+
+fn canonicalize_workspace(workspace: &Path) -> Result<String> {
+    let canonical = workspace.canonicalize().with_context(|| {
+        format!(
+            "Failed to canonicalize workspace path {} for trust evaluation",
+            workspace.display()
+        )
+    })?;
+    Ok(canonical.to_string_lossy().into_owned())
+}
+
+fn format_line(content: &str) -> String {
+    let mut display = String::new();
+    if content.chars().count() > PROMPT_CONTENT_WIDTH {
+        display = content
+            .chars()
+            .take(PROMPT_CONTENT_WIDTH.saturating_sub(1))
+            .collect();
+        display.push('…');
+    } else {
+        display.push_str(content);
+    }
+    format!("│ {:<width$} │", display, width = PROMPT_CONTENT_WIDTH)
+}

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -342,7 +342,8 @@ pub use tools::{
 pub use ui::diff_renderer::DiffRenderer;
 pub use utils::dot_config::{
     CacheConfig, DotConfig, DotManager, ProviderConfigs, UiConfig, UserPreferences,
-    initialize_dot_folder, load_user_config, save_user_config, update_theme_preference,
+    WorkspaceTrustLevel, WorkspaceTrustRecord, WorkspaceTrustStore, initialize_dot_folder,
+    load_user_config, save_user_config, update_theme_preference,
 };
 pub use utils::vtcodegitignore::initialize_vtcode_gitignore;
 

--- a/vtcode-core/src/utils/dot_config.rs
+++ b/vtcode-core/src/utils/dot_config.rs
@@ -3,6 +3,7 @@
 use crate::config::constants::defaults;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -129,6 +130,15 @@ impl Default for ProviderConfigs {
 impl Default for WorkspaceTrustLevel {
     fn default() -> Self {
         Self::ToolsPolicy
+    }
+}
+
+impl fmt::Display for WorkspaceTrustLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WorkspaceTrustLevel::ToolsPolicy => write!(f, "tools policy"),
+            WorkspaceTrustLevel::FullAuto => write!(f, "full auto"),
+        }
     }
 }
 

--- a/vtcode-core/src/utils/dot_config.rs
+++ b/vtcode-core/src/utils/dot_config.rs
@@ -15,6 +15,8 @@ pub struct DotConfig {
     pub providers: ProviderConfigs,
     pub cache: CacheConfig,
     pub ui: UiConfig,
+    #[serde(default)]
+    pub workspace_trust: WorkspaceTrustStore,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,6 +36,25 @@ pub struct ProviderConfigs {
     pub anthropic: Option<ProviderConfig>,
     pub gemini: Option<ProviderConfig>,
     pub openrouter: Option<ProviderConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceTrustStore {
+    #[serde(default)]
+    pub entries: HashMap<String, WorkspaceTrustRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceTrustRecord {
+    pub level: WorkspaceTrustLevel,
+    pub trusted_at: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceTrustLevel {
+    ToolsPolicy,
+    FullAuto,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -75,6 +96,7 @@ impl Default for DotConfig {
             providers: ProviderConfigs::default(),
             cache: CacheConfig::default(),
             ui: UiConfig::default(),
+            workspace_trust: WorkspaceTrustStore::default(),
         }
     }
 }
@@ -101,6 +123,12 @@ impl Default for ProviderConfigs {
             gemini: None,
             openrouter: None,
         }
+    }
+}
+
+impl Default for WorkspaceTrustLevel {
+    fn default() -> Self {
+        Self::ToolsPolicy
     }
 }
 


### PR DESCRIPTION
## Summary
- store workspace trust preferences in the dot-config so we can persist trust decisions per workspace
- add a workspace trust prompt and CLI flow before starting chat sessions, including full-auto escalation handling
- gate chat command execution on recorded trust level to abort sessions when trust is not granted

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68cf59a0594883239653ef279cce0294