### PR TITLE
Refine ratatui layout and event handling

### DIFF
--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -15,7 +15,7 @@ use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::core::decision_tracker::{Action as DTAction, DecisionOutcome};
 use vtcode_core::core::router::{Router, TaskClass};
 use vtcode_core::llm::error_display;
-use vtcode_core::llm::provider::{self as uni, LLMStreamEvent, MessageRole};
+use vtcode_core::llm::provider::{self as uni, LLMStreamEvent};
 use vtcode_core::tools::registry::{ToolErrorType, ToolExecutionError, ToolPermissionDecision};
 use vtcode_core::ui::ratatui::{
     RatatuiEvent, RatatuiHandle, RatatuiTextStyle, convert_style as convert_ratatui_style,
@@ -471,10 +471,7 @@ pub(crate) async fn run_single_agent_loop_unified(
     let reasoning_label = vt_cfg
         .map(|cfg| cfg.agent.reasoning_effort.as_str().to_string())
         .unwrap_or_else(|| config.reasoning_effort.as_str().to_string());
-    let center_status = format!(
-        "{} · {}",
-        config.model, reasoning_label
-    );
+    let center_status = format!("{} · {}", config.model, reasoning_label);
     handle.update_status_bar(None, Some(center_status), None);
 
     render_session_banner(&mut renderer, config, &session_bootstrap)?;

--- a/vtcode-core/src/ui/markdown.rs
+++ b/vtcode-core/src/ui/markdown.rs
@@ -1,7 +1,7 @@
 //! Markdown rendering utilities for terminal output with syntax highlighting support.
 
 use crate::config::loader::SyntaxHighlightingConfig;
-use crate::ui::theme::ThemeStyles;
+use crate::ui::theme::{self, ThemeStyles};
 use anstyle::Style;
 use anstyle_syntect::to_anstyle;
 use once_cell::sync::Lazy;
@@ -326,6 +326,14 @@ pub fn render_markdown_to_lines(
 
     trim_trailing_blank_lines(&mut lines);
     lines
+}
+
+/// Convenience helper that renders markdown using the active theme without emitting output.
+///
+/// Returns the styled lines so callers can perform custom handling or assertions in tests.
+pub fn render_markdown(source: &str) -> Vec<MarkdownLine> {
+    let styles = theme::active_styles();
+    render_markdown_to_lines(source, Style::default(), &styles, None)
 }
 
 fn handle_start_tag(

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -7,14 +7,14 @@
 provider = "openrouter"
 # Default model for single-agent mode
 # Please also check router.models below if change default_model
-default_model = "deepseek/deepseek-chat-v3.1:free"
+default_model = "x-ai/grok-4-fast:free"
 
 [router.models]
-simple = "deepseek/deepseek-chat-v3.1:free"
-standard = "deepseek/deepseek-chat-v3.1:free"
-complex = "deepseek/deepseek-chat-v3.1:free"
-codegen_heavy = "deepseek/deepseek-chat-v3.1:free"
-retrieval_heavy = "deepseek/deepseek-chat-v3.1:free"
+simple = "x-ai/grok-4-fast:free"
+standard = "x-ai/grok-4-fast:free"
+complex = "x-ai/grok-4-fast:free"
+codegen_heavy = "x-ai/grok-4-fast:free"
+retrieval_heavy = "x-ai/grok-4-fast:free"
 
 
 # Max conversation turns per session (prevents infinite loops)


### PR DESCRIPTION
## Summary
- refactor the inline Ratatui loop to drain pending commands, prioritize user events, and centralize layout calculations via a reusable `AppLayout`
- add a theme-aware `render_markdown` helper so tests and callers can exercise markdown rendering without manual setup
- clean up an unused unified turn import left over from earlier changes

## Testing
- cargo fmt
- cargo check
- cargo test -p vtcode-core --lib *(fails: suite prompts for interactive tool permissions and aborts)*

------
https://chatgpt.com/codex/tasks/task_e_68d254de832883239bc596e4e88f4f6b