### PR TITLE
Fix MCP allowlist overrides and document integration

### DIFF
--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -78,17 +78,24 @@ cargo test -p vtcode-core mcp -- --nocapture
 ```
 
 The suite includes mocked clients and parsing tests so it does not require live MCP servers. For
-end-to-end checks against real servers, temporarily enable the ignored `test_time_mcp_server_integration`
-case after installing the required provider binary.
+an end-to-end check against the Context7 MCP server, invoke the ignored smoke test which spawns the
+official `@upstash/context7-mcp` package on demand:
+
+```bash
+cargo test -p vtcode-core --test mcp_context7_manual context7_list_tools_smoke -- --ignored --nocapture
+```
+
+Expect the test to take a little longer on the first run while `npx` downloads the server bundle.
 
 ## Troubleshooting
 
 - **Unexpected tool execution permissions** – confirm whether the provider defines its own
   allowlist. Provider rules now override defaults, so missing patterns may block tools that defaults
   would otherwise allow.
-- **Provider handshake visibility** – VT Code now sends explicit MCP client metadata and records
-  provider log notifications. Look for `MCP provider log` entries in the terminal when debugging
-  initialization failures.
+- **Provider handshake visibility** – VT Code now sends explicit MCP client metadata and
+  normalizes structured tool responses. Context7 results surface as plain JSON objects in the
+  tool panel so downstream renderers can display status, metadata, and message lists without
+  additional post-processing.
 - **Stale configuration values** – ensure `max_concurrent_connections`, `request_timeout_seconds`,
   and `retry_attempts` appear under the `[mcp]` table *after* any nested `[mcp.ui]` section. TOML
   resets the table context when a new header appears.

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -86,6 +86,9 @@ case after installing the required provider binary.
 - **Unexpected tool execution permissions** – confirm whether the provider defines its own
   allowlist. Provider rules now override defaults, so missing patterns may block tools that defaults
   would otherwise allow.
+- **Provider handshake visibility** – VT Code now sends explicit MCP client metadata and records
+  provider log notifications. Look for `MCP provider log` entries in the terminal when debugging
+  initialization failures.
 - **Stale configuration values** – ensure `max_concurrent_connections`, `request_timeout_seconds`,
   and `retry_attempts` appear under the `[mcp]` table *after* any nested `[mcp.ui]` section. TOML
   resets the table context when a new header appears.

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -1,0 +1,96 @@
+# MCP Integration Guide
+
+This guide outlines how VT Code connects to external MCP (Model Context Protocol) servers, how
+allowlists control tool access, and how to troubleshoot common configuration issues.
+
+## Configuring MCP Providers
+
+1. Open `vtcode.toml` and ensure the global MCP section is enabled:
+
+   ```toml
+   [mcp]
+   enabled = true
+   max_concurrent_connections = 3
+   request_timeout_seconds = 45
+   retry_attempts = 2
+   ```
+
+2. Configure the MCP UI panel if desired:
+
+   ```toml
+   [mcp.ui]
+   mode = "compact"
+   max_events = 25
+   show_provider_names = false
+   ```
+
+3. Define one or more providers. Stdio transports embed the command, arguments, and optional
+   working directory directly in the provider table:
+
+   ```toml
+   [[mcp.providers]]
+   name = "time"
+   enabled = true
+   command = "uvx"
+   args = ["mcp-server-time"]
+   max_concurrent_requests = 2
+   ```
+
+   For HTTP transports, specify the endpoint and headers in place of the stdio fields. The
+   configuration loader automatically deserializes either transport variant.
+
+## Allowlist Behaviour
+
+MCP access is gated by pattern-based allowlists. The defaults apply to every provider unless the
+provider supplies its own patterns. Provider-specific rules now fully override the defaults:
+
+- When a provider defines `tools`, `resources`, `prompts`, or `logging` patterns, only matches in
+  that provider block are accepted. Default rules are ignored for that provider.
+- If a provider omits a rule set, VT Code falls back to the default patterns.
+- Configuration permissions (`configuration` maps) continue to support provider overrides via an
+  explicit match or by delegating to the default rules.
+
+This behaviour avoids situations where a restrictive provider configuration is silently bypassed by
+broader default patterns.
+
+### Example
+
+```toml
+[mcp.allowlist.default]
+resources = ["docs/*"]
+
+[mcp.allowlist.providers.context7]
+resources = ["journals/*"]
+```
+
+In this configuration:
+
+- `context7` can access only `journals/*` resources.
+- Other providers continue to match `docs/*` through the default rule.
+
+## Testing the Integration
+
+Run the MCP-focused test suite to verify configuration parsing, allowlist enforcement, and registry
+wiring:
+
+```bash
+cargo test -p vtcode-core mcp -- --nocapture
+```
+
+The suite includes mocked clients and parsing tests so it does not require live MCP servers. For
+end-to-end checks against real servers, temporarily enable the ignored `test_time_mcp_server_integration`
+case after installing the required provider binary.
+
+## Troubleshooting
+
+- **Unexpected tool execution permissions** – confirm whether the provider defines its own
+  allowlist. Provider rules now override defaults, so missing patterns may block tools that defaults
+  would otherwise allow.
+- **Stale configuration values** – ensure `max_concurrent_connections`, `request_timeout_seconds`,
+  and `retry_attempts` appear under the `[mcp]` table *after* any nested `[mcp.ui]` section. TOML
+  resets the table context when a new header appears.
+- **HTTP transport issues** – VT Code currently performs capability probing for HTTP MCP servers but
+  requires a streaming implementation to be fully functional. Use stdio transports when possible.
+
+With these settings and checks in place, MCP providers and allowlists should behave predictably,
+unlocking additional context-aware tooling in VT Code.

--- a/src/agent/runloop/mcp_events.rs
+++ b/src/agent/runloop/mcp_events.rs
@@ -195,14 +195,21 @@ impl McpPanelState {
             return None;
         }
 
-        let pending_count = self.events.iter()
+        let pending_count = self
+            .events
+            .iter()
             .filter(|e| e.status == McpEventStatus::Pending)
             .count();
 
         if pending_count > 0 {
-            let latest_pending = self.events.iter()
+            let latest_pending = self
+                .events
+                .iter()
                 .find(|e| e.status == McpEventStatus::Pending)?;
-            Some(format!("[~] MCP {} `{}`", latest_pending.provider, latest_pending.method))
+            Some(format!(
+                "[~] MCP {} `{}`",
+                latest_pending.provider, latest_pending.method
+            ))
         } else {
             None
         }

--- a/vtcode-core/src/mcp_client.rs
+++ b/vtcode-core/src/mcp_client.rs
@@ -1696,6 +1696,13 @@ impl McpToolExecutor for McpClient {
                 provider_errors.len(),
                 provider_errors
             );
+
+            let summary = provider_errors.join("; ");
+            return Err(anyhow::anyhow!(
+                "Failed to confirm MCP tool '{}' availability. {}",
+                tool_name,
+                summary
+            ));
         }
 
         Ok(false)

--- a/vtcode-core/src/tools/registry/mod.rs
+++ b/vtcode-core/src/tools/registry/mod.rs
@@ -317,10 +317,14 @@ impl ToolRegistry {
                                     "Error checking MCP tool availability for '{}': {}",
                                     actual_tool_name, e
                                 );
-                                let error = ToolExecutionError::new(
+                                let error = ToolExecutionError::with_original_error(
                                     name.to_string(),
-                                    ToolErrorType::ToolNotFound,
-                                    format!("Unknown MCP tool: {}", actual_tool_name),
+                                    ToolErrorType::ExecutionError,
+                                    format!(
+                                        "Failed to verify MCP tool '{}' due to provider errors",
+                                        actual_tool_name
+                                    ),
+                                    e.to_string(),
                                 );
                                 return Ok(error.to_json_value());
                             }
@@ -346,10 +350,14 @@ impl ToolRegistry {
                             }
                             Err(e) => {
                                 warn!("Error checking MCP tool availability for '{}': {}", name, e);
-                                let error = ToolExecutionError::new(
+                                let error = ToolExecutionError::with_original_error(
                                     name.to_string(),
-                                    ToolErrorType::ToolNotFound,
-                                    format!("Unknown tool: {}", name),
+                                    ToolErrorType::ExecutionError,
+                                    format!(
+                                        "Failed to verify MCP tool '{}' due to provider errors",
+                                        name
+                                    ),
+                                    e.to_string(),
                                 );
                                 return Ok(error.to_json_value());
                             }

--- a/vtcode-core/src/utils/ansi.rs
+++ b/vtcode-core/src/utils/ansi.rs
@@ -122,6 +122,14 @@ impl AnsiRenderer {
         self.sink.is_some()
     }
 
+    /// Determine whether the renderer is connected to the inline UI.
+    ///
+    /// Inline rendering uses the terminal session scrollback, so tool output should
+    /// avoid truncation that would otherwise be applied in compact CLI mode.
+    pub fn prefers_untruncated_output(&self) -> bool {
+        self.sink.is_some()
+    }
+
     /// Push text into the buffer
     pub fn push(&mut self, text: &str) {
         self.buffer.push_str(text);

--- a/vtcode-core/tests/mcp_context7_manual.rs
+++ b/vtcode-core/tests/mcp_context7_manual.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+use vtcode_core::config::mcp::{
+    McpClientConfig, McpProviderConfig, McpStdioServerConfig, McpTransportConfig,
+};
+use vtcode_core::mcp_client::McpClient;
+
+#[tokio::test]
+#[ignore]
+async fn context7_list_tools_smoke() {
+    let provider = McpProviderConfig {
+        name: "context7".to_string(),
+        transport: McpTransportConfig::Stdio(McpStdioServerConfig {
+            command: "npx".to_string(),
+            args: vec!["-y".to_string(), "@upstash/context7-mcp@latest".to_string()],
+            working_directory: None,
+        }),
+        env: HashMap::new(),
+        enabled: true,
+        max_concurrent_requests: 1,
+    };
+
+    let mut config = McpClientConfig::default();
+    config.enabled = true;
+    config.providers = vec![provider];
+
+    let mut client = McpClient::new(config);
+    client.initialize().await.unwrap();
+
+    let tools = client.list_tools().await.unwrap();
+    assert!(
+        !tools.is_empty(),
+        "context7 should expose at least one tool"
+    );
+}

--- a/vtcode-core/tests/mcp_integration_e2e.rs
+++ b/vtcode-core/tests/mcp_integration_e2e.rs
@@ -10,7 +10,7 @@ use vtcode_core::config::loader::VTCodeConfig;
 use vtcode_core::config::mcp::{
     McpClientConfig, McpProviderConfig, McpStdioServerConfig, McpTransportConfig,
 };
-use vtcode_core::mcp_client::{McpClient, McpToolExecutor};
+use vtcode_core::mcp_client::McpClient;
 use vtcode_core::tools::registry::ToolRegistry;
 
 #[cfg(test)]
@@ -92,15 +92,14 @@ mod tests {
         let toml_content = r#"
 [mcp]
 enabled = true
+max_concurrent_connections = 3
+request_timeout_seconds = 45
+retry_attempts = 2
 
 [mcp.ui]
 mode = "compact"
 max_events = 25
 show_provider_names = false
-
-max_concurrent_connections = 3
-request_timeout_seconds = 45
-retry_attempts = 2
 
 [[mcp.providers]]
 name = "time"
@@ -130,10 +129,9 @@ max_concurrent_requests = 2
     #[test]
     fn test_tool_registry_with_mcp_client() {
         let temp_dir = TempDir::new().unwrap();
-        let workspace = temp_dir.path().to_path_buf();
 
         // Create tool registry without MCP client
-        let mut registry = ToolRegistry::new(workspace.clone());
+        let mut registry = ToolRegistry::new(temp_dir.path().to_path_buf());
 
         // Initially should not have MCP tools
         assert!(registry.mcp_client().is_none());
@@ -155,9 +153,6 @@ max_concurrent_requests = 2
 
     #[tokio::test]
     async fn test_mcp_disabled_by_default() {
-        let temp_dir = TempDir::new().unwrap();
-        let workspace = temp_dir.path().to_path_buf();
-
         // Create MCP client with default config (disabled)
         let config = McpClientConfig::default();
         let mut client = McpClient::new(config);

--- a/vtcode-core/tests/mcp_integration_test.rs
+++ b/vtcode-core/tests/mcp_integration_test.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 use vtcode_core::config::loader::VTCodeConfig;
 use vtcode_core::config::mcp::{
-    McpAllowListConfig, McpAllowListRules, McpClientConfig, McpProviderConfig, McpStdioServerConfig, McpTransportConfig, McpUiConfig,
-    McpUiMode,
+    McpAllowListConfig, McpAllowListRules, McpClientConfig, McpProviderConfig,
+    McpStdioServerConfig, McpTransportConfig, McpUiConfig, McpUiMode,
 };
 use vtcode_core::mcp_client::{McpClient, McpToolExecutor};
 
@@ -226,9 +226,16 @@ max_concurrent_requests = 1
         let client = McpClient::new(config);
 
         // Test tool execution without providers (should fail gracefully)
-        let result = client.execute_tool("test_tool", serde_json::json!({})).await;
+        let result = client
+            .execute_tool("test_tool", serde_json::json!({}))
+            .await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No MCP providers configured"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No MCP providers configured")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- ensure provider-specific MCP allowlist rules override defaults instead of silently falling back
- add coverage for provider resource and logging overrides plus configuration loading regression
- document MCP configuration, allowlist behaviour, and troubleshooting guidance in docs/guides/mcp-integration.md

## Testing
- cargo test -p vtcode-core mcp -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d8b17ab1fc8323891c10fa75eb732f