### PR TITLE
feat: add Claude Sonnet 4.5 model support

### DIFF
--- a/docs/MODEL_UPDATE_IMPLEMENTATION.md
+++ b/docs/MODEL_UPDATE_IMPLEMENTATION.md
@@ -141,7 +141,8 @@ Update the VT Code codebase to focus on the latest and most capable AI models as
 **Latest Models (August 2025 releases):**
 
 -   `claude-opus-4-1-20250805` - Latest most powerful (Aug 2025)
--   `claude-sonnet-4-20250514` - Latest intelligent (May 2025)
+-   `claude-sonnet-4-5-20250929` - Latest intelligent (September 2025)
+-   `claude-sonnet-4-20250514` - Previous intelligent (May 2025)
 -   Progressive model generations (4.1, 4, 3.7, 3.5v2, 3.5)
 
 ### Groq (Updated)

--- a/tests/llm_focused_test.rs
+++ b/tests/llm_focused_test.rs
@@ -31,6 +31,10 @@ fn test_provider_auto_detection() {
         Some("openai".to_string())
     );
     assert_eq!(
+        factory.provider_from_model(models::CLAUDE_SONNET_4_5_20250929),
+        Some("anthropic".to_string())
+    );
+    assert_eq!(
         factory.provider_from_model("claude-sonnet-4-20250514"),
         Some("anthropic".to_string())
     );
