### PR TITLE
Encourage session TODO planning in onboarding prompts

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -237,10 +237,10 @@ recommended_actions = [
     "Request a workspace orientation or describe the task you want to tackle.",
     "Confirm priorities or blockers so I can suggest next steps.",
 ]
-chat_placeholder = "Sketch the TODO plan you want me to track (use update_plan)."
+# chat_placeholder = "Describe the task you want to tackle next."
 ```
 
-When enabled, VT Code prints the onboarding message before the first prompt, appends the same context block to the system prompt for the model, and shows the `chat_placeholder` hint above the initial `>` prompt so you always have a recommended next action ready.
+When enabled, VT Code prints the onboarding message before the first prompt and appends the same context block to the system prompt for the model. Provide `chat_placeholder` only if you want a custom hint above the initial `>` prompt; leaving it unset keeps the input empty by default.
 
 ## Usage Examples
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -229,13 +229,15 @@ guideline_highlight_limit = 4
 usage_tips = [
     "Share the outcome you need or ask for a quick /status summary.",
     "Reference AGENTS.md expectations before changing files.",
+    "Draft or refresh your TODOs with update_plan before editing.",
     "Prefer targeted reads (read_file, grep_search) before editing.",
 ]
 recommended_actions = [
+    "Outline a 3-6 step TODO plan via update_plan before coding.",
     "Request a workspace orientation or describe the task you want to tackle.",
     "Confirm priorities or blockers so I can suggest next steps.",
 ]
-chat_placeholder = "Implement {feature}..."
+chat_placeholder = "Sketch the TODO plan you want me to track (use update_plan)."
 ```
 
 When enabled, VT Code prints the onboarding message before the first prompt, appends the same context block to the system prompt for the model, and shows the `chat_placeholder` hint above the initial `>` prompt so you always have a recommended next action ready.

--- a/prompts/orchestrator_system.md
+++ b/prompts/orchestrator_system.md
@@ -183,6 +183,7 @@ Parameters:
 5. **Verify implementations** - Use explorer agents to confirm coder work
 6. **Synthesize knowledge** - Create strategic contexts from multiple discoveries
 7. **Track progress systematically** - Monitor task completion and build on results
+8. **Maintain a TODO plan** - Use update_plan to keep 3–6 actionable steps current for the session
 
 Your orchestration transforms individual agent capabilities into a compound intelligence system capable of solving sophisticated development challenges through strategic coordination and knowledge accumulation.
 

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -41,7 +41,9 @@ Within this workspace, "VT Code" refers to this open-source agentic coding inter
 
 ## Responsiveness & Planning
 - Send brief preamble updates before grouped tool runs; skip for trivial single-file reads.
+- Begin each new session or task by outlining a fresh TODO list with `update_plan`.
 - Use `update_plan` for multi-step tasks; keep 3–6 succinct steps, one `in_progress` at a time.
+- Keep the TODO plan current by updating `update_plan` after each completed step.
 - Update the plan when steps complete or strategy changes; include short rationale.
 - Work autonomously until the task is solved or blocked; do not guess.
 - When context is missing, perform quick workspace reconnaissance (directory listings, targeted searches) before proposing solutions.

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -82,13 +82,15 @@ pub(crate) fn prepare_session_bootstrap(
         None
     };
 
