### PR TITLE
Add xAI provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ using the OpenAI-compatible Responses API.
 
 **Multi-Provider AI Support**
 
--   Gemini, OpenAI, Anthropic, OpenRouter, and DeepSeek integration
+-   Gemini, OpenAI, Anthropic, xAI, OpenRouter, and DeepSeek integration
 -   Automatic provider selection and failover
 -   Cost optimization with safety controls
 

--- a/src/agent/runloop/ui.rs
+++ b/src/agent/runloop/ui.rs
@@ -1,7 +1,7 @@
 extern crate cfonts;
 
 use anyhow::{Context, Result};
-use cfonts::{render, Options, Fonts};
+use cfonts::{Fonts, Options, render};
 use pathdiff::diff_paths;
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::tool_policy::{ToolPolicy, ToolPolicyManager};
@@ -10,7 +10,6 @@ use vtcode_core::utils::ansi::AnsiRenderer;
 
 use super::welcome::SessionBootstrap;
 use crate::workspace_trust;
-
 
 /// Render a fancy banner using cfonts
 fn render_fancy_banner() -> String {
@@ -36,7 +35,7 @@ pub(crate) fn render_session_banner(
     for line in banner_text.lines() {
         renderer.line_with_style(theme::banner_style(), line)?;
     }
-    
+
     // Add a separator line
     renderer.line_with_style(theme::banner_style(), "")?;
 

--- a/src/agent/runloop/unified/display.rs
+++ b/src/agent/runloop/unified/display.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use anstyle;
+use anyhow::Result;
 
 use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
 use vtcode_core::utils::dot_config::update_theme_preference;
@@ -30,7 +30,8 @@ pub(crate) fn display_user_message(renderer: &mut AnsiRenderer, message: &str) -
     // Display the user message with soft-gray styling
     for line in message.lines() {
         renderer.line_with_style(
-            anstyle::Style::new().fg_color(Some(anstyle::Color::Rgb(anstyle::RgbColor(128, 128, 128)))),
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::Color::Rgb(anstyle::RgbColor(128, 128, 128)))),
             line,
         )?;
     }

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -34,7 +34,7 @@ use crate::agent::runloop::text_tools::detect_textual_tool_call;
 use crate::agent::runloop::tool_output::render_tool_output;
 use crate::agent::runloop::ui::render_session_banner;
 
