### PR TITLE
Encourage session TODO planning in onboarding prompts

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -229,13 +229,15 @@ guideline_highlight_limit = 4
 usage_tips = [
     "Share the outcome you need or ask for a quick /status summary.",
     "Reference AGENTS.md expectations before changing files.",
+    "Draft or refresh your TODOs with update_plan before editing.",
     "Prefer targeted reads (read_file, grep_search) before editing.",
 ]
 recommended_actions = [
+    "Outline a 3-6 step TODO plan via update_plan before coding.",
     "Request a workspace orientation or describe the task you want to tackle.",
     "Confirm priorities or blockers so I can suggest next steps.",
 ]
-chat_placeholder = "Implement {feature}..."
+chat_placeholder = "Sketch the TODO plan you want me to track (use update_plan)."
 ```
 
 When enabled, VT Code prints the onboarding message before the first prompt, appends the same context block to the system prompt for the model, and shows the `chat_placeholder` hint above the initial `>` prompt so you always have a recommended next action ready.

--- a/prompts/orchestrator_system.md
+++ b/prompts/orchestrator_system.md
@@ -183,6 +183,7 @@ Parameters:
 5. **Verify implementations** - Use explorer agents to confirm coder work
 6. **Synthesize knowledge** - Create strategic contexts from multiple discoveries
 7. **Track progress systematically** - Monitor task completion and build on results
+8. **Maintain a TODO plan** - Use update_plan to keep 3–6 actionable steps current for the session
 
 Your orchestration transforms individual agent capabilities into a compound intelligence system capable of solving sophisticated development challenges through strategic coordination and knowledge accumulation.
 

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -41,7 +41,9 @@ Within this workspace, "VT Code" refers to this open-source agentic coding inter
 
 ## Responsiveness & Planning
 - Send brief preamble updates before grouped tool runs; skip for trivial single-file reads.
+- Begin each new session or task by outlining a fresh TODO list with `update_plan`.
 - Use `update_plan` for multi-step tasks; keep 3–6 succinct steps, one `in_progress` at a time.
+- Keep the TODO plan current by updating `update_plan` after each completed step.
 - Update the plan when steps complete or strategy changes; include short rationale.
 - Work autonomously until the task is solved or blocked; do not guess.
 - When context is missing, perform quick workspace reconnaissance (directory listings, targeted searches) before proposing solutions.

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -198,17 +198,19 @@ fn default_usage_tips() -> Vec<String> {
     vec![
         "Describe your current coding goal or ask for a quick status overview.".to_string(),
         "Reference AGENTS.md guidelines when proposing changes.".to_string(),
+        "Draft or refresh your TODO list with update_plan before coding.".to_string(),
         "Prefer asking for targeted file reads or diffs before editing.".to_string(),
     ]
 }
 
 fn default_recommended_actions() -> Vec<String> {
     vec![
+        "Start the session by outlining a 3–6 step TODO plan via update_plan.".to_string(),
         "Review the highlighted guidelines and share the task you want to tackle.".to_string(),
         "Ask for a workspace tour if you need more context.".to_string(),
     ]
 }
 
 fn default_chat_placeholder() -> String {
-    "".to_string()
+    "Sketch the TODO plan you want me to track (use update_plan).".to_string()
 }

--- a/vtcode-core/src/prompts/system.rs
+++ b/vtcode-core/src/prompts/system.rs
@@ -19,6 +19,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
+6. **Plan TODOs** – For new sessions or tasks, outline a 3–6 step TODO list with update_plan before executing
 
 **Context Management:**
 - Start with lightweight searches (grep_search, list_files) before reading full files
@@ -30,6 +31,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 **Guidelines:**
 - When multiple approaches exist, choose the simplest that fully addresses the issue
 - If a file is mentioned, search for it first to understand its context and location
+- Keep the TODO plan current; update update_plan after each completed step
 - Always preserve existing code style and patterns in the codebase
 - For potentially destructive operations (delete, major refactor), explain the impact before proceeding
 - Acknowledge urgency or complexity in the user's request and respond with appropriate clarity

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -34,13 +34,15 @@ guideline_highlight_limit = 3
 usage_tips = [
     "Share your goal or ask for /status to recap configuration.",
     "Reference AGENTS.md norms before editing.",
+    "Draft or refresh your TODOs with update_plan before modifying code.",
     "Prefer targeted reads (read_file, grep_search) before modifying code.",
 ]
 recommended_actions = [
+    "Outline a 3-6 step TODO plan using update_plan before diving in.",
     "Request a quick workspace orientation.",
     "Describe the change you want to pursue next.",
 ]
-chat_placeholder = ""
+chat_placeholder = "Sketch the TODO plan you want me to track (use update_plan)."
 
 [tools]
 # Default policy for tools: "allow", "prompt", or "deny"


### PR DESCRIPTION
## Summary
- reinforce onboarding defaults to nudge agents toward drafting TODO plans with `update_plan`
- highlight TODO planning expectations in system and orchestrator prompt guidance
- sync example configuration and docs with the new planning-first workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddf9b0c04083238e206389892103b7