### PR TITLE
Adjust OpenAI reasoning model list

### DIFF
--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -32,10 +32,25 @@ pub mod models {
             "gpt-5-mini",
             "gpt-5-nano",
             "codex-mini-latest",
+            "o4-mini",
+            "o4-mini-deep-research",
+            "o3",
+            "o1",
+            "o1-mini",
+            "o1-preview",
+            "o1-pro",
         ];
 
         /// Models that support the OpenAI reasoning API extensions
-        pub const REASONING_MODELS: &[&str] = &[GPT_5, GPT_5_CODEX, GPT_5_MINI, GPT_5_NANO];
+        pub const REASONING_MODELS: &[&str] = &[
+            O4_MINI,
+            O4_MINI_DEEP_RESEARCH,
+            O3,
+            O1,
+            O1_PRO,
+            O1_PREVIEW,
+            O1_MINI,
+        ];
 
         // Convenience constants for commonly used models
         pub const GPT_5: &str = "gpt-5";
@@ -44,6 +59,13 @@ pub mod models {
         pub const GPT_5_NANO: &str = "gpt-5-nano";
         pub const CODEX_MINI_LATEST: &str = "codex-mini-latest";
         pub const CODEX_MINI: &str = "codex-mini";
+        pub const O4_MINI: &str = "o4-mini";
+        pub const O4_MINI_DEEP_RESEARCH: &str = "o4-mini-deep-research";
+        pub const O3: &str = "o3";
+        pub const O1: &str = "o1";
+        pub const O1_PRO: &str = "o1-pro";
+        pub const O1_PREVIEW: &str = "o1-preview";
+        pub const O1_MINI: &str = "o1-mini";
     }
 
     // OpenRouter models (extensible via vtcode.toml)

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -34,7 +34,7 @@ impl OpenAIProvider {
     }
 
     fn uses_responses_api(model: &str) -> bool {
-        Self::is_gpt5_codex_model(model)
+        Self::is_gpt5_codex_model(model) || Self::is_reasoning_model(model)
     }
 
     pub fn new(api_key: String) -> Self {


### PR DESCRIPTION
## Summary
- update OpenAI supported and reasoning model constants to reflect current API capabilities
- prevent GPT-5-family requests from including the unsupported `reasoning` parameter by restricting reasoning support to `o`-series models

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93039fa2883239e1832748a45d96f