-use super::display::{ensure_turn_bottom_gap, persist_theme_preference, display_user_message};
+use super::display::{display_user_message, ensure_turn_bottom_gap, persist_theme_preference};
 use super::session_setup::{SessionState, initialize_session};
 use super::shell::{derive_recent_tool_output, should_short_circuit_shell};
 

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -83,7 +83,7 @@ fn render_welcome_text(
 ) -> String {
     let mut lines = Vec::new();
     // Skip intro_text and use the fancy banner instead
-    
+
     if onboarding_cfg.include_project_overview {
         if let Some(project) = overview {
             let summary = project.short_for_display();

--- a/src/main_modular.rs
+++ b/src/main_modular.rs
@@ -95,14 +95,12 @@ async fn main() -> Result<()> {
     let vtcode_config = config_manager.config();
 
     // Create API key sources configuration
-    let api_key_sources = ApiKeySources {
-        gemini_env: "GEMINI_API_KEY".to_string(),
-        anthropic_env: "ANTHROPIC_API_KEY".to_string(),
-        openai_env: "OPENAI_API_KEY".to_string(),
-        gemini_config: vtcode_config.agent.gemini_api_key.clone(),
-        anthropic_config: vtcode_config.agent.anthropic_api_key.clone(),
-        openai_config: vtcode_config.agent.openai_api_key.clone(),
-    };
+    let mut api_key_sources = ApiKeySources::default();
+    api_key_sources.gemini_env = "GEMINI_API_KEY".to_string();
+    api_key_sources.anthropic_env = "ANTHROPIC_API_KEY".to_string();
+    api_key_sources.openai_env = "OPENAI_API_KEY".to_string();
+    api_key_sources.openrouter_env = "OPENROUTER_API_KEY".to_string();
+    api_key_sources.xai_env = "XAI_API_KEY".to_string();
 
     // Parse model
     let model = ModelId::from_str(&args.model)?;

--- a/src/workspace_trust.rs
+++ b/src/workspace_trust.rs
@@ -4,7 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use console::{Color, style};
-use vtcode_core::utils::dot_config::{get_dot_manager, WorkspaceTrustLevel, WorkspaceTrustRecord, load_user_config};
+use vtcode_core::utils::dot_config::{
+    WorkspaceTrustLevel, WorkspaceTrustRecord, get_dot_manager, load_user_config,
+};
 
 const WARNING_RGB: (u8, u8, u8) = (166, 51, 51);
 const INFO_RGB: (u8, u8, u8) = (217, 154, 78);

--- a/tests/llm_focused_test.rs
+++ b/tests/llm_focused_test.rs
@@ -4,7 +4,9 @@ use vtcode_core::config::constants::models;
 use vtcode_core::llm::{
     factory::{LLMFactory, create_provider_for_model},
     provider::{LLMProvider, LLMRequest, Message, MessageRole},
-    providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider},
+    providers::{
+        AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider, XAIProvider,
+    },
 };
 
 #[test]
@@ -16,7 +18,8 @@ fn test_provider_factory_basic() {
     assert!(providers.contains(&"openai".to_string()));
     assert!(providers.contains(&"anthropic".to_string()));
     assert!(providers.contains(&"openrouter".to_string()));
-    assert_eq!(providers.len(), 4);
+    assert!(providers.contains(&"xai".to_string()));
+    assert_eq!(providers.len(), 5);
 }
 
 #[test]
@@ -38,6 +41,10 @@ fn test_provider_auto_detection() {
     assert_eq!(
         factory.provider_from_model(models::OPENROUTER_X_AI_GROK_CODE_FAST_1),
         Some("openrouter".to_string())
+    );
+    assert_eq!(
+        factory.provider_from_model(models::xai::GROK_2_LATEST),
+        Some("xai".to_string())
     );
     assert_eq!(factory.provider_from_model("unknown-model"), None);
 }
@@ -61,6 +68,9 @@ fn test_unified_client_creation() {
         "test_key".to_string(),
     );
     assert!(openrouter.is_ok());
+
+    let xai = create_provider_for_model(models::xai::GROK_2_LATEST, "test_key".to_string());
+    assert!(xai.is_ok());
 }
 
 #[test]
@@ -87,6 +97,9 @@ fn test_provider_names() {
 
     let openrouter = OpenRouterProvider::new("test_key".to_string());
     assert_eq!(openrouter.name(), "openrouter");
+
+    let xai = XAIProvider::new("test_key".to_string());
+    assert_eq!(xai.name(), "xai");
 }
 
 #[test]

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -38,6 +38,7 @@ pub struct Cli {
     ///   • deepseek-reasoner - DeepSeek reasoning model
     ///   • x-ai/grok-code-fast-1 - OpenRouter Grok fast coding model
     ///   • qwen/qwen3-coder - OpenRouter Qwen3 Coder optimized for IDE usage
+    ///   • grok-2-latest - xAI Grok flagship model
     #[arg(long, global = true)]
     pub model: Option<String>,
 
@@ -49,12 +50,13 @@ pub struct Cli {
     ///   • anthropic - Anthropic Claude models
     ///   • deepseek - DeepSeek models
     ///   • openrouter - OpenRouter marketplace models
+    ///   • xai - xAI Grok models
     ///
     /// Example: --provider deepseek
     #[arg(long, global = true)]
     pub provider: Option<String>,
 
-    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
+    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
     #[arg(long, global = true, default_value = crate::config::constants::defaults::DEFAULT_API_KEY_ENV)]
     pub api_key_env: String,
 

--- a/vtcode-core/src/cli/models_commands.rs
+++ b/vtcode-core/src/cli/models_commands.rs
@@ -226,6 +226,7 @@ fn configure_standard_provider(
             .providers
             .openrouter
             .get_or_insert_with(Default::default),
+        "xai" => config.providers.xai.get_or_insert_with(Default::default),
         _ => return Err(anyhow!("Unknown provider: {}", provider)),
     };
 
@@ -314,6 +315,7 @@ fn get_provider_credentials(
         "anthropic" => Ok(get_config(config.providers.anthropic.as_ref())),
         "gemini" => Ok(get_config(config.providers.gemini.as_ref())),
         "openrouter" => Ok(get_config(config.providers.openrouter.as_ref())),
+        "xai" => Ok(get_config(config.providers.xai.as_ref())),
         _ => Err(anyhow!("Unknown provider: {}", provider)),
     }
 }
@@ -355,6 +357,8 @@ fn infer_provider_from_model(model: &str) -> &'static str {
         "Anthropic"
     } else if model.starts_with("gemini-") {
         "Google Gemini"
+    } else if model.starts_with("grok-") {
+        "xAI"
     } else if model.starts_with("deepseek-") {
         "DeepSeek"
     } else {

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -81,6 +81,24 @@ pub mod models {
         pub const CLAUDE_SONNET_4_20250514: &str = "claude-sonnet-4-20250514";
     }
 
+    // xAI models
+    pub mod xai {
+        pub const DEFAULT_MODEL: &str = "grok-2-latest";
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            "grok-2-latest",
+            "grok-2",
+            "grok-2-mini",
+            "grok-2-reasoning",
+            "grok-2-vision",
+        ];
+
+        pub const GROK_2_LATEST: &str = "grok-2-latest";
+        pub const GROK_2: &str = "grok-2";
+        pub const GROK_2_MINI: &str = "grok-2-mini";
+        pub const GROK_2_REASONING: &str = "grok-2-reasoning";
+        pub const GROK_2_VISION: &str = "grok-2-vision";
+    }
+
     // Backwards compatibility - keep old constants working
     pub const GEMINI_2_5_FLASH_PREVIEW: &str = google::GEMINI_2_5_FLASH_PREVIEW;
     pub const GEMINI_2_5_FLASH: &str = google::GEMINI_2_5_FLASH;
@@ -99,6 +117,11 @@ pub mod models {
     pub const OPENROUTER_DEEPSEEK_CHAT_V3_1: &str = openrouter::DEEPSEEK_DEEPSEEK_CHAT_V3_1;
     pub const OPENROUTER_OPENAI_GPT_5: &str = openrouter::OPENAI_GPT_5;
     pub const OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4: &str = openrouter::ANTHROPIC_CLAUDE_SONNET_4;
+    pub const XAI_GROK_2_LATEST: &str = xai::GROK_2_LATEST;
+    pub const XAI_GROK_2: &str = xai::GROK_2;
+    pub const XAI_GROK_2_MINI: &str = xai::GROK_2_MINI;
+    pub const XAI_GROK_2_REASONING: &str = xai::GROK_2_REASONING;
+    pub const XAI_GROK_2_VISION: &str = xai::GROK_2_VISION;
 }
 
 /// Model validation and helper functions
@@ -112,6 +135,7 @@ pub mod model_helpers {
             "openai" => Some(models::openai::SUPPORTED_MODELS),
             "anthropic" => Some(models::anthropic::SUPPORTED_MODELS),
             "openrouter" => Some(models::openrouter::SUPPORTED_MODELS),
+            "xai" => Some(models::xai::SUPPORTED_MODELS),
             _ => None,
         }
     }
@@ -123,6 +147,7 @@ pub mod model_helpers {
             "openai" => Some(models::openai::DEFAULT_MODEL),
             "anthropic" => Some(models::anthropic::DEFAULT_MODEL),
             "openrouter" => Some(models::openrouter::DEFAULT_MODEL),
+            "xai" => Some(models::xai::DEFAULT_MODEL),
             _ => None,
         }
     }