@@ -63,7 +67,7 @@ fn test_unified_client_creation() {
     assert!(openai.is_ok());
 
     let anthropic = create_provider_for_model(
-        models::CLAUDE_SONNET_4_20250514,
+        models::CLAUDE_SONNET_4_5_20250929,
         "test_key".to_string(),
         None,
     );
@@ -125,7 +129,7 @@ fn test_anthropic_tool_message_handling() {
         messages: vec![tool_message],
         system_prompt: None,
         tools: None,
-        model: "claude-sonnet-4-20250514".to_string(),
+        model: models::CLAUDE_SONNET_4_5_20250929.to_string(),
         max_tokens: None,
         temperature: None,
         stream: false,

--- a/tests/llm_provider_integration.rs
+++ b/tests/llm_provider_integration.rs
@@ -1,5 +1,6 @@
 //! Integration tests for universal LLM provider system
 
+use vtcode_core::config::constants::models;
 use vtcode_core::llm::{
     factory::{LLMFactory, create_provider_for_model},
     provider::{LLMProvider, Message},
@@ -22,6 +23,10 @@ fn test_provider_factory() {
         Some("openai".to_string())
     );
     assert_eq!(
+        factory.provider_from_model(models::CLAUDE_SONNET_4_5_20250929),
+        Some("anthropic".to_string())
+    );
+    assert_eq!(
         factory.provider_from_model("claude-sonnet-4-20250514"),
         Some("anthropic".to_string())
     );
@@ -40,8 +45,11 @@ fn test_provider_creation() {
     let openai = create_provider_for_model("gpt-5", "test_key".to_string(), None);
     assert!(openai.is_ok());
 
-    let anthropic =
-        create_provider_for_model("claude-sonnet-4-20250514", "test_key".to_string(), None);
+    let anthropic = create_provider_for_model(
+        models::CLAUDE_SONNET_4_5_20250929,
+        "test_key".to_string(),
+        None,
+    );
     assert!(anthropic.is_ok());
 }
 
@@ -58,8 +66,11 @@ fn test_unified_client_creation() {
     let openai_client = create_provider_for_model("gpt-5", "test_key".to_string(), None);
     assert!(openai_client.is_ok());
 
-    let anthropic_client =
-        create_provider_for_model("claude-sonnet-4-20250514", "test_key".to_string(), None);
+    let anthropic_client = create_provider_for_model(
+        models::CLAUDE_SONNET_4_5_20250929,
+        "test_key".to_string(),
+        None,
+    );
     assert!(anthropic_client.is_ok());
 }
 
@@ -97,6 +108,7 @@ fn test_provider_supported_models() {
 
     let anthropic = AnthropicProvider::new("test_key".to_string());
     let anthropic_models = anthropic.supported_models();
+    assert!(anthropic_models.contains(&models::CLAUDE_SONNET_4_5_20250929.to_string()));
     assert!(anthropic_models.contains(&"claude-sonnet-4-20250514".to_string()));
 }
 

--- a/tests/llm_providers_test.rs
+++ b/tests/llm_providers_test.rs
@@ -40,6 +40,10 @@ fn test_provider_auto_detection() {
 
     // Test Anthropic models
     assert_eq!(
+        factory.provider_from_model(models::CLAUDE_SONNET_4_5_20250929),
+        Some("anthropic".to_string())
+    );
+    assert_eq!(
         factory.provider_from_model("claude-sonnet-4-20250514"),
         Some("anthropic".to_string())
     );
@@ -71,6 +75,10 @@ fn test_provider_auto_detection() {
         factory.provider_from_model(models::OPENROUTER_QWEN3_CODER),
         Some("openrouter".to_string())
     );
+    assert_eq!(
+        factory.provider_from_model(models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5),
+        Some("openrouter".to_string())
+    );
 
     // Test xAI models
     assert_eq!(
@@ -100,7 +108,7 @@ fn test_provider_creation() {
     assert!(openai.is_ok());
 
     let anthropic = create_provider_for_model(
-        models::CLAUDE_SONNET_4_20250514,
+        models::CLAUDE_SONNET_4_5_20250929,
         "test_key".to_string(),
         None,
     );
@@ -140,8 +148,11 @@ fn test_unified_client_creation() {
         assert_eq!(client.name(), "openai");
     }
 
-    let anthropic_client =
-        create_provider_for_model("claude-sonnet-4-20250514", "test_key".to_string(), None);
+    let anthropic_client = create_provider_for_model(
+        models::CLAUDE_SONNET_4_5_20250929,
+        "test_key".to_string(),
+        None,
+    );
     assert!(anthropic_client.is_ok());
     if let Ok(client) = anthropic_client {
         assert_eq!(client.name(), "anthropic");
@@ -203,7 +214,8 @@ fn test_provider_supported_models() {
 
     let anthropic = AnthropicProvider::new("test_key".to_string());
     let anthropic_models = anthropic.supported_models();
-    assert!(anthropic_models.contains(&"claude-sonnet-4-20250514".to_string()));
+    assert!(anthropic_models.contains(&models::CLAUDE_SONNET_4_5_20250929.to_string()));
+    assert!(anthropic_models.contains(&models::CLAUDE_SONNET_4_20250514.to_string()));
     assert!(anthropic_models.contains(&"claude-opus-4-1-20250805".to_string()));
     assert!(anthropic_models.len() >= 2);
 
@@ -211,6 +223,9 @@ fn test_provider_supported_models() {
     let openrouter_models = openrouter.supported_models();
     assert!(openrouter_models.contains(&models::OPENROUTER_X_AI_GROK_CODE_FAST_1.to_string()));
     assert!(openrouter_models.contains(&models::OPENROUTER_QWEN3_CODER.to_string()));
+    assert!(
+        openrouter_models.contains(&models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5.to_string())
+    );
     assert!(openrouter_models.len() >= 2);
 
     let xai = XAIProvider::new("test_key".to_string());
@@ -282,7 +297,7 @@ fn test_request_validation() {
         messages: vec![Message::user("test".to_string())],
         system_prompt: None,
         tools: None,
-        model: "claude-sonnet-4-20250514".to_string(),
+        model: models::CLAUDE_SONNET_4_5_20250929.to_string(),
         max_tokens: None,
         temperature: None,
         stream: false,
@@ -292,6 +307,25 @@ fn test_request_validation() {
         reasoning_effort: None,
     };
     assert!(anthropic.validate_request(&valid_anthropic_request).is_ok());
+
+    let legacy_anthropic_request = LLMRequest {
+        messages: vec![Message::user("test".to_string())],
+        system_prompt: None,
+        tools: None,
+        model: "claude-sonnet-4-20250514".to_string(),
+        max_tokens: None,
+        temperature: None,
+        stream: false,
+        tool_choice: None,
+        parallel_tool_calls: None,
+        parallel_tool_config: None,
+        reasoning_effort: None,
+    };
+    assert!(
+        anthropic
+            .validate_request(&legacy_anthropic_request)
+            .is_ok()
+    );
 
     let valid_openrouter_request = LLMRequest {
         messages: vec![Message::user("test".to_string())],
@@ -363,7 +397,7 @@ fn test_anthropic_tool_message_handling() {
         messages: vec![tool_message],
         system_prompt: None,
         tools: None,
-        model: "claude-sonnet-4-20250514".to_string(),
+        model: models::CLAUDE_SONNET_4_5_20250929.to_string(),
         max_tokens: None,
         temperature: None,
         stream: false,

--- a/tests/models_sync.rs
+++ b/tests/models_sync.rs
@@ -172,11 +172,16 @@ fn backwards_compatibility_constants() {
     // Ensure old constant names still work
     assert!(!models::GEMINI_2_5_FLASH.is_empty());
     assert!(!models::GPT_5.is_empty());
+    assert!(!models::CLAUDE_SONNET_4_5_20250929.is_empty());
     assert!(!models::CLAUDE_SONNET_4_20250514.is_empty());
 
     // Test that backwards compatibility constants match the new structure
     assert_eq!(models::GEMINI_2_5_FLASH, models::google::GEMINI_2_5_FLASH);
     assert_eq!(models::GPT_5, models::openai::GPT_5);
+    assert_eq!(
+        models::CLAUDE_SONNET_4_5_20250929,
+        models::anthropic::CLAUDE_SONNET_4_5_20250929
+    );
     assert_eq!(
         models::CLAUDE_SONNET_4_20250514,
         models::anthropic::CLAUDE_SONNET_4_20250514

--- a/tests/tool_call_verification.rs
+++ b/tests/tool_call_verification.rs
@@ -113,7 +113,7 @@ fn test_anthropic_tool_call_format() {
         ],
         system_prompt: Some("You are a helpful assistant.".to_string()),
         tools: Some(vec![tool]),
-        model: models::CLAUDE_SONNET_4_20250514.to_string(),
+        model: models::CLAUDE_SONNET_4_5_20250929.to_string(),
         max_tokens: Some(1000),
         temperature: Some(0.7),
         stream: false,

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -33,7 +33,7 @@ pub struct Cli {
     ///   • gemini-2.5-flash - Fast, cost-effective
     ///   • gemini-2.5-pro - Latest, most capable
     ///   • gpt-5 - OpenAI's latest
-    ///   • claude-sonnet-4-20250514 - Anthropic's latest
+    ///   • claude-sonnet-4-5-20250929 - Anthropic's latest
     ///   • qwen/qwen3-4b-2507 - Qwen3 local model
     ///   • deepseek-reasoner - DeepSeek reasoning model
     ///   • x-ai/grok-code-fast-1 - OpenRouter Grok fast coding model
@@ -481,7 +481,7 @@ pub enum ModelCommands {
         provider: String,
     },
 
-    /// Set default model (e.g., deepseek-reasoner, gpt-5, claude-sonnet-4-20250514)
+    /// Set default model (e.g., deepseek-reasoner, gpt-5, claude-sonnet-4-5-20250929)
     #[command(name = "set-model")]
     SetModel {
         /// Model name to set as default

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -78,6 +78,7 @@ pub mod models {
             "deepseek/deepseek-chat-v3.1",
             "openai/gpt-5",
             "openai/gpt-5-codex",
+            "anthropic/claude-sonnet-4.5",
             "anthropic/claude-sonnet-4",
         ];
 
@@ -86,6 +87,7 @@ pub mod models {
             X_AI_GROK_4_FAST_FREE,
             OPENAI_GPT_5,
             OPENAI_GPT_5_CODEX,
+            ANTHROPIC_CLAUDE_SONNET_4_5,
             ANTHROPIC_CLAUDE_SONNET_4,
         ];
 
@@ -95,20 +97,23 @@ pub mod models {
         pub const DEEPSEEK_DEEPSEEK_CHAT_V3_1: &str = "deepseek/deepseek-chat-v3.1";
         pub const OPENAI_GPT_5: &str = "openai/gpt-5";
         pub const OPENAI_GPT_5_CODEX: &str = "openai/gpt-5-codex";
+        pub const ANTHROPIC_CLAUDE_SONNET_4_5: &str = "anthropic/claude-sonnet-4.5";
         pub const ANTHROPIC_CLAUDE_SONNET_4: &str = "anthropic/claude-sonnet-4";
     }
 
     // Anthropic models (from docs/models.json) - Updated for tool use best practices
     pub mod anthropic {
         // Standard model for straightforward tools - Sonnet 4 preferred for most use cases
-        pub const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
+        pub const DEFAULT_MODEL: &str = "claude-sonnet-4-5-20250929";
         pub const SUPPORTED_MODELS: &[&str] = &[
-            "claude-opus-4-1-20250805", // Latest: Opus 4.1 (2025-08-05)
-            "claude-sonnet-4-20250514", // Latest: Sonnet 4 (2025-05-14)
+            "claude-opus-4-1-20250805",   // Latest: Opus 4.1 (2025-08-05)
+            "claude-sonnet-4-5-20250929", // Latest: Sonnet 4.5 (2025-09-29)
+            "claude-sonnet-4-20250514",   // Previous: Sonnet 4 (2025-05-14)
         ];
 
         // Convenience constants for commonly used models
         pub const CLAUDE_OPUS_4_1_20250805: &str = "claude-opus-4-1-20250805";
+        pub const CLAUDE_SONNET_4_5_20250929: &str = "claude-sonnet-4-5-20250929";
         pub const CLAUDE_SONNET_4_20250514: &str = "claude-sonnet-4-20250514";
     }
 
@@ -142,6 +147,7 @@ pub mod models {
     pub const CODEX_MINI: &str = openai::CODEX_MINI;
     pub const CODEX_MINI_LATEST: &str = openai::CODEX_MINI_LATEST;
     pub const CLAUDE_OPUS_4_1_20250805: &str = anthropic::CLAUDE_OPUS_4_1_20250805;
+    pub const CLAUDE_SONNET_4_5_20250929: &str = anthropic::CLAUDE_SONNET_4_5_20250929;
     pub const CLAUDE_SONNET_4_20250514: &str = anthropic::CLAUDE_SONNET_4_20250514;
     pub const OPENROUTER_X_AI_GROK_CODE_FAST_1: &str = openrouter::X_AI_GROK_CODE_FAST_1;
     pub const OPENROUTER_X_AI_GROK_4_FAST_FREE: &str = openrouter::X_AI_GROK_4_FAST_FREE;
@@ -149,6 +155,8 @@ pub mod models {
     pub const OPENROUTER_DEEPSEEK_CHAT_V3_1: &str = openrouter::DEEPSEEK_DEEPSEEK_CHAT_V3_1;
     pub const OPENROUTER_OPENAI_GPT_5: &str = openrouter::OPENAI_GPT_5;
     pub const OPENROUTER_OPENAI_GPT_5_CODEX: &str = openrouter::OPENAI_GPT_5_CODEX;
+    pub const OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5: &str =
+        openrouter::ANTHROPIC_CLAUDE_SONNET_4_5;
     pub const OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4: &str = openrouter::ANTHROPIC_CLAUDE_SONNET_4;
     pub const XAI_GROK_2_LATEST: &str = xai::GROK_2_LATEST;
     pub const XAI_GROK_2: &str = xai::GROK_2;

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -101,7 +101,9 @@ pub enum ModelId {
     // Anthropic models
     /// Claude Opus 4.1 - Latest most capable Anthropic model (2025-08-05)
     ClaudeOpus41,
-    /// Claude Sonnet 4 - Latest balanced Anthropic model (2025-05-14)
+    /// Claude Sonnet 4.5 - Latest balanced Anthropic model (2025-09-29)
+    ClaudeSonnet45,
+    /// Claude Sonnet 4 - Previous balanced Anthropic model (2025-05-14)
     ClaudeSonnet4,
 
     // xAI models
@@ -125,6 +127,8 @@ pub enum ModelId {
     OpenRouterDeepSeekChatV31,
     /// OpenAI GPT-5 via OpenRouter
     OpenRouterOpenAIGPT5,
+    /// Anthropic Claude Sonnet 4.5 via OpenRouter
+    OpenRouterAnthropicClaudeSonnet45,
     /// Anthropic Claude Sonnet 4 via OpenRouter
     OpenRouterAnthropicClaudeSonnet4,
 }
@@ -146,6 +150,7 @@ impl ModelId {
             ModelId::CodexMiniLatest => models::CODEX_MINI_LATEST,
             // Anthropic models
             ModelId::ClaudeOpus41 => models::CLAUDE_OPUS_4_1_20250805,
+            ModelId::ClaudeSonnet45 => models::CLAUDE_SONNET_4_5_20250929,
             ModelId::ClaudeSonnet4 => models::CLAUDE_SONNET_4_20250514,
             // xAI models
             ModelId::XaiGrok2Latest => models::xai::GROK_2_LATEST,
@@ -158,6 +163,9 @@ impl ModelId {
             ModelId::OpenRouterQwen3Coder => models::OPENROUTER_QWEN3_CODER,
             ModelId::OpenRouterDeepSeekChatV31 => models::OPENROUTER_DEEPSEEK_CHAT_V3_1,
             ModelId::OpenRouterOpenAIGPT5 => models::OPENROUTER_OPENAI_GPT_5,
+            ModelId::OpenRouterAnthropicClaudeSonnet45 => {
+                models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5
+            }
             ModelId::OpenRouterAnthropicClaudeSonnet4 => {
                 models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4
             }
@@ -174,7 +182,9 @@ impl ModelId {
             ModelId::GPT5 | ModelId::GPT5Mini | ModelId::GPT5Nano | ModelId::CodexMiniLatest => {
                 Provider::OpenAI
             }
-            ModelId::ClaudeOpus41 | ModelId::ClaudeSonnet4 => Provider::Anthropic,
+            ModelId::ClaudeOpus41 | ModelId::ClaudeSonnet45 | ModelId::ClaudeSonnet4 => {
+                Provider::Anthropic
+            }
             ModelId::XaiGrok2Latest
             | ModelId::XaiGrok2
             | ModelId::XaiGrok2Mini
@@ -184,6 +194,7 @@ impl ModelId {
             | ModelId::OpenRouterQwen3Coder
             | ModelId::OpenRouterDeepSeekChatV31
             | ModelId::OpenRouterOpenAIGPT5
+            | ModelId::OpenRouterAnthropicClaudeSonnet45
             | ModelId::OpenRouterAnthropicClaudeSonnet4 => Provider::OpenRouter,
         }
     }
@@ -203,6 +214,7 @@ impl ModelId {
             ModelId::CodexMiniLatest => "Codex Mini Latest",
             // Anthropic models
             ModelId::ClaudeOpus41 => "Claude Opus 4.1",
+            ModelId::ClaudeSonnet45 => "Claude Sonnet 4.5",
             ModelId::ClaudeSonnet4 => "Claude Sonnet 4",
             // xAI models
             ModelId::XaiGrok2Latest => "Grok-2 Latest",
@@ -215,6 +227,9 @@ impl ModelId {
             ModelId::OpenRouterQwen3Coder => "Qwen3 Coder",
             ModelId::OpenRouterDeepSeekChatV31 => "DeepSeek Chat v3.1",
             ModelId::OpenRouterOpenAIGPT5 => "OpenAI GPT-5 via OpenRouter",
+            ModelId::OpenRouterAnthropicClaudeSonnet45 => {
+                "Anthropic Claude Sonnet 4.5 via OpenRouter"
+            }
             ModelId::OpenRouterAnthropicClaudeSonnet4 => "Anthropic Claude Sonnet 4 via OpenRouter",
         }
     }
@@ -240,7 +255,10 @@ impl ModelId {
             ModelId::CodexMiniLatest => "Latest Codex model optimized for code generation",
             // Anthropic models
             ModelId::ClaudeOpus41 => "Latest most capable Anthropic model with advanced reasoning",
-            ModelId::ClaudeSonnet4 => "Latest balanced Anthropic model for general tasks",
+            ModelId::ClaudeSonnet45 => "Latest balanced Anthropic model for general tasks",
+            ModelId::ClaudeSonnet4 => {
+                "Previous balanced Anthropic model maintained for compatibility"
+            }
             // xAI models
             ModelId::XaiGrok2Latest => "Flagship xAI Grok model with long context and tool use",
             ModelId::XaiGrok2 => "Stable Grok 2 release tuned for general coding tasks",
@@ -256,6 +274,9 @@ impl ModelId {
             }
             ModelId::OpenRouterDeepSeekChatV31 => "Advanced DeepSeek model via OpenRouter",
             ModelId::OpenRouterOpenAIGPT5 => "OpenAI GPT-5 model accessed through OpenRouter",
+            ModelId::OpenRouterAnthropicClaudeSonnet45 => {
+                "Anthropic Claude Sonnet 4.5 model accessed through OpenRouter"
+            }
             ModelId::OpenRouterAnthropicClaudeSonnet4 => {
                 "Anthropic Claude Sonnet 4 model accessed through OpenRouter"
             }
@@ -277,6 +298,7 @@ impl ModelId {
             ModelId::CodexMiniLatest,
             // Anthropic models
             ModelId::ClaudeOpus41,
+            ModelId::ClaudeSonnet45,
             ModelId::ClaudeSonnet4,
             // xAI models
             ModelId::XaiGrok2Latest,
@@ -289,6 +311,7 @@ impl ModelId {
             ModelId::OpenRouterQwen3Coder,
             ModelId::OpenRouterDeepSeekChatV31,
             ModelId::OpenRouterOpenAIGPT5,
+            ModelId::OpenRouterAnthropicClaudeSonnet45,
             ModelId::OpenRouterAnthropicClaudeSonnet4,
         ]
     }
@@ -308,6 +331,7 @@ impl ModelId {
             ModelId::Gemini25Pro,
             ModelId::GPT5,
             ModelId::ClaudeOpus41,
+            ModelId::ClaudeSonnet45,
             ModelId::XaiGrok2Latest,
             ModelId::OpenRouterGrokCodeFast1,
         ]
@@ -344,7 +368,7 @@ impl ModelId {
         match provider {
             Provider::Gemini => ModelId::Gemini25FlashPreview,
             Provider::OpenAI => ModelId::GPT5Mini,
-            Provider::Anthropic => ModelId::ClaudeSonnet4,
+            Provider::Anthropic => ModelId::ClaudeSonnet45,
             Provider::XAI => ModelId::XaiGrok2Mini,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
         }
@@ -398,8 +422,10 @@ impl ModelId {
             ModelId::Gemini25Pro
                 | ModelId::GPT5
                 | ModelId::ClaudeOpus41
+                | ModelId::ClaudeSonnet45
                 | ModelId::ClaudeSonnet4
                 | ModelId::OpenRouterQwen3Coder
+                | ModelId::OpenRouterAnthropicClaudeSonnet45
                 | ModelId::XaiGrok2Latest
                 | ModelId::XaiGrok2Reasoning
         )
@@ -416,6 +442,7 @@ impl ModelId {
             // OpenAI generations
             ModelId::GPT5 | ModelId::GPT5Mini | ModelId::GPT5Nano | ModelId::CodexMiniLatest => "5",
             // Anthropic generations
+            ModelId::ClaudeSonnet45 => "4.5",
             ModelId::ClaudeSonnet4 => "4",
             ModelId::ClaudeOpus41 => "4.1",
             // xAI generations
@@ -430,6 +457,7 @@ impl ModelId {
             ModelId::OpenRouterDeepSeekChatV31
             | ModelId::OpenRouterOpenAIGPT5
             | ModelId::OpenRouterAnthropicClaudeSonnet4 => "2025-08-07",
+            ModelId::OpenRouterAnthropicClaudeSonnet45 => "2025-09-29",
         }
     }
 }
@@ -458,6 +486,7 @@ impl FromStr for ModelId {
             s if s == models::CODEX_MINI_LATEST => Ok(ModelId::CodexMiniLatest),
             // Anthropic models
             s if s == models::CLAUDE_OPUS_4_1_20250805 => Ok(ModelId::ClaudeOpus41),
+            s if s == models::CLAUDE_SONNET_4_5_20250929 => Ok(ModelId::ClaudeSonnet45),
             s if s == models::CLAUDE_SONNET_4_20250514 => Ok(ModelId::ClaudeSonnet4),
             // xAI models
             s if s == models::xai::GROK_2_LATEST => Ok(ModelId::XaiGrok2Latest),
@@ -474,6 +503,9 @@ impl FromStr for ModelId {
                 Ok(ModelId::OpenRouterDeepSeekChatV31)
             }
             s if s == models::OPENROUTER_OPENAI_GPT_5 => Ok(ModelId::OpenRouterOpenAIGPT5),
+            s if s == models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5 => {
+                Ok(ModelId::OpenRouterAnthropicClaudeSonnet45)
+            }
             s if s == models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4 => {
                 Ok(ModelId::OpenRouterAnthropicClaudeSonnet4)
             }
@@ -547,6 +579,10 @@ mod tests {
         assert_eq!(ModelId::CodexMiniLatest.as_str(), models::CODEX_MINI_LATEST);
         // Anthropic models
         assert_eq!(
+            ModelId::ClaudeSonnet45.as_str(),
+            models::CLAUDE_SONNET_4_5_20250929
+        );
+        assert_eq!(
             ModelId::ClaudeSonnet4.as_str(),
             models::CLAUDE_SONNET_4_20250514
         );
@@ -579,6 +615,10 @@ mod tests {
         assert_eq!(
             ModelId::OpenRouterOpenAIGPT5.as_str(),
             models::OPENROUTER_OPENAI_GPT_5
+        );
+        assert_eq!(
+            ModelId::OpenRouterAnthropicClaudeSonnet45.as_str(),
+            models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5
         );
         assert_eq!(
             ModelId::OpenRouterAnthropicClaudeSonnet4.as_str(),
@@ -620,6 +660,12 @@ mod tests {
             ModelId::CodexMiniLatest
         );
         // Anthropic models
+        assert_eq!(
+            models::CLAUDE_SONNET_4_5_20250929
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::ClaudeSonnet45
+        );
         assert_eq!(
             models::CLAUDE_SONNET_4_20250514.parse::<ModelId>().unwrap(),
             ModelId::ClaudeSonnet4
@@ -671,6 +717,12 @@ mod tests {
             ModelId::OpenRouterOpenAIGPT5
         );
         assert_eq!(
+            models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::OpenRouterAnthropicClaudeSonnet45
+        );
+        assert_eq!(
             models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4
                 .parse::<ModelId>()
                 .unwrap(),
@@ -700,10 +752,15 @@ mod tests {
     fn test_model_providers() {
         assert_eq!(ModelId::Gemini25FlashPreview.provider(), Provider::Gemini);
         assert_eq!(ModelId::GPT5.provider(), Provider::OpenAI);
+        assert_eq!(ModelId::ClaudeSonnet45.provider(), Provider::Anthropic);
         assert_eq!(ModelId::ClaudeSonnet4.provider(), Provider::Anthropic);
         assert_eq!(ModelId::XaiGrok2Latest.provider(), Provider::XAI);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
+            Provider::OpenRouter
+        );
+        assert_eq!(
+            ModelId::OpenRouterAnthropicClaudeSonnet45.provider(),
             Provider::OpenRouter
         );
     }
@@ -741,7 +798,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_subagent_for_provider(Provider::Anthropic),
-            ModelId::ClaudeSonnet4
+            ModelId::ClaudeSonnet45
         );
         assert_eq!(
             ModelId::default_subagent_for_provider(Provider::OpenRouter),
@@ -785,8 +842,10 @@ mod tests {
         // Top tier models
         assert!(ModelId::Gemini25Pro.is_top_tier());
         assert!(ModelId::GPT5.is_top_tier());
+        assert!(ModelId::ClaudeSonnet45.is_top_tier());
         assert!(ModelId::ClaudeSonnet4.is_top_tier());
         assert!(ModelId::OpenRouterQwen3Coder.is_top_tier());
+        assert!(ModelId::OpenRouterAnthropicClaudeSonnet45.is_top_tier());
         assert!(ModelId::XaiGrok2Latest.is_top_tier());
         assert!(ModelId::XaiGrok2Reasoning.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
@@ -807,6 +866,7 @@ mod tests {
         assert_eq!(ModelId::CodexMiniLatest.generation(), "5");
 
         // Anthropic generations
+        assert_eq!(ModelId::ClaudeSonnet45.generation(), "4.5");
         assert_eq!(ModelId::ClaudeSonnet4.generation(), "4");
         assert_eq!(ModelId::ClaudeOpus41.generation(), "4.1");
 
@@ -831,6 +891,10 @@ mod tests {
             ModelId::OpenRouterAnthropicClaudeSonnet4.generation(),
             "2025-08-07"
         );
+        assert_eq!(
+            ModelId::OpenRouterAnthropicClaudeSonnet45.generation(),
+            "2025-09-29"
+        );
     }
 
     #[test]
@@ -844,6 +908,7 @@ mod tests {
         assert!(!openai_models.contains(&ModelId::Gemini25Pro));
 
         let anthropic_models = ModelId::models_for_provider(Provider::Anthropic);
+        assert!(anthropic_models.contains(&ModelId::ClaudeSonnet45));
         assert!(anthropic_models.contains(&ModelId::ClaudeSonnet4));
         assert!(!anthropic_models.contains(&ModelId::GPT5));
 
@@ -852,6 +917,7 @@ mod tests {
         assert!(openrouter_models.contains(&ModelId::OpenRouterQwen3Coder));
         assert!(openrouter_models.contains(&ModelId::OpenRouterDeepSeekChatV31));
         assert!(openrouter_models.contains(&ModelId::OpenRouterOpenAIGPT5));
+        assert!(openrouter_models.contains(&ModelId::OpenRouterAnthropicClaudeSonnet45));
         assert!(openrouter_models.contains(&ModelId::OpenRouterAnthropicClaudeSonnet4));
 
         let xai_models = ModelId::models_for_provider(Provider::XAI);

--- a/vtcode-core/src/llm/providers/anthropic.rs
+++ b/vtcode-core/src/llm/providers/anthropic.rs
@@ -888,7 +888,7 @@ mod tests {
             messages: vec![Message::user("What's the forecast?".to_string())],
             system_prompt: Some("You are a weather assistant".to_string()),
             tools: Some(vec![tool]),
-            model: models::CLAUDE_SONNET_4_20250514.to_string(),
+            model: models::CLAUDE_SONNET_4_5_20250929.to_string(),
             max_tokens: Some(512),
             temperature: Some(0.2),
             stream: false,
@@ -904,7 +904,7 @@ mod tests {
         let config = base_prompt_cache_config();
         let provider = AnthropicProvider::from_config(
             Some("key".to_string()),
-            Some(models::CLAUDE_SONNET_4_20250514.to_string()),
+            Some(models::CLAUDE_SONNET_4_5_20250929.to_string()),
             None,
             Some(config),
         );
@@ -944,7 +944,7 @@ mod tests {
         let config = base_prompt_cache_config();
         let provider = AnthropicProvider::from_config(
             Some("key".to_string()),
-            Some(models::CLAUDE_SONNET_4_20250514.to_string()),
+            Some(models::CLAUDE_SONNET_4_5_20250929.to_string()),
             None,
             Some(config),
         );
@@ -964,7 +964,7 @@ mod tests {
 
         let provider = AnthropicProvider::from_config(
             Some("key".to_string()),
-            Some(models::CLAUDE_SONNET_4_20250514.to_string()),
+            Some(models::CLAUDE_SONNET_4_5_20250929.to_string()),
             None,
             Some(config),
         );


### PR DESCRIPTION
## Summary
- add Anthropics Claude Sonnet 4.5 constants and make it the Anthropic default model
- extend the model registry and provider logic with new Claude Sonnet 4.5 variants and update tests accordingly
- refresh documentation and CLI help text to reference the new Anthropic model generation

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dac2b0a0d083239b150e09ffa13b00