### PR TITLE
Fix HITL prompts in iocraft UI

### DIFF
--- a/vtcode-core/src/tool_policy.rs
+++ b/vtcode-core/src/tool_policy.rs
@@ -426,6 +426,10 @@ impl ToolPolicyManager {
         }
     }
 
+    pub fn is_auto_allow_tool(tool_name: &str) -> bool {
+        AUTO_ALLOW_TOOLS.contains(&tool_name)
+    }
+
     /// Prompt user for tool execution permission
     fn prompt_user_for_tool(&mut self, tool_name: &str) -> Result<bool> {
         let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();


### PR DESCRIPTION
## Summary
- add ToolPermissionDecision and helper methods to centralize per-tool policy evaluation and preapproval
- extend the unified runloop to prompt for tool approval inside the iocraft session, handling yes/no/exit flows and scroll events
- expose ToolPolicyManager::is_auto_allow_tool to reuse auto-allow logic when evaluating policies

## Testing
- cargo fmt
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cfbe2f37908323aa6a3f6f67306918