@@ -171,6 +196,7 @@ pub mod urls {
     pub const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com/v1";
     pub const ANTHROPIC_API_VERSION: &str = "2023-06-01";
     pub const OPENROUTER_API_BASE: &str = "https://openrouter.ai/api/v1";
+    pub const XAI_API_BASE: &str = "https://api.x.ai/v1";
 }
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Agent-wide configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentConfig {
-    /// AI provider for single agent mode (gemini, openai, anthropic, openrouter)
+    /// AI provider for single agent mode (gemini, openai, anthropic, openrouter, xai)
     #[serde(default = "default_provider")]
     pub provider: String,
 

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -20,6 +20,8 @@ pub enum Provider {
     Anthropic,
     /// OpenRouter marketplace models
     OpenRouter,
+    /// xAI Grok models
+    XAI,
 }
 
 impl Provider {
@@ -30,6 +32,7 @@ impl Provider {
             Provider::OpenAI => "OPENAI_API_KEY",
             Provider::Anthropic => "ANTHROPIC_API_KEY",
             Provider::OpenRouter => "OPENROUTER_API_KEY",
+            Provider::XAI => "XAI_API_KEY",
         }
     }
 
@@ -40,6 +43,7 @@ impl Provider {
             Provider::OpenAI,
             Provider::Anthropic,
             Provider::OpenRouter,
+            Provider::XAI,
         ]
     }
 }
@@ -51,6 +55,7 @@ impl fmt::Display for Provider {
             Provider::OpenAI => write!(f, "openai"),
             Provider::Anthropic => write!(f, "anthropic"),
             Provider::OpenRouter => write!(f, "openrouter"),
+            Provider::XAI => write!(f, "xai"),
         }
     }
 }
@@ -64,6 +69,7 @@ impl FromStr for Provider {
             "openai" => Ok(Provider::OpenAI),
             "anthropic" => Ok(Provider::Anthropic),
             "openrouter" => Ok(Provider::OpenRouter),
+            "xai" => Ok(Provider::XAI),
             _ => Err(ModelParseError::InvalidProvider(s.to_string())),
         }
     }
