### PR TITLE
Add xAI provider API key inference to CLI args

### DIFF
--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -780,6 +780,7 @@ impl Cli {
                     "gemini" => "GEMINI_API_KEY".to_string(),
                     "deepseek" => "DEEPSEEK_API_KEY".to_string(),
                     "openrouter" => "OPENROUTER_API_KEY".to_string(),
+                    "xai" => "XAI_API_KEY".to_string(),
                     _ => "GEMINI_API_KEY".to_string(),
                 }
             } else {


### PR DESCRIPTION
## Summary
- add the missing xAI provider branch to CLI API key inference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de94b258f88323bf4dfcfe30f2c0a1