### PR TITLE
Add agent quote prefix styling

### DIFF
--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -273,6 +273,7 @@ pub mod ui {
     pub const INLINE_PREVIEW_MAX_CHARS: usize = 56;
     pub const INLINE_PREVIEW_ELLIPSIS: &str = "…";
     pub const INLINE_AGENT_MESSAGE_LEFT_PADDING: &str = "  ";
+    pub const INLINE_AGENT_QUOTE_PREFIX: &str = "│ ";
     pub const INLINE_USER_MESSAGE_DIVIDER_SYMBOL: &str = "─";
     pub const HEADER_VERSION_PROMPT: &str = "> ";
     pub const HEADER_VERSION_PREFIX: &str = "VT Code";


### PR DESCRIPTION
## Summary
- add a reusable UI constant for the inline agent quote prefix
- render agent message prefixes with the theme accent color and include any labels
- update inline session tests to cover the new prefix behavior and styling

## Testing
- cargo test -p vtcode-core agent_prefix_uses_quote_prefix_and_accent_color

------
https://chatgpt.com/codex/tasks/task_e_68de125773008323a0fd25ee1dbd3435