### PR TITLE
Refine inline ratatui behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ indicatif = "0.17"
 indexmap = { version = "2.2", features = ["serde"] }
 itertools = "0.13"
 termimad = "0.31"
+rpassword = "7.3"
 regex = "1.10"
 tree-sitter = "0.23"
 tree-sitter-rust = "0.23"

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -15,7 +15,7 @@ use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::core::decision_tracker::{Action as DTAction, DecisionOutcome};
 use vtcode_core::core::router::{Router, TaskClass};
 use vtcode_core::llm::error_display;
-use vtcode_core::llm::provider::{self as uni, LLMStreamEvent, MessageRole};
+use vtcode_core::llm::provider::{self as uni, LLMStreamEvent};
 use vtcode_core::tools::registry::{ToolErrorType, ToolExecutionError, ToolPermissionDecision};
 use vtcode_core::ui::ratatui::{
     RatatuiEvent, RatatuiHandle, RatatuiTextStyle, convert_style as convert_ratatui_style,
@@ -471,10 +471,7 @@ pub(crate) async fn run_single_agent_loop_unified(
     let reasoning_label = vt_cfg
         .map(|cfg| cfg.agent.reasoning_effort.as_str().to_string())
         .unwrap_or_else(|| config.reasoning_effort.as_str().to_string());
-    let center_status = format!(
-        "{} · {}",
-        config.model, reasoning_label
-    );
+    let center_status = format!("{} · {}", config.model, reasoning_label);
     handle.update_status_bar(None, Some(center_status), None);
 
     render_session_banner(&mut renderer, config, &session_bootstrap)?;


### PR DESCRIPTION
## Summary
- switch the ratatui terminal to an inline viewport with dynamic height
- stop re-enabling transcript autoscroll on input and resize events to keep manual scroll positions stable
- update selection highlighting to use the accent background with a dark text color and clean up an unused import

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d234c3e16883239496a6dbc68e6540