### PR TITLE
Stabilize tool policy availability ordering

### DIFF
--- a/vtcode-core/src/tools/registry/policy.rs
+++ b/vtcode-core/src/tools/registry/policy.rs
@@ -11,6 +11,8 @@ impl ToolRegistry {
     pub(super) fn sync_policy_available_tools(&mut self) {
         let mut available = self.available_tools();
         available.extend(self.mcp_policy_keys());
+        available.sort();
+        available.dedup();
         if let Some(ref mut pm) = self.tool_policy
             && let Err(err) = pm.update_available_tools(available)
         {


### PR DESCRIPTION
## Summary
- ensure the combined tool policy inventory is sorted and deduplicated before persisting so repeated runs do not rewrite `.vtcode/tool-policy.json`

## Testing
- cargo test --test test_tool_policy

------
https://chatgpt.com/codex/tasks/task_e_68dbdc3b10bc8323a32800d070eae3fa