### PR TITLE
Solved the problem of build failure in windows environment

### DIFF
--- a/vtcode-core/src/mcp_client.rs
+++ b/vtcode-core/src/mcp_client.rs
@@ -1514,8 +1514,12 @@ impl McpProvider {
             command.envs(&self.config.env);
         }
 
-        // Create new process group to ensure proper cleanup
-        command.process_group(0);
+        // Create new process group to ensure proper cleanup (Unix only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
 
         debug!(
             "Creating TokioChildProcess for provider '{}'",


### PR DESCRIPTION
…m support

The `process_group` method is only available on Unix platforms through the `CommandExt` trait. This change wraps the process group call in conditional compilation to ensure compatibility across Windows and Unix systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)