### PR TITLE
feat: overhaul ratatui interface and ansi rendering

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -205,7 +205,7 @@ recommended_actions = [
     "Request a workspace orientation or describe the task you want to tackle.",
     "Confirm priorities or blockers so I can suggest next steps.",
 ]
-chat_placeholder = "Describe your next coding goal (e.g., \"analyze router config\")"
+chat_placeholder = "Implement {feature}..."
 ```
 
 When enabled, VT Code prints the onboarding message before the first prompt, appends the same context block to the system prompt for the model, and shows the `chat_placeholder` hint above the initial `>` prompt so you always have a recommended next action ready.

--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -26,7 +26,6 @@ pub(crate) fn render_tool_output(
     if let Some(stdout) = val.get("stdout").and_then(|value| value.as_str())
         && !stdout.trim().is_empty()
     {
-        renderer.line(MessageStyle::Tool, "[stdout]")?;
         for line in stdout.lines() {
             let indented = format!("  {}", line);
             if let Some(style) = select_line_style(tool_name, line, &git_styles, &ls_styles) {

--- a/src/agent/runloop/unified/display.rs
+++ b/src/agent/runloop/unified/display.rs
@@ -1,4 +1,3 @@
-use anstyle;
 use anyhow::Result;
 
 use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
@@ -25,17 +24,9 @@ pub(crate) fn ensure_turn_bottom_gap(
     Ok(())
 }
 
-/// Display a user message with soft-gray ANSI styling
+/// Display a user message using the active user styling
 pub(crate) fn display_user_message(renderer: &mut AnsiRenderer, message: &str) -> Result<()> {
-    // Display the user message with soft-gray styling
-    for line in message.lines() {
-        renderer.line_with_style(
-            anstyle::Style::new()
-                .fg_color(Some(anstyle::Color::Rgb(anstyle::RgbColor(128, 128, 128)))),
-            line,
-        )?;
-    }
-    // Add a small gap after the user message
+    renderer.line(MessageStyle::User, message)?;
     renderer.line(MessageStyle::Output, "")?;
     Ok(())
 }

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -270,6 +270,7 @@ impl PlaceholderSpinner {
         let spinner_handle = handle.clone();
         let restore_on_stop = restore_hint.clone();
 
+        spinner_handle.set_cursor_visible(false);
         let task = task::spawn(async move {
             let mut index = 0usize;
             let frame_count = PLACEHOLDER_SPINNER_FRAMES.len().max(1);
@@ -279,6 +280,7 @@ impl PlaceholderSpinner {
                 index = (index + 1) % frame_count;
                 sleep(Duration::from_millis(120)).await;
             }
+            spinner_handle.set_cursor_visible(true);
             spinner_handle.set_placeholder(restore_on_stop);
         });
 
@@ -293,6 +295,7 @@ impl PlaceholderSpinner {
     fn finish(&self) {
         if self.active.swap(false, Ordering::SeqCst) {
             self.handle.set_placeholder(self.restore_hint.clone());
+            self.handle.set_cursor_visible(true);
         }
     }
 }

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -92,6 +92,7 @@ crossterm = { version = "0.27", features = ["event-stream"] }
 ignore = "0.4"
 nucleo-matcher = "0.3"
 ansi-to-tui = "7.0"
+color-to-tui = "0.3"
 pulldown-cmark = { version = "0.9", default-features = false, features = ["simd"] }
 
 [[example]]

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -87,7 +87,6 @@ quick_cache = "0.6"
 roff = "0.2"
 syntect = "5.2"
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
-tui-term = "0.2"
 unicode-width = "0.1"
 crossterm = { version = "0.27", features = ["event-stream"] }
 ignore = "0.4"

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -205,5 +205,5 @@ fn default_recommended_actions() -> Vec<String> {
 }
 
 fn default_chat_placeholder() -> String {
-    "Describe your next coding step (e.g., \"audit router config\")".to_string()
+    "Implement {feature}...".to_string()
 }

--- a/vtcode-core/src/ui/ratatui.rs
+++ b/vtcode-core/src/ui/ratatui.rs
@@ -361,7 +361,10 @@ async fn run_ratatui(
     Ok(())
 }
 
-struct TerminalGuard;
+struct TerminalGuard {
+    mouse_capture_enabled: bool,
+    cursor_hidden: bool,
+}
 
 impl TerminalGuard {
     fn new() -> Result<Self> {
@@ -373,7 +376,10 @@ impl TerminalGuard {
         stdout
             .execute(cursor::Hide)
             .context("failed to hide cursor")?;
-        Ok(Self)
+        Ok(Self {
+            mouse_capture_enabled: true,
+            cursor_hidden: true,
+        })
     }
 }
 
@@ -381,8 +387,12 @@ impl Drop for TerminalGuard {
     fn drop(&mut self) {
         let _ = disable_raw_mode();
         let mut stdout = io::stdout();
-        let _ = stdout.execute(DisableMouseCapture);
-        let _ = stdout.execute(cursor::Show);
+        if self.mouse_capture_enabled {
+            let _ = stdout.execute(DisableMouseCapture);
+        }
+        if self.cursor_hidden {
+            let _ = stdout.execute(cursor::Show);
+        }
         let _ = stdout.execute(Clear(ClearType::FromCursorDown));
     }
 }

--- a/vtcode-core/src/ui/styled.rs
+++ b/vtcode-core/src/ui/styled.rs
@@ -1,6 +1,6 @@
 use super::theme;
 use anstream::println as styled_println;
-use anstyle::{Effects, Reset, Style};
+use anstyle::{Color, Effects, Reset, Style};
 
 /// Style presets for consistent UI theming
 pub struct Styles;
@@ -53,7 +53,10 @@ impl Styles {
 
     /// Header style (bold blue)
     pub fn header() -> Style {
-        theme::active_styles().response
+        let accent = theme::banner_color();
+        Style::new()
+            .fg_color(Some(Color::Rgb(accent)))
+            .effects(Effects::BOLD)
     }
 
     /// Code style (magenta)

--- a/vtcode-core/src/ui/theme.rs
+++ b/vtcode-core/src/ui/theme.rs
@@ -141,7 +141,7 @@ static REGISTRY: Lazy<HashMap<&'static str, ThemeDefinition>> = Lazy::new(|| {
                 foreground: RgbColor(0xBF, 0xB3, 0x8F),
                 secondary_accent: RgbColor(0xD9, 0x9A, 0x4E),
                 alert: RgbColor(0xFF, 0x8A, 0x8A),
-                logo_accent: RgbColor(0xBF, 0x45, 0x45),
+                logo_accent: RgbColor(0xD9, 0x9A, 0x4E),
             },
         },
     );
@@ -156,7 +156,7 @@ static REGISTRY: Lazy<HashMap<&'static str, ThemeDefinition>> = Lazy::new(|| {
                 foreground: RgbColor(0xBF, 0xB3, 0x8F),
                 secondary_accent: RgbColor(0xBF, 0xB3, 0x8F),
                 alert: RgbColor(0xFF, 0x8A, 0x8A),
-                logo_accent: RgbColor(0xA6, 0x33, 0x33),
+                logo_accent: RgbColor(0xD9, 0x9A, 0x4E),
             },
         },
     );

--- a/vtcode-core/src/ui/theme.rs
+++ b/vtcode-core/src/ui/theme.rs
@@ -9,8 +9,6 @@ pub const DEFAULT_THEME_ID: &str = "ciapre-dark";
 
 const MIN_CONTRAST: f64 = 4.5;
 
-const WELCOME_TOOL_COLOR: RgbColor = RgbColor(0xBF, 0xB3, 0x8F);
-
 /// Palette describing UI colors for the terminal experience.
 #[derive(Clone, Debug)]
 pub struct ThemePalette {
@@ -54,7 +52,17 @@ impl ThemePalette {
             MIN_CONTRAST,
             &[lighten(secondary, 0.2), text_color, fallback_light],
         );
-        let tool_color = WELCOME_TOOL_COLOR;
+        let tool_candidate = lighten(secondary, 0.3);
+        let tool_color = ensure_contrast(
+            tool_candidate,
+            background,
+            MIN_CONTRAST,
+            &[
+                lighten(secondary, 0.45),
+                lighten(primary, 0.35),
+                fallback_light,
+            ],
+        );
         let response_color = ensure_contrast(
             text_color,
             background,
@@ -207,14 +215,26 @@ pub fn active_styles() -> ThemeStyles {
     ACTIVE.read().styles.clone()
 }
 
-/// Slightly darkened accent color for banner-like copy.
+/// Slightly adjusted accent color for banner-like copy.
 pub fn banner_color() -> RgbColor {
-    WELCOME_TOOL_COLOR
+    let guard = ACTIVE.read();
+    let accent = guard.palette.logo_accent;
+    let secondary = guard.palette.secondary_accent;
+    let background = guard.palette.background;
+    drop(guard);
+
+    let candidate = lighten(accent, 0.35);
+    ensure_contrast(
+        candidate,
+        background,
+        MIN_CONTRAST,
+        &[lighten(accent, 0.5), lighten(secondary, 0.25), accent],
+    )
 }
 
 /// Slightly darkened accent style for banner-like copy.
 pub fn banner_style() -> Style {
-    let accent = logo_accent_color();
+    let accent = banner_color();
     Style::new().fg_color(Some(Color::Rgb(accent))).bold()
 }
 

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -50,7 +50,7 @@ usage_tips = []
 # ]
 recommended_actions = []
 
-# suggestion: "Describe your next coding goal (e.g., \"analyze router config\")"
+# suggestion: "Implement {feature}..."
 chat_placeholder = ""
 
 [security]

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -38,7 +38,7 @@ recommended_actions = [
     "Request a quick workspace orientation.",
     "Describe the change you want to pursue next.",
 ]
-chat_placeholder = "Describe your next coding goal"
+chat_placeholder = "Implement {feature}..."
 
 [tools]
 # Default policy for tools: "allow", "prompt", or "deny"


### PR DESCRIPTION
## Summary
- overhaul the ratatui session layout to embed the chat input in the transcript, add cursor visibility control, and compact the status bar while supporting mouse scrolling
- replace the tui-term PTY panel with an ANSI-to-TUI powered renderer wrapped in a rounded block and integrate ANSI conversion for agent output
- update onboarding placeholder defaults and theme logo accent color to match the new UI polish

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d163409ba88323aa28bab73002c343