### PR TITLE
Improve human-in-the-loop approval prompt rendering

### DIFF
--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -191,6 +191,11 @@ impl Session {
                 self.input_enabled = value;
                 self.update_slash_suggestions();
             }
+            InlineCommand::SetInput(content) => {
+                self.input = content;
+                self.cursor = self.input.len();
+                self.update_slash_suggestions();
+            }
             InlineCommand::ClearInput => {
                 self.clear_input();
             }

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -88,6 +88,7 @@ pub enum InlineCommand {
     },
     SetCursorVisible(bool),
     SetInputEnabled(bool),
+    SetInput(String),
     ClearInput,
     ForceRedraw,
     ShowModal {
@@ -172,6 +173,10 @@ impl InlineHandle {
 
     pub fn set_input_enabled(&self, enabled: bool) {
         let _ = self.sender.send(InlineCommand::SetInputEnabled(enabled));
+    }
+
+    pub fn set_input(&self, content: String) {
+        let _ = self.sender.send(InlineCommand::SetInput(content));
     }
 
     pub fn clear_input(&self) {


### PR DESCRIPTION
## Summary
- add constants and a modal guard to reuse inline UI overlays
- show a tool approval modal with clear instructions when human-in-the-loop prompts fire

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68da92d46f4483239c0d28df48952cf3