### PR TITLE
Use list widget for chat transcript

### DIFF
--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -85,6 +85,7 @@ colorchoice-clap = "1.0"
 quick_cache = "0.6"
 roff = "0.2"
 syntect = "5.2"
+unicode-segmentation = "1.11"
 unicode-width = "0.1"
 crossterm = "0.27"
 ratatui = { version = "0.29", default-features = false, features = ["crossterm", "unstable-rendered-line-info"] }

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -815,6 +815,11 @@ impl Session {
                     continue;
                 }
 
+                if grapheme.chars().any(|c| c == '\n') {
+                    flush_current(&mut current_spans, &mut current_width, &mut rows);
+                    continue;
+                }
+
                 let grapheme_width = UnicodeWidthStr::width(grapheme);
                 if grapheme_width == 0 {
                     continue;


### PR DESCRIPTION
## Summary
- render the inline chat transcript with a ratatui `List` so we can display entire chat loop entries
- add manual grapheme-aware wrapping for list items to keep text visible within the viewport
- add the `unicode-segmentation` dependency to support the new wrapping logic

## Testing
- `cargo fmt`
- `cargo test -p vtcode-core` *(fails: existing policy/tool permission and configuration assertions outside the scope of this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d9499e6e9c8323a30670801669e9e5