### PR TITLE
Revamp inline TUI layout

### DIFF
--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -264,7 +264,7 @@ pub mod ui {
     pub const TOOL_OUTPUT_MODE_FULL: &str = "full";
     pub const DEFAULT_INLINE_VIEWPORT_ROWS: u16 = 16;
     pub const SLASH_SUGGESTION_LIMIT: usize = 6;
-    pub const INLINE_HEADER_HEIGHT: u16 = 3;
+    pub const INLINE_HEADER_HEIGHT: u16 = 5;
     pub const INLINE_INPUT_HEIGHT: u16 = 3;
     pub const INLINE_NAVIGATION_PERCENT: u16 = 32;
     pub const INLINE_NAVIGATION_MIN_WIDTH: u16 = 24;

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -264,6 +264,40 @@ pub mod ui {
     pub const TOOL_OUTPUT_MODE_FULL: &str = "full";
     pub const DEFAULT_INLINE_VIEWPORT_ROWS: u16 = 16;
     pub const SLASH_SUGGESTION_LIMIT: usize = 6;
+    pub const INLINE_HEADER_HEIGHT: u16 = 3;
+    pub const INLINE_INPUT_HEIGHT: u16 = 3;
+    pub const INLINE_NAVIGATION_PERCENT: u16 = 32;
+    pub const INLINE_NAVIGATION_MIN_WIDTH: u16 = 24;
+    pub const INLINE_CONTENT_MIN_WIDTH: u16 = 48;
+    pub const INLINE_PREVIEW_MAX_CHARS: usize = 56;
+    pub const INLINE_PREVIEW_ELLIPSIS: &str = "…";
+    pub const HEADER_BLOCK_TITLE: &str = "Session";
+    pub const HEADER_TITLE_PREFIX: &str = "Sessions";
+    pub const HEADER_TITLE_SEPARATOR: &str = " ▸ ";
+    pub const HEADER_DEFAULT_SUBTITLE: &str = "Inline Session";
+    pub const HEADER_STATUS_LABEL: &str = "Status";
+    pub const HEADER_STATUS_ACTIVE: &str = "Active";
+    pub const HEADER_STATUS_PAUSED: &str = "Paused";
+    pub const HEADER_MESSAGES_LABEL: &str = "Messages";
+    pub const HEADER_INPUT_LABEL: &str = "Input";
+    pub const HEADER_INPUT_ENABLED: &str = "Enabled";
+    pub const HEADER_INPUT_DISABLED: &str = "Disabled";
+    pub const HEADER_SHORTCUT_HINT: &str =
+        "Shortcuts: Ctrl+Enter to submit • Esc to cancel • Ctrl+C to interrupt";
+    pub const HEADER_META_SEPARATOR: &str = "   ";
+    pub const NAVIGATION_BLOCK_TITLE: &str = "Timeline";
+    pub const NAVIGATION_EMPTY_LABEL: &str = "Waiting for activity";
+    pub const NAVIGATION_INDEX_PREFIX: &str = "#";
+    pub const NAVIGATION_LABEL_AGENT: &str = "Agent";
+    pub const NAVIGATION_LABEL_ERROR: &str = "Error";
+    pub const NAVIGATION_LABEL_INFO: &str = "Info";
+    pub const NAVIGATION_LABEL_POLICY: &str = "Policy";
+    pub const NAVIGATION_LABEL_TOOL: &str = "Tool";
+    pub const NAVIGATION_LABEL_USER: &str = "User";
+    pub const NAVIGATION_LABEL_PTY: &str = "PTY";
+    pub const TRANSCRIPT_BLOCK_TITLE: &str = "Conversation";
+    pub const INPUT_BLOCK_TITLE: &str = "Compose";
+    pub const SUGGESTION_BLOCK_TITLE: &str = "Slash Commands";
 }
 
 /// Reasoning effort configuration constants

--- a/vtcode-core/src/config/mcp.rs
+++ b/vtcode-core/src/config/mcp.rs
@@ -541,6 +541,7 @@ fn default_mcp_server_version() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_mcp_config_defaults() {
@@ -590,14 +591,14 @@ mod tests {
         config.enforce = true;
 
         let mut default_rules = McpAllowListRules::default();
-        default_rules.configuration = Some(HashMap::from([(
+        default_rules.configuration = Some(BTreeMap::from([(
             "ui".to_string(),
             vec!["mode".to_string(), "max_events".to_string()],
         )]));
         config.default = default_rules;
 
         let mut provider_rules = McpAllowListRules::default();
-        provider_rules.configuration = Some(HashMap::from([(
+        provider_rules.configuration = Some(BTreeMap::from([(
             "provider".to_string(),
             vec!["max_concurrent_requests".to_string()],
         )]));


### PR DESCRIPTION
## Summary
- add dedicated inline UI constants for headers, navigation, and content sizing
- redesign the inline session renderer with a top status bar, navigation sidebar, and framed transcript/input areas
- update TUI tests and allowlist tests to match the new layout utilities

## Testing
- cargo test --package vtcode-core session::tests::

------
https://chatgpt.com/codex/tasks/task_e_68dd4994a7908323a48bae8f8d06af0a