### PR TITLE
Add j/k chat history navigation bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ unwrap_used = "deny"
 vtcode-core = { path = "vtcode-core", version = "0.14.1" }
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+clap-markdown = "0.1.5"
 serde_json = "1.0"
 tokio = { version = "1.37", features = [
     "full",

--- a/README.md
+++ b/README.md
@@ -160,7 +160,11 @@ Model identifiers should always reference `vtcode-core/src/config/constants.rs` 
     ./run-debug.sh
     ```
 
-CLI options are discoverable via `vtcode --help` or `/help` inside the REPL. All defaults live in `vtcode.toml`, including provider fallbacks, tool allowlists, streaming options, and safety policies.
+CLI options are discoverable via `vtcode --help` or `/help` inside the REPL. All defaults live in
+`vtcode.toml`, including provider fallbacks, tool allowlists, streaming options, and safety
+policies. A Markdown snapshot of the full command tree lives in
+[`docs/CommandLineHelp.md`](docs/CommandLineHelp.md); regenerate it with
+`cargo run -- --markdown-help > docs/CommandLineHelp.md`.
 
 ---
 
@@ -255,6 +259,7 @@ Refer to the guides under `docs/project/` for deep dives on providers, tools, an
 - [**Configuration**](docs/project/) - Advanced configuration options
 - [**Architecture**](docs/ARCHITECTURE.md) - Technical architecture details
 - [**Advanced Features**](docs/ADVANCED_FEATURES_IMPLEMENTATION.md) - Safety controls and debug mode
+- [**CLI Reference**](docs/CommandLineHelp.md) - Generated help text for every command and option
 - [**API Reference**](https://docs.rs/vtcode) - Complete API documentation
 - [**Contributing**](CONTRIBUTING.md) - Development guidelines
 

--- a/docs/CommandLineHelp.md
+++ b/docs/CommandLineHelp.md
@@ -1,0 +1,617 @@
+# Command-Line Help for `vtcode`
+
+This document contains the help content for the `vtcode` command-line program.
+
+**Command Overview:**
+
+* [`vtcode`↴](#vtcode)
+* [`vtcode chat`↴](#vtcode-chat)
+* [`vtcode ask`↴](#vtcode-ask)
+* [`vtcode chat-verbose`↴](#vtcode-chat-verbose)
+* [`vtcode analyze`↴](#vtcode-analyze)
+* [`vtcode performance`↴](#vtcode-performance)
+* [`vtcode trajectory`↴](#vtcode-trajectory)
+* [`vtcode benchmark`↴](#vtcode-benchmark)
+* [`vtcode create-project`↴](#vtcode-create-project)
+* [`vtcode compress-context`↴](#vtcode-compress-context)
+* [`vtcode revert`↴](#vtcode-revert)
+* [`vtcode snapshots`↴](#vtcode-snapshots)
+* [`vtcode cleanup-snapshots`↴](#vtcode-cleanup-snapshots)
+* [`vtcode init`↴](#vtcode-init)
+* [`vtcode init-project`↴](#vtcode-init-project)
+* [`vtcode config`↴](#vtcode-config)
+* [`vtcode tool-policy`↴](#vtcode-tool-policy)
+* [`vtcode tool-policy status`↴](#vtcode-tool-policy-status)
+* [`vtcode tool-policy allow`↴](#vtcode-tool-policy-allow)
+* [`vtcode tool-policy deny`↴](#vtcode-tool-policy-deny)
+* [`vtcode tool-policy prompt`↴](#vtcode-tool-policy-prompt)
+* [`vtcode tool-policy allow-all`↴](#vtcode-tool-policy-allow-all)
+* [`vtcode tool-policy deny-all`↴](#vtcode-tool-policy-deny-all)
+* [`vtcode tool-policy reset-all`↴](#vtcode-tool-policy-reset-all)
+* [`vtcode models`↴](#vtcode-models)
+* [`vtcode models list`↴](#vtcode-models-list)
+* [`vtcode models set-provider`↴](#vtcode-models-set-provider)
+* [`vtcode models set-model`↴](#vtcode-models-set-model)
+* [`vtcode models config`↴](#vtcode-models-config)
+* [`vtcode models test`↴](#vtcode-models-test)
+* [`vtcode models compare`↴](#vtcode-models-compare)
+* [`vtcode models info`↴](#vtcode-models-info)
+* [`vtcode security`↴](#vtcode-security)
+* [`vtcode tree-sitter`↴](#vtcode-tree-sitter)
+* [`vtcode man`↴](#vtcode-man)
+
+## `vtcode`
+
+Advanced coding agent with Decision Ledger
+
+Features:
+• Single-agent architecture with Decision Ledger for reliable task execution
+• Tree-sitter powered code analysis (Rust, Python, JavaScript, TypeScript, Go, Java)
+• Multi-provider LLM support (Gemini, OpenAI, Anthropic, DeepSeek)
+• Real-time performance monitoring and benchmarking
+• Enhanced security with tool policies and sandboxing
+• Research-preview context management and conversation compression
+
+Quick Start:
+  export GEMINI_API_KEY="your_key"
+  vtcode chat
+
+**Usage:** `vtcode [OPTIONS] [WORKSPACE] [COMMAND]`
+
+###### **Subcommands:**
+
+* `chat` — **Interactive AI coding assistant** with advanced capabilities
+* `ask` — **Single prompt mode** - prints model reply without tools
+* `chat-verbose` — **Verbose interactive chat** with enhanced transparency
+* `analyze` — **Analyze workspace** with tree-sitter integration
+* `performance` — **Display performance metrics** and system status\n\n**Shows:**\n• Token usage and API costs\n• Response times and latency\n• Tool execution statistics\n• Memory usage patterns\n\n**Usage:** vtcode performance
+* `trajectory` — Pretty-print trajectory logs and show basic analytics
+* `benchmark` — **Benchmark against SWE-bench evaluation framework**
+* `create-project` — **Create complete Rust project with advanced features**
+* `compress-context` — **Compress conversation context** for long-running sessions
+* `revert` — **Revert agent to a previous snapshot
+* `snapshots` — **List all available snapshots**
+* `cleanup-snapshots` — **Clean up old snapshots**
+* `init` — **Initialize project** with enhanced dot-folder structure
+* `init-project` — **Initialize project with dot-folder structure** - sets up ~/.vtcode/projects/<project-name> structure
+* `config` — **Generate configuration file - creates a vtcode.toml configuration file
+* `tool-policy` — **Manage tool execution policies** - control which tools the agent can use
+* `models` — **Manage models and providers** - configure and switch between LLM providers\n\n**Features:**\n• Support for latest models (DeepSeek, etc.)\n• Provider configuration and testing\n• Model performance comparison\n• API key management\n\n**Examples:**\n  vtcode models list\n  vtcode models set-provider deepseek\n  vtcode models set-model deepseek-reasoner
+* `security` — **Security and safety management**\n\n**Features:**\n• Security scanning and vulnerability detection\n• Audit logging and monitoring\n• Access control management\n• Privacy protection settings\n\n**Usage:** vtcode security
+* `tree-sitter` — **Tree-sitter code analysis tools**\n\n**Features:**\n• AST-based code parsing\n• Symbol extraction and navigation\n• Code complexity analysis\n• Multi-language refactoring\n\n**Usage:** vtcode tree-sitter
+* `man` — **Generate or display man pages** for VTCode commands\n\n**Features:**\n• Generate Unix man pages for all commands\n• Display detailed command documentation\n• Save man pages to files\n• Comprehensive help for all VTCode features\n\n**Examples:**\n  vtcode man\n  vtcode man chat\n  vtcode man chat --output chat.1
+
+###### **Arguments:**
+
+* `<WORKSPACE>` — Optional positional path to run vtcode against a different workspace
+
+###### **Options:**
+
+* `--color <WHEN>` — Controls when to use color
+
+  Default value: `auto`
+
+  Possible values: `auto`, `always`, `never`
+
+* `--model <MODEL>` — LLM Model ID with latest model support
+
+   Available providers & models: • gemini-2.5-flash-preview-05-20 - Latest fast Gemini model (default) • gemini-2.5-flash - Fast, cost-effective • gemini-2.5-pro - Latest, most capable • gpt-5 - OpenAI's latest • claude-sonnet-4-20250514 - Anthropic's latest • qwen/qwen3-4b-2507 - Qwen3 local model • deepseek-reasoner - DeepSeek reasoning model • x-ai/grok-code-fast-1 - OpenRouter Grok fast coding model • qwen/qwen3-coder - OpenRouter Qwen3 Coder optimized for IDE usage • grok-2-latest - xAI Grok flagship model
+* `--provider <PROVIDER>` — **LLM Provider** with expanded support
+
+   Available providers: • gemini - Google Gemini (default) • openai - OpenAI GPT models • anthropic - Anthropic Claude models • deepseek - DeepSeek models • openrouter - OpenRouter marketplace models • xai - xAI Grok models
+
+   Example: --provider deepseek
+* `--api-key-env <API_KEY_ENV>` — **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
+
+  Default value: `GEMINI_API_KEY`
+* `--workspace <PATH>` — **Workspace root directory for file operations**
+
+   Security: All file operations restricted to this path Default: Current directory
+* `--enable-tree-sitter` — **Enable tree-sitter code analysis**
+
+   Features: • AST-based code parsing • Symbol extraction and navigation • Intelligent refactoring suggestions • Multi-language support (Rust, Python, JS, TS, Go, Java)
+* `--performance-monitoring` — **Enable performance monitoring**
+
+   Tracks: • Token usage and API costs • Response times and latency • Tool execution metrics • Memory usage patterns
+* `--research-preview` — **Enable research-preview features**
+
+   Includes: • Advanced context compression • Conversation summarization • Enhanced error recovery • Decision transparency tracking
+* `--security-level <SECURITY_LEVEL>` — **Security level** for tool execution
+
+   Options: • strict - Maximum security, prompt for all tools • moderate - Balance security and usability • permissive - Minimal restrictions (not recommended)
+
+  Default value: `moderate`
+* `--show-file-diffs` — **Show diffs for file changes in chat interface**
+
+   Features: • Real-time diff rendering • Syntax highlighting • Line-by-line changes • Before/after comparison
+* `--max-concurrent-ops <MAX_CONCURRENT_OPS>` — **Maximum concurrent async operations**
+
+   Default: 5 Higher values: Better performance but more resource usage
+
+  Default value: `5`
+* `--api-rate-limit <API_RATE_LIMIT>` — **Maximum API requests per minute**
+
+   Default: 30 Purpose: Prevents rate limiting
+
+  Default value: `30`
+* `--max-tool-calls <MAX_TOOL_CALLS>` — **Maximum tool calls per session**
+
+   Default: 10 Purpose: Prevents runaway execution
+
+  Default value: `10`
+* `--debug` — **Enable debug output for troubleshooting**
+
+   Shows: • Tool call details • API request/response • Internal agent state • Performance metrics
+* `--verbose` — **Enable verbose logging**
+
+   Includes: • Detailed operation logs • Context management info • Agent coordination details
+* `--config <CONFIG>` — **Configuration file path**
+
+   Supported formats: TOML Default locations: ./vtcode.toml, ~/.vtcode/vtcode.toml
+* `--log-level <LOG_LEVEL>` — Log level (error, warn, info, debug, trace)
+
+   Default: info
+
+  Default value: `info`
+* `--no-color` — Disable color output
+
+   Useful for: Log files, CI/CD pipelines
+* `--theme <THEME>` — Select UI theme for ANSI styling (e.g., ciapre-dark, ciapre-blue)
+* `--skip-confirmations` — **Skip safety confirmations**
+
+   Warning: Reduces security, use with caution
+* `--full-auto` — **Enable full-auto mode (no interaction)**
+
+   Runs the agent without pausing for approvals. Requires enabling in configuration.
+
+
+
+## `vtcode chat`
+
+**Interactive AI coding assistant** with advanced capabilities
+
+Features: • Real-time code generation and editing • Tree-sitter powered analysis • Research-preview context management
+
+Usage: vtcode chat
+
+**Usage:** `vtcode chat`
+
+
+
+## `vtcode ask`
+
+**Single prompt mode** - prints model reply without tools
+
+Perfect for: • Quick questions • Code explanations • Simple queries
+
+Example: vtcode ask "Explain Rust ownership"
+
+**Usage:** `vtcode ask <PROMPT>`
+
+###### **Arguments:**
+
+* `<PROMPT>`
+
+
+
+## `vtcode chat-verbose`
+
+**Verbose interactive chat** with enhanced transparency
+
+Shows: • Tool execution details • API request/response • Performance metrics
+
+Usage: vtcode chat-verbose
+
+**Usage:** `vtcode chat-verbose`
+
+
+
+## `vtcode analyze`
+
+**Analyze workspace** with tree-sitter integration
+
+Provides: • Project structure analysis • Language detection • Code complexity metrics • Dependency insights • Symbol extraction
+
+Usage: vtcode analyze
+
+**Usage:** `vtcode analyze`
+
+
+
+## `vtcode performance`
+
+**Display performance metrics** and system status\n\n**Shows:**\n• Token usage and API costs\n• Response times and latency\n• Tool execution statistics\n• Memory usage patterns\n\n**Usage:** vtcode performance
+
+**Usage:** `vtcode performance`
+
+
+
+## `vtcode trajectory`
+
+Pretty-print trajectory logs and show basic analytics
+
+Sources: • logs/trajectory.jsonl (default) Options: • --file to specify an alternate path • --top to limit report rows (default: 10)
+
+Shows: • Class distribution with percentages • Model usage statistics • Tool success rates with status indicators • Time range of logged activity
+
+**Usage:** `vtcode trajectory [OPTIONS]`
+
+###### **Options:**
+
+* `--file <FILE>` — Optional path to trajectory JSONL file
+* `--top <TOP>` — Number of top entries to show for each section
+
+  Default value: `10`
+
+
+
+## `vtcode benchmark`
+
+**Benchmark against SWE-bench evaluation framework**
+
+Features: • Automated performance testing • Comparative analysis across models • Benchmark scoring and metrics • Optimization insights
+
+Usage: vtcode benchmark
+
+**Usage:** `vtcode benchmark`
+
+
+
+## `vtcode create-project`
+
+**Create complete Rust project with advanced features**
+
+Features: • Web frameworks (Axum, Rocket, Warp) • Database integration • Authentication systems • Testing setup • Tree-sitter integration
+
+Example: vtcode create-project myapp web,auth,db
+
+**Usage:** `vtcode create-project <NAME> [FEATURES]...`
+
+###### **Arguments:**
+
+* `<NAME>`
+* `<FEATURES>`
+
+
+
+## `vtcode compress-context`
+
+**Compress conversation context** for long-running sessions
+
+Benefits: • Reduced token usage • Faster responses • Memory optimization • Context preservation
+
+Usage: vtcode compress-context
+
+**Usage:** `vtcode compress-context`
+
+
+
+## `vtcode revert`
+
+**Revert agent to a previous snapshot
+
+Features: • Revert to any previous turn • Partial reverts (memory, context, full) • Safe rollback with validation
+
+Examples: vtcode revert --turn 5 vtcode revert --turn 3 --partial memory
+
+**Usage:** `vtcode revert [OPTIONS] --turn <TURN>`
+
+###### **Options:**
+
+* `-t`, `--turn <TURN>` — Turn number to revert to
+
+   Required: Yes Example: 5
+* `-p`, `--partial <PARTIAL>` — Scope of revert operation
+
+   Options: memory, context, full Default: full Examples: --partial memory (revert conversation only) --partial context (revert decisions/errors only)
+
+
+
+## `vtcode snapshots`
+
+**List all available snapshots**
+
+Shows: • Snapshot ID and turn number • Creation timestamp • Description • File size and compression status
+
+Usage: vtcode snapshots
+
+**Usage:** `vtcode snapshots`
+
+
+
+## `vtcode cleanup-snapshots`
+
+**Clean up old snapshots**
+
+Features: • Remove snapshots beyond limit • Configurable retention policy • Safe deletion with confirmation
+
+Examples: vtcode cleanup-snapshots vtcode cleanup-snapshots --max 20
+
+**Usage:** `vtcode cleanup-snapshots [OPTIONS]`
+
+###### **Options:**
+
+* `-m`, `--max <MAX>` — Maximum number of snapshots to keep
+
+   Default: 50 Example: --max 20
+
+  Default value: `50`
+
+
+
+## `vtcode init`
+
+**Initialize project** with enhanced dot-folder structure
+
+Features: • Creates project directory structure • Sets up config, cache, embeddings directories • Creates .project metadata file • Tree-sitter parser setup
+
+Usage: vtcode init
+
+**Usage:** `vtcode init`
+
+
+
+## `vtcode init-project`
+
+**Initialize project with dot-folder structure** - sets up ~/.vtcode/projects/<project-name> structure
+
+Features: • Creates project directory structure in ~/.vtcode/projects/ • Sets up config, cache, embeddings, and retrieval directories • Creates .project metadata file • Migrates existing config/cache files with user confirmation
+
+Examples: vtcode init-project vtcode init-project --name my-project vtcode init-project --force
+
+**Usage:** `vtcode init-project [OPTIONS]`
+
+###### **Options:**
+
+* `--name <NAME>` — Project name - defaults to current directory name
+* `--force` — Force initialization - overwrite existing project structure
+* `--migrate` — Migrate existing files - move existing config/cache files to new structure
+
+
+
+## `vtcode config`
+
+**Generate configuration file - creates a vtcode.toml configuration file
+
+Features: • Generate default configuration • Support for global (home directory) and local configuration • TOML format with comprehensive settings • Tree-sitter and performance monitoring settings
+
+Examples: vtcode config vtcode config --output ./custom-config.toml vtcode config --global
+
+**Usage:** `vtcode config [OPTIONS]`
+
+###### **Options:**
+
+* `--output <OUTPUT>` — Output file path - where to save the configuration file
+* `--global` — Create in user home directory - creates ~/.vtcode/vtcode.toml
+
+
+
+## `vtcode tool-policy`
+
+**Manage tool execution policies** - control which tools the agent can use
+
+Features: • Granular tool permissions • Security level presets • Audit logging • Safe tool execution
+
+Examples: vtcode tool-policy status vtcode tool-policy allow file-write vtcode tool-policy deny shell-exec
+
+**Usage:** `vtcode tool-policy <COMMAND>`
+
+###### **Subcommands:**
+
+* `status` — Show current tool policy status
+* `allow` — Allow a specific tool
+* `deny` — Deny a specific tool
+* `prompt` — Set a tool to prompt for confirmation
+* `allow-all` — Allow all tools
+* `deny-all` — Deny all tools
+* `reset-all` — Reset all tools to prompt
+
+
+
+## `vtcode tool-policy status`
+
+Show current tool policy status
+
+**Usage:** `vtcode tool-policy status`
+
+
+
+## `vtcode tool-policy allow`
+
+Allow a specific tool
+
+**Usage:** `vtcode tool-policy allow <TOOL>`
+
+###### **Arguments:**
+
+* `<TOOL>` — Tool name to allow
+
+
+
+## `vtcode tool-policy deny`
+
+Deny a specific tool
+
+**Usage:** `vtcode tool-policy deny <TOOL>`
+
+###### **Arguments:**
+
+* `<TOOL>` — Tool name to deny
+
+
+
+## `vtcode tool-policy prompt`
+
+Set a tool to prompt for confirmation
+
+**Usage:** `vtcode tool-policy prompt <TOOL>`
+
+###### **Arguments:**
+
+* `<TOOL>` — Tool name to set to prompt
+
+
+
+## `vtcode tool-policy allow-all`
+
+Allow all tools
+
+**Usage:** `vtcode tool-policy allow-all`
+
+
+
+## `vtcode tool-policy deny-all`
+
+Deny all tools
+
+**Usage:** `vtcode tool-policy deny-all`
+
+
+
+## `vtcode tool-policy reset-all`
+
+Reset all tools to prompt
+
+**Usage:** `vtcode tool-policy reset-all`
+
+
+
+## `vtcode models`
+
+**Manage models and providers** - configure and switch between LLM providers\n\n**Features:**\n• Support for latest models (DeepSeek, etc.)\n• Provider configuration and testing\n• Model performance comparison\n• API key management\n\n**Examples:**\n  vtcode models list\n  vtcode models set-provider deepseek\n  vtcode models set-model deepseek-reasoner
+
+**Usage:** `vtcode models <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List all providers and models with status indicators
+* `set-provider` — Set default provider (gemini, openai, anthropic, deepseek)
+* `set-model` — Set default model (e.g., deepseek-reasoner, gpt-5, claude-sonnet-4-20250514)
+* `config` — Configure provider settings (API keys, base URLs, models)
+* `test` — Test provider connectivity and validate configuration
+* `compare` — Compare model performance across providers (coming soon)
+* `info` — Show detailed model information and specifications
+
+
+
+## `vtcode models list`
+
+List all providers and models with status indicators
+
+**Usage:** `vtcode models list`
+
+
+
+## `vtcode models set-provider`
+
+Set default provider (gemini, openai, anthropic, deepseek)
+
+**Usage:** `vtcode models set-provider <PROVIDER>`
+
+###### **Arguments:**
+
+* `<PROVIDER>` — Provider name to set as default
+
+
+
+## `vtcode models set-model`
+
+Set default model (e.g., deepseek-reasoner, gpt-5, claude-sonnet-4-20250514)
+
+**Usage:** `vtcode models set-model <MODEL>`
+
+###### **Arguments:**
+
+* `<MODEL>` — Model name to set as default
+
+
+
+## `vtcode models config`
+
+Configure provider settings (API keys, base URLs, models)
+
+**Usage:** `vtcode models config [OPTIONS] <PROVIDER>`
+
+###### **Arguments:**
+
+* `<PROVIDER>` — Provider name to configure
+
+###### **Options:**
+
+* `--api-key <API_KEY>` — API key for the provider
+* `--base-url <BASE_URL>` — Base URL for local providers
+* `--model <MODEL>` — Default model for this provider
+
+
+
+## `vtcode models test`
+
+Test provider connectivity and validate configuration
+
+**Usage:** `vtcode models test <PROVIDER>`
+
+###### **Arguments:**
+
+* `<PROVIDER>` — Provider name to test
+
+
+
+## `vtcode models compare`
+
+Compare model performance across providers (coming soon)
+
+**Usage:** `vtcode models compare`
+
+
+
+## `vtcode models info`
+
+Show detailed model information and specifications
+
+**Usage:** `vtcode models info <MODEL>`
+
+###### **Arguments:**
+
+* `<MODEL>` — Model name to get information about
+
+
+
+## `vtcode security`
+
+**Security and safety management**\n\n**Features:**\n• Security scanning and vulnerability detection\n• Audit logging and monitoring\n• Access control management\n• Privacy protection settings\n\n**Usage:** vtcode security
+
+**Usage:** `vtcode security`
+
+
+
+## `vtcode tree-sitter`
+
+**Tree-sitter code analysis tools**\n\n**Features:**\n• AST-based code parsing\n• Symbol extraction and navigation\n• Code complexity analysis\n• Multi-language refactoring\n\n**Usage:** vtcode tree-sitter
+
+**Usage:** `vtcode tree-sitter`
+
+
+
+## `vtcode man`
+
+**Generate or display man pages** for VTCode commands\n\n**Features:**\n• Generate Unix man pages for all commands\n• Display detailed command documentation\n• Save man pages to files\n• Comprehensive help for all VTCode features\n\n**Examples:**\n  vtcode man\n  vtcode man chat\n  vtcode man chat --output chat.1
+
+**Usage:** `vtcode man [OPTIONS] [COMMAND]`
+
+###### **Arguments:**
+
+* `<COMMAND>` — **Command name** to generate man page for (optional)\n\n**Available commands:**\n• chat, ask, analyze, performance, benchmark\n• create-project, init, man\n\n**If not specified, shows main VTCode man page**
+
+###### **Options:**
+
+* `-o`, `--output <OUTPUT>` — **Output file path** to save man page\n\n**Format:** Standard Unix man page format (.1, .8, etc.)\n**Default:** Display to stdout
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ New to VT Code? Start with installation and basic usage:
 -   **[Getting Started](./user-guide/getting-started.md)** - Installation, configuration, and first steps
 -   [Decision Ledger](./context/DECISION_LEDGER.md) - How decisions are tracked and injected
 -   **[Configuration Guide](./CONFIGURATION.md)** - Comprehensive configuration options
+-   **[CLI Reference](./CommandLineHelp.md)** - Generated Markdown help for every command
 
 ### For Developers
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
+use clap_markdown::print_help_markdown;
 use colorchoice::ColorChoice as GlobalColorChoice;
 use std::path::PathBuf;
 use vtcode_core::cli::args::{Cli, Commands};
@@ -23,6 +24,10 @@ async fn main() -> Result<()> {
     load_dotenv().ok();
 
     let args = Cli::parse();
+    if args.markdown_help {
+        print_help_markdown::<Cli>();
+        return Ok(());
+    }
     args.color.write_global();
     if args.no_color {
         GlobalColorChoice::Never.write_global();

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -99,6 +99,7 @@ pulldown-cmark = { version = "0.9", default-features = false, features = [
     "simd",
 ] }
 catppuccin = { version = "2.5", default-features = false }
+tui-widget-list = { version = "0.13.2" }
 
 [[example]]
 name = "anstyle_test"

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -18,6 +18,10 @@ pub struct Cli {
     #[command(flatten)]
     pub color: ColorSelection,
 
+    /// Emit Markdown documentation for the CLI (hidden helper)
+    #[arg(long, hide = true)]
+    pub markdown_help: bool,
+
     /// Optional positional path to run vtcode against a different workspace
     #[arg(
         value_name = "WORKSPACE",
@@ -602,6 +606,7 @@ impl Default for Cli {
             color: ColorSelection {
                 color: ColorChoice::Auto,
             },
+            markdown_help: false,
             workspace_path: None,
             model: Some(ModelId::default().as_str().to_string()),
             provider: Some("gemini".to_string()),

--- a/vtcode-core/src/ui/tui/events/mod.rs
+++ b/vtcode-core/src/ui/tui/events/mod.rs
@@ -248,6 +248,14 @@ impl RatatuiLoop {
                 {
                     return Ok(false);
                 }
+                if key.modifiers.is_empty() {
+                    if matches!(ch, 'k') && self.view_previous_conversation() {
+                        return Ok(true);
+                    }
+                    if matches!(ch, 'j') && self.view_next_conversation() {
+                        return Ok(true);
+                    }
+                }
                 if !self.input_enabled {
                     return Ok(true);
                 }

--- a/vtcode-core/src/ui/tui/events/mod.rs
+++ b/vtcode-core/src/ui/tui/events/mod.rs
@@ -342,17 +342,13 @@ impl RatatuiLoop {
                 }
                 if key.modifiers.is_empty() {
                     let history_focus_active = self.transcript_focused || !self.input_enabled;
-                    let allow_from_input = self.input.value().is_empty();
                     if matches!(ch, 'k')
-                        && (history_focus_active || allow_from_input)
+                        && history_focus_active
                         && self.view_previous_conversation()
                     {
                         return Ok(true);
                     }
-                    if matches!(ch, 'j')
-                        && (history_focus_active || allow_from_input)
-                        && self.view_next_conversation()
-                    {
+                    if matches!(ch, 'j') && history_focus_active && self.view_next_conversation() {
                         return Ok(true);
                     }
                     if self.transcript_focused {

--- a/vtcode-core/src/ui/tui/render/mod.rs
+++ b/vtcode-core/src/ui/tui/render/mod.rs
@@ -624,11 +624,35 @@ impl RatatuiLoop {
         }
     }
 
+    fn stylize_user_block(&self, block: &MessageBlock, accent: Color) -> MessageBlock {
+        let mut lines = Vec::with_capacity(block.lines.len());
+        for line in &block.lines {
+            let mut segments = Vec::with_capacity(line.segments.len());
+            for segment in &line.segments {
+                let mut styled_segment = segment.clone();
+                let mut style = styled_segment.style.clone();
+                if style.color.is_none() {
+                    style.color = Some(accent);
+                }
+                style.bold = true;
+                styled_segment.style = style;
+                segments.push(styled_segment);
+            }
+            lines.push(StyledLine { segments });
+        }
+        MessageBlock {
+            kind: block.kind,
+            lines,
+        }
+    }
+
     fn build_user_block(&self, block: &MessageBlock, width: usize) -> Vec<Line<'static>> {
+        let accent = self.kind_color(RatatuiMessageKind::User);
         let mut prefix_style = RatatuiTextStyle::default();
-        prefix_style.color = Some(self.kind_color(RatatuiMessageKind::User));
+        prefix_style.color = Some(accent);
         prefix_style.bold = true;
-        self.build_prefixed_block(block, width, "❯ ", prefix_style, self.theme.foreground)
+        let decorated = self.stylize_user_block(block, accent);
+        self.build_prefixed_block(&decorated, width, "❯ ", prefix_style, Some(accent))
     }
 
     fn build_response_block(

--- a/vtcode-core/src/ui/tui/state/mod.rs
+++ b/vtcode-core/src/ui/tui/state/mod.rs
@@ -14,7 +14,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::ListState,
+    widgets::ListState as RatatuiListState,
 };
 use serde_json::Value;
 use std::collections::{HashSet, VecDeque};
@@ -24,6 +24,7 @@ use std::mem;
 use std::time::Instant;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tui_widget_list::ListState as WidgetListState;
 use unicode_width::UnicodeWidthStr;
 
 pub(crate) const ESCAPE_DOUBLE_MS: u64 = 750;
@@ -639,6 +640,11 @@ impl TranscriptScrollState {
         self.offset = self.max_offset();
     }
 
+    pub(crate) fn set_offset(&mut self, offset: usize) {
+        let max_offset = self.max_offset();
+        self.offset = offset.min(max_offset);
+    }
+
     pub(crate) fn scroll_to_top(&mut self) {
         self.offset = 0;
     }
@@ -807,7 +813,7 @@ impl SelectionState {
 #[derive(Default)]
 pub(crate) struct SlashSuggestionState {
     pub(crate) items: Vec<&'static SlashCommandInfo>,
-    pub(crate) list_state: ListState,
+    pub(crate) list_state: RatatuiListState,
 }
 
 impl SlashSuggestionState {
@@ -851,7 +857,7 @@ impl SlashSuggestionState {
         &self.items
     }
 
-    pub(crate) fn list_state(&mut self) -> &mut ListState {
+    pub(crate) fn list_state(&mut self) -> &mut RatatuiListState {
         &mut self.list_state
     }
 
@@ -1128,6 +1134,7 @@ pub(crate) struct RatatuiLoop {
     pub(crate) theme: RatatuiTheme,
     pub(crate) last_escape: Option<Instant>,
     pub(crate) transcript_scroll: TranscriptScrollState,
+    pub(crate) transcript_list_state: WidgetListState,
     pub(crate) transcript_autoscroll: bool,
     pub(crate) pty_scroll: TranscriptScrollState,
     pub(crate) pty_autoscroll: bool,
@@ -1182,6 +1189,7 @@ impl RatatuiLoop {
             theme,
             last_escape: None,
             transcript_scroll: TranscriptScrollState::default(),
+            transcript_list_state: WidgetListState::default(),
             transcript_autoscroll: true,
             pty_scroll: TranscriptScrollState::default(),
             pty_autoscroll: true,

--- a/vtcode-core/src/ui/tui/state/mod.rs
+++ b/vtcode-core/src/ui/tui/state/mod.rs
@@ -3,7 +3,7 @@ use ansi_to_tui::IntoText;
 use anyhow::{Context, Result};
 use crossterm::{
     ExecutableCommand, cursor,
-    event::{EnableMouseCapture, DisableMouseCapture},
+    event::{DisableMouseCapture, EnableMouseCapture},
     terminal::{
         Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
         enable_raw_mode,
@@ -1019,6 +1019,7 @@ pub(crate) struct RatatuiLoop {
     pub(crate) pty_scroll: TranscriptScrollState,
     pub(crate) pty_autoscroll: bool,
     pub(crate) scroll_focus: ScrollFocus,
+    pub(crate) transcript_focused: bool,
     pub(crate) transcript_area: Option<Rect>,
     pub(crate) pty_area: Option<Rect>,
     pub(crate) pty_block: Option<PtyPlacement>,
@@ -1072,6 +1073,7 @@ impl RatatuiLoop {
             pty_scroll: TranscriptScrollState::default(),
             pty_autoscroll: true,
             scroll_focus: ScrollFocus::Transcript,
+            transcript_focused: false,
             transcript_area: None,
             pty_area: None,
             pty_block: None,
@@ -1489,6 +1491,7 @@ impl RatatuiLoop {
         }
         self.active_conversation -= 1;
         self.transcript_autoscroll = false;
+        self.transcript_focused = true;
         if let Some(&offset) = self.conversation_line_offsets.get(self.active_conversation) {
             self.transcript_scroll.jump_to(offset);
         } else {
@@ -1514,6 +1517,7 @@ impl RatatuiLoop {
                 self.transcript_scroll.scroll_to_top();
             }
         }
+        self.transcript_focused = true;
         self.scroll_focus = ScrollFocus::Transcript;
         true
     }

--- a/vtcode-core/src/ui/tui/state/mod.rs
+++ b/vtcode-core/src/ui/tui/state/mod.rs
@@ -28,7 +28,7 @@ use unicode_width::UnicodeWidthStr;
 pub(crate) const ESCAPE_DOUBLE_MS: u64 = 750;
 pub(crate) const REDRAW_INTERVAL_MS: u64 = 33;
 pub(crate) const MESSAGE_INDENT: usize = 2;
-pub(crate) const NAVIGATION_HINT_TEXT: &str = "↵ send · esc exit · alt+Pg↑/Pg↓ history";
+pub(crate) const NAVIGATION_HINT_TEXT: &str = "↵ send · esc exit · alt+Pg↑/Pg↓ · j/k history";
 pub(crate) const MAX_SLASH_SUGGESTIONS: usize = 6;
 const SURFACE_ENV_KEY: &str = "VT_RATATUI_SURFACE";
 const INLINE_FALLBACK_ROWS: u16 = 24;


### PR DESCRIPTION
## Summary
- route plain j/k keypresses to switch between older and newer conversations in the ratatui chat view
- update the status bar hint to advertise the new j/k chat history shortcut

## Testing
- cargo test *(fails: missing `human_in_the_loop` field in `SessionBootstrap`)*
- cargo test -p vtcode-core *(fails: multiple pre-existing assertion failures and tool permission prompts)*

------
https://chatgpt.com/codex/tasks/task_e_68d4017675f483239ec2b61f0d06be4e