@@ -98,6 +104,18 @@ pub enum ModelId {
     /// Claude Sonnet 4 - Latest balanced Anthropic model (2025-05-14)
     ClaudeSonnet4,
 
+    // xAI models
+    /// Grok-2 Latest - Flagship xAI model with advanced reasoning
+    XaiGrok2Latest,
+    /// Grok-2 - Stable xAI model variant
+    XaiGrok2,
+    /// Grok-2 Mini - Efficient xAI model
+    XaiGrok2Mini,
+    /// Grok-2 Reasoning - Enhanced reasoning trace variant
+    XaiGrok2Reasoning,
+    /// Grok-2 Vision - Multimodal xAI model
+    XaiGrok2Vision,
+
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model
     OpenRouterGrokCodeFast1,
@@ -129,6 +147,12 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41 => models::CLAUDE_OPUS_4_1_20250805,
             ModelId::ClaudeSonnet4 => models::CLAUDE_SONNET_4_20250514,
+            // xAI models
+            ModelId::XaiGrok2Latest => models::xai::GROK_2_LATEST,
+            ModelId::XaiGrok2 => models::xai::GROK_2,
+            ModelId::XaiGrok2Mini => models::xai::GROK_2_MINI,
+            ModelId::XaiGrok2Reasoning => models::xai::GROK_2_REASONING,
+            ModelId::XaiGrok2Vision => models::xai::GROK_2_VISION,
             // OpenRouter models
             ModelId::OpenRouterGrokCodeFast1 => models::OPENROUTER_X_AI_GROK_CODE_FAST_1,
             ModelId::OpenRouterQwen3Coder => models::OPENROUTER_QWEN3_CODER,
@@ -151,6 +175,11 @@ impl ModelId {
                 Provider::OpenAI
             }
             ModelId::ClaudeOpus41 | ModelId::ClaudeSonnet4 => Provider::Anthropic,
+            ModelId::XaiGrok2Latest
+            | ModelId::XaiGrok2
+            | ModelId::XaiGrok2Mini
+            | ModelId::XaiGrok2Reasoning
+            | ModelId::XaiGrok2Vision => Provider::XAI,
             ModelId::OpenRouterGrokCodeFast1
             | ModelId::OpenRouterQwen3Coder
             | ModelId::OpenRouterDeepSeekChatV31
@@ -175,6 +204,12 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41 => "Claude Opus 4.1",
             ModelId::ClaudeSonnet4 => "Claude Sonnet 4",
+            // xAI models
+            ModelId::XaiGrok2Latest => "Grok-2 Latest",
+            ModelId::XaiGrok2 => "Grok-2",
+            ModelId::XaiGrok2Mini => "Grok-2 Mini",
+            ModelId::XaiGrok2Reasoning => "Grok-2 Reasoning",
+            ModelId::XaiGrok2Vision => "Grok-2 Vision",
             // OpenRouter models
             ModelId::OpenRouterGrokCodeFast1 => "Grok Code Fast 1",
             ModelId::OpenRouterQwen3Coder => "Qwen3 Coder",
@@ -206,6 +241,14 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41 => "Latest most capable Anthropic model with advanced reasoning",
             ModelId::ClaudeSonnet4 => "Latest balanced Anthropic model for general tasks",
+            // xAI models
+            ModelId::XaiGrok2Latest => "Flagship xAI Grok model with long context and tool use",
+            ModelId::XaiGrok2 => "Stable Grok 2 release tuned for general coding tasks",
+            ModelId::XaiGrok2Mini => "Efficient Grok 2 variant optimized for latency",
+            ModelId::XaiGrok2Reasoning => {
+                "Grok 2 variant that surfaces structured reasoning traces"
+            }
+            ModelId::XaiGrok2Vision => "Multimodal Grok 2 model with image understanding",
             // OpenRouter models
             ModelId::OpenRouterGrokCodeFast1 => "Fast OpenRouter coding model powered by xAI Grok",
             ModelId::OpenRouterQwen3Coder => {
@@ -235,6 +278,12 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41,
             ModelId::ClaudeSonnet4,
+            // xAI models
+            ModelId::XaiGrok2Latest,
+            ModelId::XaiGrok2,
+            ModelId::XaiGrok2Mini,
+            ModelId::XaiGrok2Reasoning,
+            ModelId::XaiGrok2Vision,
             // OpenRouter models
             ModelId::OpenRouterGrokCodeFast1,
             ModelId::OpenRouterQwen3Coder,
@@ -259,6 +308,7 @@ impl ModelId {
             ModelId::Gemini25Pro,
             ModelId::GPT5,
             ModelId::ClaudeOpus41,
+            ModelId::XaiGrok2Latest,
             ModelId::OpenRouterGrokCodeFast1,
         ]
     }
@@ -284,6 +334,7 @@ impl ModelId {
             Provider::Gemini => ModelId::Gemini25Pro,
             Provider::OpenAI => ModelId::GPT5,
             Provider::Anthropic => ModelId::ClaudeOpus41,
+            Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
         }
     }
@@ -294,6 +345,7 @@ impl ModelId {
             Provider::Gemini => ModelId::Gemini25FlashPreview,
             Provider::OpenAI => ModelId::GPT5Mini,
             Provider::Anthropic => ModelId::ClaudeSonnet4,
+            Provider::XAI => ModelId::XaiGrok2Mini,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
         }
     }
@@ -304,6 +356,7 @@ impl ModelId {
             Provider::Gemini => ModelId::Gemini25FlashPreview,
             Provider::OpenAI => ModelId::GPT5,
             Provider::Anthropic => ModelId::ClaudeOpus41,
+            Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
         }
     }
@@ -320,7 +373,7 @@ impl ModelId {
     pub fn is_pro_variant(&self) -> bool {
         matches!(
             self,
-            ModelId::Gemini25Pro | ModelId::GPT5 | ModelId::ClaudeOpus41
+            ModelId::Gemini25Pro | ModelId::GPT5 | ModelId::ClaudeOpus41 | ModelId::XaiGrok2Latest
         )
     }
 
@@ -334,6 +387,7 @@ impl ModelId {
                 | ModelId::GPT5Mini
                 | ModelId::GPT5Nano
                 | ModelId::OpenRouterGrokCodeFast1
+                | ModelId::XaiGrok2Mini
         )
     }
 