-    let placeholder = {
+    let placeholder = if onboarding_cfg.enabled {
         let trimmed = onboarding_cfg.chat_placeholder.trim();
         if trimmed.is_empty() {
             None
         } else {
             Some(trimmed.to_string())
         }
+    } else {
+        None
     };
 
     SessionBootstrap {

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -83,12 +83,14 @@ pub(crate) fn prepare_session_bootstrap(
     };
 
     let placeholder = if onboarding_cfg.enabled {
-        let trimmed = onboarding_cfg.chat_placeholder.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
+        onboarding_cfg.chat_placeholder.as_ref().and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
     } else {
         None
     };
@@ -366,7 +368,7 @@ mod tests {
         vt_cfg.agent.onboarding.guideline_highlight_limit = 2;
         vt_cfg.agent.onboarding.usage_tips = vec!["Tip one".into()];
         vt_cfg.agent.onboarding.recommended_actions = vec!["Do something".into()];
-        vt_cfg.agent.onboarding.chat_placeholder = "Type your plan".into();
+        vt_cfg.agent.onboarding.chat_placeholder = Some("Type your plan".into());
 
         let runtime_cfg = CoreAgentConfig {
             model: vtcode_core::config::constants::models::google::GEMINI_2_5_FLASH_PREVIEW

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -273,6 +273,7 @@ pub mod ui {
     pub const INLINE_PREVIEW_MAX_CHARS: usize = 56;
     pub const INLINE_PREVIEW_ELLIPSIS: &str = "…";
     pub const INLINE_AGENT_MESSAGE_LEFT_PADDING: &str = "  ";
+    pub const INLINE_AGENT_QUOTE_PREFIX: &str = "│ ";
     pub const INLINE_USER_MESSAGE_DIVIDER_SYMBOL: &str = "─";
     pub const HEADER_VERSION_PROMPT: &str = "> ";
     pub const HEADER_VERSION_PREFIX: &str = "VT Code";

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -272,6 +272,8 @@ pub mod ui {
     pub const INLINE_STACKED_NAVIGATION_PERCENT: u16 = INLINE_NAVIGATION_PERCENT;
     pub const INLINE_PREVIEW_MAX_CHARS: usize = 56;
     pub const INLINE_PREVIEW_ELLIPSIS: &str = "…";
+    pub const INLINE_AGENT_MESSAGE_LEFT_PADDING: &str = "  ";
+    pub const INLINE_USER_MESSAGE_DIVIDER_SYMBOL: &str = "─";
     pub const HEADER_VERSION_PROMPT: &str = "> ";
     pub const HEADER_VERSION_PREFIX: &str = "VT Code";
     pub const HEADER_VERSION_LEFT_DELIMITER: &str = "(";

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -17,6 +17,10 @@ pub struct AgentConfig {
     #[serde(default = "default_theme")]
     pub theme: String,
 
+    /// Enable TODO planning workflow integrations (update_plan tool, onboarding hints)
+    #[serde(default = "default_todo_planning_mode")]
+    pub todo_planning_mode: bool,
+
     /// Preferred rendering surface for the interactive chat UI (auto, alternate, inline)
     #[serde(default)]
     pub ui_surface: UiSurfacePreference,
@@ -65,6 +69,7 @@ impl Default for AgentConfig {
             provider: default_provider(),
             default_model: default_model(),
             theme: default_theme(),
+            todo_planning_mode: default_todo_planning_mode(),
             ui_surface: UiSurfacePreference::default(),
             max_conversation_turns: default_max_conversation_turns(),
             reasoning_effort: default_reasoning_effort(),
@@ -87,6 +92,10 @@ fn default_model() -> String {
 }
 fn default_theme() -> String {
     defaults::DEFAULT_THEME.to_string()
+}
+
+fn default_todo_planning_mode() -> bool {
+    true
 }
 fn default_max_conversation_turns() -> usize {
     150

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -159,7 +159,7 @@ pub struct AgentOnboardingConfig {
     pub recommended_actions: Vec<String>,
 
     /// Placeholder suggestion for the chat input bar
-    #[serde(default = "default_chat_placeholder")]
+    #[serde(default)]
     pub chat_placeholder: Option<String>,
 }
 
@@ -174,7 +174,7 @@ impl Default for AgentOnboardingConfig {
             guideline_highlight_limit: default_guideline_highlight_limit(),
             usage_tips: default_usage_tips(),
             recommended_actions: default_recommended_actions(),
-            chat_placeholder: default_chat_placeholder(),
+            chat_placeholder: None,
         }
     }
 }
@@ -218,8 +218,4 @@ fn default_recommended_actions() -> Vec<String> {
         "Review the highlighted guidelines and share the task you want to tackle.".to_string(),
         "Ask for a workspace tour if you need more context.".to_string(),
     ]
-}
-
-fn default_chat_placeholder() -> Option<String> {
-    Some("Sketch the TODO plan you want me to track (use update_plan).".to_string())
 }

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -151,7 +151,7 @@ pub struct AgentOnboardingConfig {
 
     /// Placeholder suggestion for the chat input bar
     #[serde(default = "default_chat_placeholder")]
-    pub chat_placeholder: String,
+    pub chat_placeholder: Option<String>,
 }
 
 impl Default for AgentOnboardingConfig {
@@ -211,6 +211,6 @@ fn default_recommended_actions() -> Vec<String> {
     ]
 }
 
-fn default_chat_placeholder() -> String {
-    "Sketch the TODO plan you want me to track (use update_plan).".to_string()
+fn default_chat_placeholder() -> Option<String> {
+    Some("Sketch the TODO plan you want me to track (use update_plan).".to_string())
 }

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -198,17 +198,19 @@ fn default_usage_tips() -> Vec<String> {
     vec![
         "Describe your current coding goal or ask for a quick status overview.".to_string(),
         "Reference AGENTS.md guidelines when proposing changes.".to_string(),
+        "Draft or refresh your TODO list with update_plan before coding.".to_string(),
         "Prefer asking for targeted file reads or diffs before editing.".to_string(),
     ]
 }
 
 fn default_recommended_actions() -> Vec<String> {
     vec![
+        "Start the session by outlining a 3–6 step TODO plan via update_plan.".to_string(),
         "Review the highlighted guidelines and share the task you want to tackle.".to_string(),
         "Ask for a workspace tour if you need more context.".to_string(),
     ]
 }
 
 fn default_chat_placeholder() -> String {
-    "".to_string()
+    "Sketch the TODO plan you want me to track (use update_plan).".to_string()
 }

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -154,7 +154,7 @@ pub use tools::grep_search::GrepSearchManager;
 pub use tools::tree_sitter::TreeSitterAnalyzer;
 pub use tools::{
     ToolRegistration, ToolRegistry, build_function_declarations,
-    build_function_declarations_for_level,
+    build_function_declarations_for_level, build_function_declarations_with_mode,
 };
 pub use ui::diff_renderer::DiffRenderer;
 pub use utils::dot_config::{

--- a/vtcode-core/src/prompts/system.rs
+++ b/vtcode-core/src/prompts/system.rs
@@ -19,6 +19,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
+6. **Plan TODOs** – For new sessions or tasks, outline a 3–6 step TODO list with update_plan before executing
 
 **Context Management:**
 - Start with lightweight searches (grep_search, list_files) before reading full files
@@ -30,6 +31,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 **Guidelines:**
 - When multiple approaches exist, choose the simplest that fully addresses the issue
 - If a file is mentioned, search for it first to understand its context and location
+- Keep the TODO plan current; update update_plan after each completed step
 - Always preserve existing code style and patterns in the codebase
 - For potentially destructive operations (delete, major refactor), explain the impact before proceeding
 - Acknowledge urgency or complexity in the user's request and respond with appropriate clarity

--- a/vtcode-core/src/tools/mod.rs
+++ b/vtcode-core/src/tools/mod.rs
@@ -161,3 +161,4 @@ pub use types::*;
 // Re-export function declarations for external use
 pub use registry::build_function_declarations;
 pub use registry::build_function_declarations_for_level;
+pub use registry::build_function_declarations_with_mode;

--- a/vtcode-core/src/tools/registry/builtins.rs
+++ b/vtcode-core/src/tools/registry/builtins.rs
@@ -4,8 +4,11 @@ use crate::config::types::CapabilityLevel;
 use super::ToolRegistry;
 use super::registration::ToolRegistration;
 
-pub(super) fn register_builtin_tools(registry: &mut ToolRegistry) {
+pub(super) fn register_builtin_tools(registry: &mut ToolRegistry, todo_planning_enabled: bool) {
     for registration in builtin_tool_registrations() {
+        if !todo_planning_enabled && registration.name() == tools::UPDATE_PLAN {
+            continue;
+        }
         if registration.name() == tools::AST_GREP_SEARCH && registry.ast_grep_engine.is_none() {
             continue;
         }

--- a/vtcode-core/src/tools/registry/declarations.rs
+++ b/vtcode-core/src/tools/registry/declarations.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 
 use super::builtins::builtin_tool_registrations;
 
-pub fn build_function_declarations() -> Vec<FunctionDeclaration> {
+fn base_function_declarations() -> Vec<FunctionDeclaration> {
     vec![
         // Ripgrep search tool
         FunctionDeclaration {
@@ -259,6 +259,20 @@ pub fn build_function_declarations() -> Vec<FunctionDeclaration> {
             }),
         },
     ]
+}
+
+pub fn build_function_declarations() -> Vec<FunctionDeclaration> {
+    build_function_declarations_with_mode(true)
+}
+
+pub fn build_function_declarations_with_mode(
+    todo_planning_enabled: bool,
+) -> Vec<FunctionDeclaration> {
+    let mut declarations = base_function_declarations();
+    if !todo_planning_enabled {
+        declarations.retain(|decl| decl.name != tools::UPDATE_PLAN);
+    }
+    declarations
 }
 
 /// Build function declarations filtered by capability level

--- a/vtcode-core/src/tools/registry/mod.rs
+++ b/vtcode-core/src/tools/registry/mod.rs
@@ -12,7 +12,10 @@ mod pty;
 mod registration;
 mod utils;
 
-pub use declarations::{build_function_declarations, build_function_declarations_for_level};
+pub use declarations::{
+    build_function_declarations, build_function_declarations_for_level,
+    build_function_declarations_with_mode,
+};
 pub use error::{ToolErrorType, ToolExecutionError, classify_error};
 pub use registration::{ToolExecutorFn, ToolHandler, ToolRegistration};
 
@@ -81,10 +84,26 @@ pub enum ToolPermissionDecision {
 
 impl ToolRegistry {
     pub fn new(workspace_root: PathBuf) -> Self {
-        Self::new_with_config(workspace_root, PtyConfig::default())
+        Self::build(workspace_root, PtyConfig::default(), true)
     }
 
     pub fn new_with_config(workspace_root: PathBuf, pty_config: PtyConfig) -> Self {
+        Self::build(workspace_root, pty_config, true)
+    }
+
+    pub fn new_with_features(workspace_root: PathBuf, todo_planning_enabled: bool) -> Self {
+        Self::build(workspace_root, PtyConfig::default(), todo_planning_enabled)
+    }
+
+    pub fn new_with_config_and_features(
+        workspace_root: PathBuf,
+        pty_config: PtyConfig,
+        todo_planning_enabled: bool,
+    ) -> Self {
+        Self::build(workspace_root, pty_config, todo_planning_enabled)
+    }
+
+    fn build(workspace_root: PathBuf, pty_config: PtyConfig, todo_planning_enabled: bool) -> Self {
         let grep_search = Arc::new(GrepSearchManager::new(workspace_root.clone()));
 
         let search_tool = SearchTool::new(workspace_root.clone(), grep_search.clone());
@@ -135,7 +154,7 @@ impl ToolRegistry {
             full_auto_allowlist: None,
         };
 
-        register_builtin_tools(&mut registry);
+        register_builtin_tools(&mut registry, todo_planning_enabled);
         registry
     }
 

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -807,7 +807,7 @@ impl Session {
         }
 
         let block = Block::default()
-            .borders(Borders::ALL)
+            .borders(Borders::TOP | Borders::BOTTOM)
             .border_type(BorderType::Rounded)
             .style(self.default_style());
         let inner = block.inner(area);
@@ -823,14 +823,13 @@ impl Session {
         }
     }
 
-    fn transcript_lines(&self) -> Vec<Line<'static>> {
-        if self.lines.is_empty() {
-            return vec![Line::default()];
-        }
-
+    fn transcript_lines(&self) -> Vec<(InlineMessageKind, Line<'static>)> {
         self.lines
             .iter()
-            .map(|line| Line::from(self.render_message_spans(line)))
+            .map(|line| {
+                let spans = self.render_message_spans(line);
+                (line.kind, Line::from(spans))
+            })
             .collect()
     }
 
@@ -1228,6 +1227,10 @@ impl Session {
                 prefix,
                 ratatui_style_from_inline(&style, self.theme.foreground),
             ));
+        }
+
+        if line.kind == InlineMessageKind::Agent {
+            spans.push(Span::raw(ui::INLINE_AGENT_MESSAGE_LEFT_PADDING));
         }
 
         if line.segments.is_empty() {
@@ -1897,15 +1900,28 @@ impl Session {
     }
 
     fn reflow_transcript_lines(&self, width: u16) -> Vec<Line<'static>> {
+        let entries = self.transcript_lines();
         if width == 0 {
-            return self.transcript_lines();
+            let mut lines: Vec<Line<'static>> = entries.into_iter().map(|(_, line)| line).collect();
+            if lines.is_empty() {
+                lines.push(Line::default());
+            }
+            return lines;
         }
 
         let mut wrapped_lines = Vec::new();
         let max_width = width as usize;
 
-        for line in self.transcript_lines() {
+        for (kind, line) in entries {
+            if kind == InlineMessageKind::User && max_width > 0 {
+                wrapped_lines.push(self.message_divider_line(max_width, kind));
+            }
+
             wrapped_lines.extend(self.wrap_line(line, max_width));
+
+            if kind == InlineMessageKind::User && max_width > 0 {
+                wrapped_lines.push(self.message_divider_line(max_width, kind));
+            }
         }
 
         if wrapped_lines.is_empty() {
@@ -1913,6 +1929,22 @@ impl Session {
         }
 
         wrapped_lines
+    }
+
+    fn message_divider_line(&self, width: usize, kind: InlineMessageKind) -> Line<'static> {
+        if width == 0 {
+            return Line::default();
+        }
+
+        let content = ui::INLINE_USER_MESSAGE_DIVIDER_SYMBOL.repeat(width);
+        let style = self.message_divider_style(kind);
+        Line::from(vec![Span::styled(content, style)])
+    }
+
+    fn message_divider_style(&self, kind: InlineMessageKind) -> Style {
+        let mut style = InlineTextStyle::default();
+        style.color = self.text_fallback(kind).or(self.theme.foreground);
+        ratatui_style_from_inline(&style, self.theme.foreground).add_modifier(Modifier::DIM)
     }
 
     fn wrap_line(&self, line: Line<'static>, max_width: usize) -> Vec<Line<'static>> {
@@ -2030,7 +2062,7 @@ impl Session {
 mod tests {
     use super::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use ratatui::{Terminal, backend::TestBackend};
+    use ratatui::{Terminal, backend::TestBackend, text::Line};
 
     const VIEW_ROWS: u16 = 14;
     const VIEW_WIDTH: u16 = 100;
@@ -2076,6 +2108,13 @@ mod tests {
                     .trim_end()
                     .to_string()
             })
+            .collect()
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.clone().into_owned())
             .collect()
     }
 
@@ -2253,5 +2292,47 @@ mod tests {
         assert_eq!(session.scroll_offset, 0);
         let max_offset = session.current_max_scroll_offset();
         assert_eq!(max_offset, 0);
+    }
+
+    #[test]
+    fn user_messages_render_with_dividers() {
+        let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+        session.push_line(InlineMessageKind::User, vec![make_segment("Hi")]);
+
+        let width = 10;
+        let lines = session.reflow_transcript_lines(width);
+        assert!(
+            lines.len() >= 3,
+            "expected dividers around the user message"
+        );
+
+        let top = line_text(&lines[0]);
+        let bottom = line_text(
+            lines
+                .last()
+                .expect("user message should have closing divider"),
+        );
+        let expected = ui::INLINE_USER_MESSAGE_DIVIDER_SYMBOL.repeat(width as usize);
+
+        assert_eq!(top, expected);
+        assert_eq!(bottom, expected);
+    }
+
+    #[test]
+    fn agent_messages_include_left_padding() {
+        let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+        session.push_line(InlineMessageKind::Agent, vec![make_segment("Response")]);
+
+        let lines = session.reflow_transcript_lines(VIEW_WIDTH);
+        let message_line = lines
+            .iter()
+            .map(line_text)
+            .find(|text| text.contains("Response"))
+            .expect("agent message should be visible");
+
+        assert!(
+            message_line.starts_with(ui::INLINE_AGENT_MESSAGE_LEFT_PADDING),
+            "agent message should be padded on the left"
+        );
     }
 }

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -24,7 +24,7 @@ use crate::config::constants::ui;
 use crate::ui::slash::{SlashCommandInfo, suggestions_for};
 
 const USER_PREFIX: &str = "❯ ";
-const PLACEHOLDER_COLOR: RgbColor = RgbColor(0xD3, 0xD3, 0xD3);
+const PLACEHOLDER_COLOR: RgbColor = RgbColor(0x88, 0x88, 0x88);
 
 #[derive(Clone)]
 struct MessageLine {
@@ -846,6 +846,7 @@ impl Session {
                         .clone()
                         .unwrap_or_else(|| InlineTextStyle {
                             color: Some(AnsiColorEnum::Rgb(PLACEHOLDER_COLOR)),
+                            italic: true,
                             ..InlineTextStyle::default()
                         });
                 let style = ratatui_style_from_inline(

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -24,6 +24,7 @@ retrieval_heavy = "x-ai/grok-4-fast:free"
 max_conversation_turns = 150
 # Reasoning effort for models that support it: "low" | "medium" | "high"
 reasoning_effort = "medium"
+todo_planning_mode = true
 
 [security]
 # Runloop guardrails enforced inside session_setup

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -43,7 +43,6 @@ recommended_actions = [
     "Request a quick workspace orientation.",
     "Describe the change you want to pursue next.",
 ]
-chat_placeholder = "Sketch the TODO plan you want me to track (use update_plan)."
 
 [tools]
 # Default policy for tools: "allow", "prompt", or "deny"

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -34,13 +34,15 @@ guideline_highlight_limit = 3
 usage_tips = [
     "Share your goal or ask for /status to recap configuration.",
     "Reference AGENTS.md norms before editing.",
+    "Draft or refresh your TODOs with update_plan before modifying code.",
     "Prefer targeted reads (read_file, grep_search) before modifying code.",
 ]
 recommended_actions = [
+    "Outline a 3-6 step TODO plan using update_plan before diving in.",
     "Request a quick workspace orientation.",
     "Describe the change you want to pursue next.",
 ]
-chat_placeholder = ""
+chat_placeholder = "Sketch the TODO plan you want me to track (use update_plan)."
 
 [tools]
 # Default policy for tools: "allow", "prompt", or "deny"

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -18,6 +18,7 @@ refine_prompts_max_passes = 1
 refine_prompts_model = ""
 enable_self_review = false
 max_review_passes = 1
+todo_planning_mode = true
 
 # UI theme applied to ANSI output (options: "ciapre-dark", "ciapre-blue")
 theme = "ciapre-dark"


### PR DESCRIPTION
## Summary
- reinforce onboarding defaults to nudge agents toward drafting TODO plans with `update_plan`
- highlight TODO planning expectations in system and orchestrator prompt guidance
- sync example configuration and docs with the new planning-first workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddf9b0c04083238e206389892103b7