### PR TITLE
docs: refresh release status for v0.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 <h1>VT Code</h1>
 
+<p align="center">
+  <a href="https://crates.io/crates/vtcode">
+    <img alt="crates.io" src="https://img.shields.io/crates/v/vtcode.svg?style=for-the-badge&label=crates.io&logo=rust" />
+  </a>
+  <a href="https://docs.rs/vtcode">
+    <img alt="docs.rs" src="https://img.shields.io/docsrs/vtcode.svg?style=for-the-badge&label=docs.rs&logo=docsdotrs" />
+  </a>
+</p>
+
 <p align="center"><code>cargo install vtcode</code><br />or <code>brew install vinhnx/tap/vtcode</code></p>
 
 <p align="center"><strong>VT Code</strong> is a Rust-based terminal coding agent with modular architecture supporting multiple LLM providers.
@@ -84,6 +93,13 @@ OPENROUTER_API_KEY=your_openrouter_key_here
 -   `provider = "openrouter"` → `OPENROUTER_API_KEY`
 
 VT Code supports advanced configuration via `vtcode.toml`. See [Configuration](docs/project/) for details.
+
+### Release Status (v0.11.1)
+
+-   Published on [crates.io](https://crates.io/crates/vtcode) with the latest binaries and metadata.
+-   Documentation refreshed on [docs.rs for vtcode](https://docs.rs/vtcode/0.11.1) and [vtcode-core](https://docs.rs/vtcode-core/0.11.1).
+-   Tagged [GitHub release v0.11.1](https://github.com/vinhnx/vtcode/releases/tag/v0.11.1) with binaries for all platforms.
+-   Monitor [GitHub Actions](https://github.com/vinhnx/vtcode/actions) for CI verification (docs.rs updates may take 10-30 minutes).
 
 ### Using OpenRouter models
 

--- a/docs/project/DISTRIBUTION_SETUP.md
+++ b/docs/project/DISTRIBUTION_SETUP.md
@@ -4,6 +4,13 @@ This document outlines the complete distribution setup for VT Code across multip
 
 ## Distribution Channels
 
+### Current Release Status (v0.11.1)
+
+-   **Status: Complete** – Published crate: [vtcode on crates.io](https://crates.io/crates/vtcode)
+-   **Status: Complete** – Documentation refreshed: [docs.rs/vtcode 0.11.1](https://docs.rs/vtcode/0.11.1) and [docs.rs/vtcode-core 0.11.1](https://docs.rs/vtcode-core/0.11.1)
+-   **Status: Complete** – Release tag: [GitHub v0.11.1](https://github.com/vinhnx/vtcode/releases/tag/v0.11.1) with binaries for macOS, Linux, and Windows
+-   **Status: Monitoring** – CI tracking: [GitHub Actions dashboard](https://github.com/vinhnx/vtcode/actions) (docs.rs propagation typically needs 10-30 minutes)
+
 ### 1. Cargo (crates.io)
 
 -   **Primary Rust package repository**


### PR DESCRIPTION
## Summary
- add docs.rs and crates.io badges to the README hero section
- capture the v0.11.1 release status and distribution links in README and distribution setup docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfbaae6cd08323a8186c3dcdc57936