@@ -346,6 +400,8 @@ impl ModelId {
                 | ModelId::ClaudeOpus41
                 | ModelId::ClaudeSonnet4
                 | ModelId::OpenRouterQwen3Coder
+                | ModelId::XaiGrok2Latest
+                | ModelId::XaiGrok2Reasoning
         )
     }
 
@@ -362,6 +418,12 @@ impl ModelId {
             // Anthropic generations
             ModelId::ClaudeSonnet4 => "4",
             ModelId::ClaudeOpus41 => "4.1",
+            // xAI generations
+            ModelId::XaiGrok2Latest
+            | ModelId::XaiGrok2
+            | ModelId::XaiGrok2Mini
+            | ModelId::XaiGrok2Reasoning
+            | ModelId::XaiGrok2Vision => "2",
             // OpenRouter marketplace listings
             ModelId::OpenRouterGrokCodeFast1 | ModelId::OpenRouterQwen3Coder => "marketplace",
             // New OpenRouter models
@@ -397,6 +459,12 @@ impl FromStr for ModelId {
             // Anthropic models
             s if s == models::CLAUDE_OPUS_4_1_20250805 => Ok(ModelId::ClaudeOpus41),
             s if s == models::CLAUDE_SONNET_4_20250514 => Ok(ModelId::ClaudeSonnet4),
+            // xAI models
+            s if s == models::xai::GROK_2_LATEST => Ok(ModelId::XaiGrok2Latest),
+            s if s == models::xai::GROK_2 => Ok(ModelId::XaiGrok2),
+            s if s == models::xai::GROK_2_MINI => Ok(ModelId::XaiGrok2Mini),
+            s if s == models::xai::GROK_2_REASONING => Ok(ModelId::XaiGrok2Reasoning),
+            s if s == models::xai::GROK_2_VISION => Ok(ModelId::XaiGrok2Vision),
             // OpenRouter models
             s if s == models::OPENROUTER_X_AI_GROK_CODE_FAST_1 => {
                 Ok(ModelId::OpenRouterGrokCodeFast1)
@@ -486,6 +554,15 @@ mod tests {
             ModelId::ClaudeOpus41.as_str(),
             models::CLAUDE_OPUS_4_1_20250805
         );
+        // xAI models
+        assert_eq!(ModelId::XaiGrok2Latest.as_str(), models::xai::GROK_2_LATEST);
+        assert_eq!(ModelId::XaiGrok2.as_str(), models::xai::GROK_2);
+        assert_eq!(ModelId::XaiGrok2Mini.as_str(), models::xai::GROK_2_MINI);
+        assert_eq!(
+            ModelId::XaiGrok2Reasoning.as_str(),
+            models::xai::GROK_2_REASONING
+        );
+        assert_eq!(ModelId::XaiGrok2Vision.as_str(), models::xai::GROK_2_VISION);
         // OpenRouter models
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.as_str(),
@@ -548,6 +625,32 @@ mod tests {
             ModelId::ClaudeSonnet4
         );
         assert_eq!(
+            models::CLAUDE_OPUS_4_1_20250805.parse::<ModelId>().unwrap(),
+            ModelId::ClaudeOpus41
+        );
+        // xAI models
+        assert_eq!(
+            models::xai::GROK_2_LATEST.parse::<ModelId>().unwrap(),
+            ModelId::XaiGrok2Latest
+        );
+        assert_eq!(
+            models::xai::GROK_2.parse::<ModelId>().unwrap(),
+            ModelId::XaiGrok2
+        );
+        assert_eq!(
+            models::xai::GROK_2_MINI.parse::<ModelId>().unwrap(),
+            ModelId::XaiGrok2Mini
+        );
+        assert_eq!(
+            models::xai::GROK_2_REASONING.parse::<ModelId>().unwrap(),
+            ModelId::XaiGrok2Reasoning
+        );
+        assert_eq!(
+            models::xai::GROK_2_VISION.parse::<ModelId>().unwrap(),
+            ModelId::XaiGrok2Vision
+        );
+        // OpenRouter models
+        assert_eq!(
             models::OPENROUTER_X_AI_GROK_CODE_FAST_1
                 .parse::<ModelId>()
                 .unwrap(),
@@ -589,6 +692,7 @@ mod tests {
             "openrouter".parse::<Provider>().unwrap(),
             Provider::OpenRouter
         );
+        assert_eq!("xai".parse::<Provider>().unwrap(), Provider::XAI);
         assert!("invalid-provider".parse::<Provider>().is_err());
     }
 
@@ -597,6 +701,7 @@ mod tests {
         assert_eq!(ModelId::Gemini25FlashPreview.provider(), Provider::Gemini);
         assert_eq!(ModelId::GPT5.provider(), Provider::OpenAI);
         assert_eq!(ModelId::ClaudeSonnet4.provider(), Provider::Anthropic);
+        assert_eq!(ModelId::XaiGrok2Latest.provider(), Provider::XAI);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -621,6 +726,10 @@ mod tests {
             ModelId::default_orchestrator_for_provider(Provider::OpenRouter),
             ModelId::OpenRouterGrokCodeFast1
         );
+        assert_eq!(
+            ModelId::default_orchestrator_for_provider(Provider::XAI),
+            ModelId::XaiGrok2Latest
+        );
 
         assert_eq!(
             ModelId::default_subagent_for_provider(Provider::Gemini),
@@ -637,6 +746,10 @@ mod tests {
         assert_eq!(
             ModelId::default_subagent_for_provider(Provider::OpenRouter),
             ModelId::OpenRouterGrokCodeFast1
+        );
+        assert_eq!(
+            ModelId::default_subagent_for_provider(Provider::XAI),
+            ModelId::XaiGrok2Mini
         );
     }
 
@@ -666,6 +779,7 @@ mod tests {
         assert!(ModelId::Gemini25FlashLite.is_efficient_variant());
         assert!(ModelId::GPT5Mini.is_efficient_variant());
         assert!(ModelId::OpenRouterGrokCodeFast1.is_efficient_variant());
+        assert!(ModelId::XaiGrok2Mini.is_efficient_variant());
         assert!(!ModelId::GPT5.is_efficient_variant());
 
         // Top tier models
@@ -673,6 +787,8 @@ mod tests {
         assert!(ModelId::GPT5.is_top_tier());
         assert!(ModelId::ClaudeSonnet4.is_top_tier());
         assert!(ModelId::OpenRouterQwen3Coder.is_top_tier());
+        assert!(ModelId::XaiGrok2Latest.is_top_tier());
+        assert!(ModelId::XaiGrok2Reasoning.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
     }
 
@@ -693,6 +809,13 @@ mod tests {
         // Anthropic generations
         assert_eq!(ModelId::ClaudeSonnet4.generation(), "4");
         assert_eq!(ModelId::ClaudeOpus41.generation(), "4.1");
+
+        // xAI generations
+        assert_eq!(ModelId::XaiGrok2Latest.generation(), "2");
+        assert_eq!(ModelId::XaiGrok2.generation(), "2");
+        assert_eq!(ModelId::XaiGrok2Mini.generation(), "2");
+        assert_eq!(ModelId::XaiGrok2Reasoning.generation(), "2");
+        assert_eq!(ModelId::XaiGrok2Vision.generation(), "2");
 
         // OpenRouter marketplace entries
         assert_eq!(ModelId::OpenRouterGrokCodeFast1.generation(), "marketplace");
@@ -730,6 +853,13 @@ mod tests {
         assert!(openrouter_models.contains(&ModelId::OpenRouterDeepSeekChatV31));
         assert!(openrouter_models.contains(&ModelId::OpenRouterOpenAIGPT5));
         assert!(openrouter_models.contains(&ModelId::OpenRouterAnthropicClaudeSonnet4));
+
+        let xai_models = ModelId::models_for_provider(Provider::XAI);
+        assert!(xai_models.contains(&ModelId::XaiGrok2Latest));
+        assert!(xai_models.contains(&ModelId::XaiGrok2));
+        assert!(xai_models.contains(&ModelId::XaiGrok2Mini));
+        assert!(xai_models.contains(&ModelId::XaiGrok2Reasoning));
+        assert!(xai_models.contains(&ModelId::XaiGrok2Vision));
     }
 
     #[test]
@@ -738,6 +868,7 @@ mod tests {
         assert!(!fallbacks.is_empty());
         assert!(fallbacks.contains(&ModelId::Gemini25Pro));
         assert!(fallbacks.contains(&ModelId::GPT5));
+        assert!(fallbacks.contains(&ModelId::XaiGrok2Latest));
         assert!(fallbacks.contains(&ModelId::OpenRouterGrokCodeFast1));
     }
 }

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -312,7 +312,7 @@ pub use code::code_completion::{CompletionEngine, CompletionSuggestion};
 pub use commands::stats::handle_stats_command;
 pub use config::types::{
     AnalysisDepth, CapabilityLevel, CommandResult, CompressionLevel, ContextConfig, LoggingConfig,
-    OutputFormat, PerformanceMetrics, SessionInfo, ToolConfig, ReasoningEffortLevel,
+    OutputFormat, PerformanceMetrics, ReasoningEffortLevel, SessionInfo, ToolConfig,
 };
 pub use config::{AgentConfig, VTCodeConfig};
 pub use core::agent::core::Agent;

--- a/vtcode-core/src/llm/client.rs
+++ b/vtcode-core/src/llm/client.rs
@@ -1,5 +1,7 @@
 use super::provider::LLMError;
-use super::providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider};
+use super::providers::{
+    AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider, XAIProvider,
+};
 use super::types::{BackendKind, LLMResponse};
 use crate::config::models::{ModelId, Provider};
 use async_trait::async_trait;
@@ -31,5 +33,6 @@ pub fn make_client(api_key: String, model: ModelId) -> AnyClient {
             api_key,
             model.as_str().to_string(),
         )),
+        Provider::XAI => Box::new(XAIProvider::with_model(api_key, model.as_str().to_string())),
     }
 }

--- a/vtcode-core/src/llm/factory.rs
+++ b/vtcode-core/src/llm/factory.rs
@@ -1,4 +1,6 @@
-use super::providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider};
+use super::providers::{
+    AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider, XAIProvider,
+};
 use crate::llm::provider::{LLMError, LLMProvider};
 use std::collections::HashMap;
 
@@ -73,6 +75,18 @@ impl LLMFactory {
             }),
         );
 
