### PR TITLE
Enable word-wise cursor navigation in inline chat input

### DIFF
--- a/.vtcode/tool-policy.json
+++ b/.vtcode/tool-policy.json
@@ -15,10 +15,10 @@
     "apply_patch",
     "srgn",
     "mcp::sequential-thinking::sequentialthinking",
-    "mcp::context7::get-library-docs",
-    "mcp::context7::resolve-library-id",
     "mcp::time::convert_time",
-    "mcp::time::get_current_time"
+    "mcp::time::get_current_time",
+    "mcp::context7::get-library-docs",
+    "mcp::context7::resolve-library-id"
   ],
   "policies": {
     "grep_search": "allow",
@@ -116,6 +116,11 @@
           "mcp.tool_denied"
         ],
         "configuration": {
+          "client": [
+            "max_concurrent_connections",
+            "request_timeout_seconds",
+            "retry_attempts"
+          ],
           "server": [
             "enabled",
             "bind_address",
@@ -128,11 +133,6 @@
             "mode",
             "max_events",
             "show_provider_names"
-          ],
-          "client": [
-            "max_concurrent_connections",
-            "request_timeout_seconds",
-            "retry_attempts"
           ]
         }
       },
@@ -166,38 +166,6 @@
             ]
           }
         },
-        "sequential-thinking": {
-          "tools": [
-            "plan",
-            "critique",
-            "reflect",
-            "decompose",
-            "sequential_*"
-          ],
-          "resources": null,
-          "prompts": [
-            "sequential-thinking::*",
-            "plan",
-            "reflect",
-            "critique"
-          ],
-          "logging": [
-            "mcp.tool_execution",
-            "mcp.tool_failed",
-            "mcp.tool_denied",
-            "mcp.tool_filtered",
-            "mcp.provider_initialized"
-          ],
-          "configuration": {
-            "sequencing": [
-              "max_depth",
-              "max_branches"
-            ],
-            "provider": [
-              "max_concurrent_requests"
-            ]
-          }
-        },
         "context7": {
           "tools": [
             "search_*",
@@ -225,13 +193,45 @@
             "mcp.provider_initialized"
           ],
           "configuration": {
+            "provider": [
+              "max_concurrent_requests"
+            ],
             "context7": [
               "workspace",
               "search_scope",
               "max_results"
-            ],
+            ]
+          }
+        },
+        "sequential-thinking": {
+          "tools": [
+            "plan",
+            "critique",
+            "reflect",
+            "decompose",
+            "sequential_*"
+          ],
+          "resources": null,
+          "prompts": [
+            "sequential-thinking::*",
+            "plan",
+            "reflect",
+            "critique"
+          ],
+          "logging": [
+            "mcp.tool_execution",
+            "mcp.tool_failed",
+            "mcp.tool_denied",
+            "mcp.tool_filtered",
+            "mcp.provider_initialized"
+          ],
+          "configuration": {
             "provider": [
               "max_concurrent_requests"
+            ],
+            "sequencing": [
+              "max_depth",
+              "max_branches"
             ]
           }
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,6 +3949,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+ "unicode-segmentation",
  "unicode-width 0.1.14",
  "walkdir",
 ]

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -387,8 +387,11 @@ impl Session {
     fn process_key(&mut self, key: KeyEvent) -> Option<InlineEvent> {
         let modifiers = key.modifiers;
         let has_control = modifiers.contains(KeyModifiers::CONTROL);
-        let has_alt = modifiers.contains(KeyModifiers::ALT);
+        let raw_alt = modifiers.contains(KeyModifiers::ALT);
+        let raw_meta = modifiers.contains(KeyModifiers::META);
         let has_super = modifiers.contains(KeyModifiers::SUPER);
+        let has_alt = raw_alt || (!has_super && raw_meta);
+        let has_command = has_super || (raw_meta && !has_alt);
 
         match key.code {
             KeyCode::Char('c') if has_control => {
@@ -442,7 +445,7 @@ impl Session {
             }
             KeyCode::Left => {
                 if self.input_enabled {
-                    if has_super {
+                    if has_command {
                         self.move_to_start();
                     } else if has_alt {
                         self.move_left_word();
@@ -455,7 +458,7 @@ impl Session {
             }
             KeyCode::Right => {
                 if self.input_enabled {
-                    if has_super {
+                    if has_command {
                         self.move_to_end();
                     } else if has_alt {
                         self.move_right_word();
@@ -481,7 +484,44 @@ impl Session {
                 None
             }
             KeyCode::Char(ch) => {
-                if self.input_enabled && !has_control && !has_alt {
+                if !self.input_enabled {
+                    return None;
+                }
+
+                if has_command {
+                    match ch {
+                        'a' | 'A' => {
+                            self.move_to_start();
+                            self.mark_dirty();
+                            return None;
+                        }
+                        'e' | 'E' => {
+                            self.move_to_end();
+                            self.mark_dirty();
+                            return None;
+                        }
+                        _ => {
+                            return None;
+                        }
+                    }
+                }
+
+                if has_alt {
+                    match ch {
+                        'b' | 'B' => {
+                            self.move_left_word();
+                            self.mark_dirty();
+                        }
+                        'f' | 'F' => {
+                            self.move_right_word();
+                            self.mark_dirty();
+                        }
+                        _ => {}
+                    }
+                    return None;
+                }
+
+                if !has_control {
                     self.insert_char(ch);
                     self.mark_dirty();
                 }
@@ -1007,6 +1047,7 @@ impl Session {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{Terminal, backend::TestBackend};
 
     const VIEW_ROWS: u16 = 6;
@@ -1072,6 +1113,28 @@ mod tests {
     }
 
     #[test]
+    fn alt_arrow_left_moves_cursor_by_word() {
+        let text = "hello world";
+        let mut session = session_with_input(text, text.len());
+
+        let event = KeyEvent::new(KeyCode::Left, KeyModifiers::ALT);
+        session.process_key(event);
+
+        assert_eq!(session.cursor, 6);
+    }
+
+    #[test]
+    fn alt_b_moves_cursor_by_word() {
+        let text = "hello world";
+        let mut session = session_with_input(text, text.len());
+
+        let event = KeyEvent::new(KeyCode::Char('b'), KeyModifiers::ALT);
+        session.process_key(event);
+
+        assert_eq!(session.cursor, 6);
+    }
+
+    #[test]
     fn move_right_word_advances_to_word_boundaries() {
         let text = "hello  world";
         let mut session = session_with_input(text, 0);
@@ -1093,6 +1156,28 @@ mod tests {
 
         session.move_right_word();
         assert_eq!(session.cursor, 7);
+    }
+
+    #[test]
+    fn super_arrow_right_moves_cursor_to_end() {
+        let text = "hello world";
+        let mut session = session_with_input(text, 0);
+
+        let event = KeyEvent::new(KeyCode::Right, KeyModifiers::SUPER);
+        session.process_key(event);
+
+        assert_eq!(session.cursor, text.len());
+    }
+
+    #[test]
+    fn super_a_moves_cursor_to_start() {
+        let text = "hello world";
+        let mut session = session_with_input(text, text.len());
+
+        let event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::SUPER);
+        session.process_key(event);
+
+        assert_eq!(session.cursor, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow the inline chat input to treat ⌥/Alt+Arrow as word-wise movement and ⌘/Super+Arrow as start/end jumps
- add supporting cursor movement helpers and regression tests for the new navigation behaviour
- refresh Cargo.lock to record the unicode-segmentation dependency for vtcode-core

## Testing
- cargo fmt
- cargo test -p vtcode-core *(fails: several pre-existing tests require interactive tool permissions and updated defaults)*

------
https://chatgpt.com/codex/tasks/task_e_68d954174d448323a2ae30c059788227