### PR TITLE
Add configuration toggle for inline timeline pane

### DIFF
--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -1214,11 +1214,13 @@ pub(crate) async fn run_single_agent_loop_unified(
     let inline_rows = vt_cfg
         .map(|cfg| cfg.ui.inline_viewport_rows)
         .unwrap_or(ui::DEFAULT_INLINE_VIEWPORT_ROWS);
+    let show_timeline = vt_cfg.map(|cfg| cfg.ui.show_timeline_pane).unwrap_or(false);
     let session = spawn_session(
         theme_spec.clone(),
         default_placeholder.clone(),
         config.ui_surface,
         inline_rows,
+        show_timeline,
     )
     .context("failed to launch inline session")?;
     let handle = session.handle.clone();

--- a/vtcode-core/src/config/mod.rs
+++ b/vtcode-core/src/config/mod.rs
@@ -220,6 +220,8 @@ pub struct UiConfig {
     pub tool_output_mode: ToolOutputMode,
     #[serde(default = "default_inline_viewport_rows")]
     pub inline_viewport_rows: u16,
+    #[serde(default = "default_show_timeline_pane")]
+    pub show_timeline_pane: bool,
 }
 
 impl Default for UiConfig {
@@ -227,8 +229,13 @@ impl Default for UiConfig {
         Self {
             tool_output_mode: default_tool_output_mode(),
             inline_viewport_rows: default_inline_viewport_rows(),
+            show_timeline_pane: default_show_timeline_pane(),
         }
     }
+}
+
+fn default_show_timeline_pane() -> bool {
+    false
 }
 
 /// PTY configuration

--- a/vtcode-core/src/ui/tui.rs
+++ b/vtcode-core/src/ui/tui.rs
@@ -21,6 +21,7 @@ pub fn spawn_session(
     placeholder: Option<String>,
     surface_preference: UiSurfacePreference,
     inline_rows: u16,
+    show_timeline: bool,
 ) -> Result<InlineSession> {
     let (command_tx, command_rx) = mpsc::unbounded_channel();
     let (event_tx, event_rx) = mpsc::unbounded_channel();
@@ -33,6 +34,7 @@ pub fn spawn_session(
             placeholder,
             surface_preference,
             inline_rows,
+            show_timeline,
         )
         .await
         {

--- a/vtcode-core/src/ui/tui/tui.rs
+++ b/vtcode-core/src/ui/tui/tui.rs
@@ -194,9 +194,10 @@ pub async fn run_tui(
     placeholder: Option<String>,
     surface_preference: UiSurfacePreference,
     inline_rows: u16,
+    show_timeline: bool,
 ) -> Result<()> {
     let surface = TerminalSurface::detect(surface_preference, inline_rows)?;
-    let mut session = Session::new(theme, placeholder, surface.rows());
+    let mut session = Session::new(theme, placeholder, surface.rows(), show_timeline);
     let mut inputs = InputListener::spawn();
 
     let mut stdout = io::stdout();

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -108,6 +108,8 @@ stdout_tail_lines = 20
 [ui]
 # Controls inline tool output rendering in vtcode-core::ui
 tool_output_mode = "compact"
+# Toggle the inline timeline/navigation pane in the TUI session
+show_timeline_pane = false
 
 [mcp]
 # Local MCP transports; fine-grained allowlists live in .vtcode/tool-policy.json

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -25,6 +25,11 @@ theme = "ciapre-dark"
 # Chat UI surface: "auto" (default), "alternate" (always alternate screen), or "inline"
 ui_surface = "auto"
 
+[ui]
+# Inline transcript rendering options and navigation pane visibility
+tool_output_mode = "compact"
+show_timeline_pane = false
+
 [agent.onboarding]
 enabled = true
 intro_text = "Welcome! I preloaded workspace context so you can focus on decisions."


### PR DESCRIPTION
## Summary
- add a `show_timeline_pane` toggle to the UI configuration with a default of `false`
- plumb the flag through inline session setup so navigation layout is skipped when disabled and add timeline visibility tests
- document the new option in `vtcode.toml` and `vtcode.toml.example`

## Testing
- cargo test -p vtcode-core timeline_hidden_uses_full_width_transcript
- cargo test -p vtcode-core timeline_visible_reduces_transcript_width

------
https://chatgpt.com/codex/tasks/task_e_68de12522d3c83239c1cb0bba66d8c56