+        factory.register_provider(
+            "xai",
+            Box::new(|config: ProviderConfig| {
+                let ProviderConfig {
+                    api_key,
+                    base_url,
+                    model,
+                } = config;
+                Box::new(XAIProvider::from_config(api_key, model, base_url)) as Box<dyn LLMProvider>
+            }),
+        );
+
         factory
     }
 
@@ -112,6 +126,8 @@ impl LLMFactory {
             Some("anthropic".to_string())
         } else if m.contains("gemini") || m.starts_with("palm") {
             Some("gemini".to_string())
+        } else if m.starts_with("grok-") || m.starts_with("xai-") {
+            Some("xai".to_string())
         } else if m.contains('/') || m.contains('@') {
             Some("openrouter".to_string())
         } else {

--- a/vtcode-core/src/llm/llm_modular/providers/mod.rs
+++ b/vtcode-core/src/llm/llm_modular/providers/mod.rs
@@ -1,7 +1,9 @@
 pub mod gemini;
 pub mod openai;
 pub mod anthropic;
+pub mod xai;
 
 pub use gemini::GeminiProvider;
 pub use openai::OpenAIProvider;
 pub use anthropic::AnthropicProvider;
+pub use xai::XAIProvider;

--- a/vtcode-core/src/llm/llm_modular/providers/xai.rs
+++ b/vtcode-core/src/llm/llm_modular/providers/xai.rs
@@ -1,0 +1,97 @@
+use crate::llm_modular::client::LLMClient;
+use crate::llm_modular::types::{BackendKind, LLMError, LLMResponse, Usage};
+use async_trait::async_trait;
+use reqwest;
+use serde_json::{Value, json};
+
+/// xAI Grok provider for the modular LLM client
+pub struct XAIProvider {
+    api_key: String,
+    model: String,
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl XAIProvider {
+    pub fn new(api_key: String, model: String) -> Self {
+        Self {
+            api_key,
+            model,
+            client: reqwest::Client::new(),
+            base_url: "https://api.x.ai/v1".to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMClient for XAIProvider {
+    async fn generate(&mut self, prompt: &str) -> Result<LLMResponse, LLMError> {
+        let request_body = json!({
+            "model": self.model,
+            "messages": [{
+                "role": "user",
+                "content": prompt
+            }],
+            "temperature": 0.7
+        });
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| LLMError::ApiError(format!("Failed to send request: {}", e)))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(LLMError::ApiError(format!("API error: {}", error_text)));
+        }
+
+        let response_json: Value = response
+            .json()
+            .await
+            .map_err(|e| LLMError::ApiError(format!("Failed to parse response: {}", e)))?;
+
+        let content = response_json["choices"][0]["message"]["content"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+
+        let usage = response_json["usage"].as_object().map(|usage_obj| Usage {
+            prompt_tokens: usage_obj
+                .get("prompt_tokens")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0) as usize,
+            completion_tokens: usage_obj
+                .get("completion_tokens")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0) as usize,
+            total_tokens: usage_obj
+                .get("total_tokens")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0) as usize,
+        });
+
+        Ok(LLMResponse {
+            content,
+            model: self.model.clone(),
+            usage,
+            reasoning: None,
+        })
+    }
+
+    fn backend_kind(&self) -> BackendKind {
+        BackendKind::XAI
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}

--- a/vtcode-core/src/llm/mod.rs
+++ b/vtcode-core/src/llm/mod.rs
@@ -1,7 +1,7 @@
 //! # LLM Integration Layer
 //!
 //! This module provides a unified, modular interface for integrating multiple LLM providers
-//! with VTCode, supporting Gemini, OpenAI, Anthropic, and DeepSeek.
+//! with VTCode, supporting Gemini, OpenAI, Anthropic, xAI, and DeepSeek.
 //!
 //! ## Architecture Overview
 //!
@@ -20,6 +20,7 @@
 //! | Gemini | ✅ | gemini-2.5-pro, gemini-2.5-flash-preview-05-20 |
 //! | OpenAI | ✅ | gpt-5, gpt-4.1, gpt-5-mini |
 //! | Anthropic | ✅ | claude-4.1-opus, claude-4-sonnet |
+//! | xAI | ✅ | grok-2-latest, grok-2-mini |
 //! | DeepSeek | ✅ | deepseek-chat |
 //!
 //! ## Basic Usage
@@ -174,5 +175,5 @@ mod error_display_test;
 pub use client::{AnyClient, make_client};
 pub use factory::{create_provider_with_config, get_factory};
 pub use provider::{LLMStream, LLMStreamEvent};
-pub use providers::{AnthropicProvider, GeminiProvider, OpenAIProvider};
+pub use providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, XAIProvider};
 pub use types::{BackendKind, LLMError, LLMResponse};

--- a/vtcode-core/src/llm/provider.rs
+++ b/vtcode-core/src/llm/provider.rs
@@ -478,7 +478,7 @@ impl MessageRole {
     ) -> Result<(), String> {
         match (self, provider) {
             (MessageRole::Tool, provider)
-                if matches!(provider, "openai" | "openrouter") && !has_tool_call_id =>
+                if matches!(provider, "openai" | "openrouter" | "xai") && !has_tool_call_id =>
             {
                 Err(format!("{} tool messages must have tool_call_id", provider))
             }

--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -2,6 +2,7 @@ pub mod anthropic;
 pub mod gemini;
 pub mod openai;
 pub mod openrouter;
+pub mod xai;
 
 mod reasoning;
 
@@ -11,3 +12,4 @@ pub use anthropic::AnthropicProvider;
 pub use gemini::GeminiProvider;
 pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
+pub use xai::XAIProvider;

--- a/vtcode-core/src/llm/providers/xai.rs
+++ b/vtcode-core/src/llm/providers/xai.rs
@@ -1,0 +1,115 @@
+use crate::config::constants::{models, urls};
+use crate::llm::client::LLMClient;
+use crate::llm::error_display;
+use crate::llm::provider::{LLMError, LLMProvider, LLMRequest, LLMResponse};
+use crate::llm::providers::openai::OpenAIProvider;
+use crate::llm::types as llm_types;
+use async_trait::async_trait;
+
+/// xAI provider that leverages the OpenAI-compatible Grok API surface
+pub struct XAIProvider {
+    inner: OpenAIProvider,
+    model: String,
+}
+
+impl XAIProvider {
+    pub fn new(api_key: String) -> Self {
+        Self::with_model(api_key, models::xai::DEFAULT_MODEL.to_string())
+    }
+
+    pub fn with_model(api_key: String, model: String) -> Self {
+        Self::from_config(Some(api_key), Some(model), None)
+    }
+
+    pub fn from_config(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+    ) -> Self {
+        let resolved_model = model.unwrap_or_else(|| models::xai::DEFAULT_MODEL.to_string());
+        let resolved_base_url = base_url.unwrap_or_else(|| urls::XAI_API_BASE.to_string());
+        let inner = OpenAIProvider::from_config(
+            api_key,
+            Some(resolved_model.clone()),
+            Some(resolved_base_url),
+        );
+
+        Self {
+            inner,
+            model: resolved_model,
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for XAIProvider {
+    fn name(&self) -> &str {
+        "xai"
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+        requested.contains("reasoning")
+    }
+
+    fn supports_reasoning_effort(&self, _model: &str) -> bool {
+        false
+    }
+
+    async fn generate(&self, mut request: LLMRequest) -> Result<LLMResponse, LLMError> {
+        if request.model.trim().is_empty() {
+            request.model = self.model.clone();
+        }
+        self.inner.generate(request).await
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        models::xai::SUPPORTED_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
+        if request.messages.is_empty() {
+            let formatted = error_display::format_llm_error("xAI", "Messages cannot be empty");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        if !request.model.trim().is_empty() && !self.supported_models().contains(&request.model) {
+            let formatted = error_display::format_llm_error(
+                "xAI",
+                &format!("Unsupported model: {}", request.model),
+            );
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider("openai") {
+                let formatted = error_display::format_llm_error("xAI", &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LLMClient for XAIProvider {
+    async fn generate(&mut self, prompt: &str) -> Result<llm_types::LLMResponse, LLMError> {
+        <OpenAIProvider as LLMClient>::generate(&mut self.inner, prompt).await
+    }
+
+    fn backend_kind(&self) -> llm_types::BackendKind {
+        llm_types::BackendKind::XAI
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}

--- a/vtcode-core/src/llm/types.rs
+++ b/vtcode-core/src/llm/types.rs
@@ -7,6 +7,7 @@ pub enum BackendKind {
     OpenAI,
     Anthropic,
     OpenRouter,
+    XAI,
 }
 
 /// Unified LLM response structure

--- a/vtcode-core/src/utils/dot_config.rs
+++ b/vtcode-core/src/utils/dot_config.rs
@@ -37,6 +37,7 @@ pub struct ProviderConfigs {
     pub anthropic: Option<ProviderConfig>,
     pub gemini: Option<ProviderConfig>,
     pub openrouter: Option<ProviderConfig>,
+    pub xai: Option<ProviderConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -123,6 +124,7 @@ impl Default for ProviderConfigs {
             anthropic: None,
             gemini: None,
             openrouter: None,
+            xai: None,
         }
     }
 }

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -8,7 +8,7 @@ max_conversation_turns = 1000
 max_session_duration_minutes = 60
 verbose_logging = false
 
-# AI Provider configuration (supports "gemini", "openai", "anthropic", "openrouter")
+# AI Provider configuration (supports "gemini", "openai", "anthropic", "openrouter", "xai")
 provider = "gemini"
 default_model = "gemini-2.5-flash"
 api_key_env = "GEMINI_API_KEY"


### PR DESCRIPTION
## Summary
- relocate the xAI model constants under the `models` namespace and expose reusable aliases
- ensure the xAI client delegates generation to the OpenAI-backed implementation
- update provider-focused tests to account for the new xAI backend

## Testing
- cargo fmt
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf89fd8010832383d751b19b90fea8