### PR TITLE
Add Terminal Benchmark runner integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ Contributing to VT Code? Understand the architecture and development processes:
 -   **[API Documentation](./api/README.md)** - Technical API references
 -   **[Code Standards](./development/code-style.md)** - Coding guidelines and best practices
 -   **[Codex Cloud Setup](./guides/codex-cloud-setup.md)** - Configure Codex Cloud environments for VT Code
+-   **[TBench Benchmarking](./guides/tbench-terminal-benchmark.md)** - Run the Terminal Benchmark harness via `vtcode benchmark`
 
 ### For Organizations
 

--- a/docs/guides/tbench-terminal-benchmark.md
+++ b/docs/guides/tbench-terminal-benchmark.md
@@ -45,11 +45,9 @@ config_path = "benchmarks/vtcode.yaml"        # Workspace-relative scenario defi
 results_dir = "benchmarks/results"            # Directory created before the run
 run_log = "benchmarks/logs/latest.log"        # Optional consolidated stdout/stderr log
 attach_workspace_env = true                   # Inject VT_CODE_WORKSPACE into the runner
+providers = ["gemini", "openai", "anthropic", "openrouter"]
 env = { "TBENCH_API_KEY" = "${env:TBENCH_API_KEY}" }
 passthrough_env = [
-    "OPENAI_API_KEY",
-    "ANTHROPIC_API_KEY",
-    "GEMINI_API_KEY",
     "TBENCH_API_KEY",
 ]
 ```
@@ -61,8 +59,22 @@ Key behaviors:
 - **Path resolution** – `config_path`, `results_dir`, and `run_log` are resolved relative to the
   active workspace unless absolute.
 - **Environment management** – `env` injects static key/value pairs. `passthrough_env` copies values
-  from the current process if defined (ideal for API keys). When `attach_workspace_env` is true,
-  VTCode exports `VT_CODE_WORKSPACE` pointing to the workspace root for the TBench runner.
+  from the current process if defined (ideal for API keys). Use `providers` to auto-bridge
+  credentials (e.g., adding `"openrouter"` forwards `OPENROUTER_API_KEY`). When
+  `attach_workspace_env` is true, VTCode exports `VT_CODE_WORKSPACE` pointing to the workspace root
+  for the TBench runner.
+
+### OpenRouter provider setup
+
+To evaluate VTCode with the OpenRouter provider, export your marketplace key before running the
+benchmark:
+
+```bash
+export OPENROUTER_API_KEY="your-openrouter-key"
+```
+
+Adding `"openrouter"` to `providers` in `[benchmark.tbench]` forwards this key automatically, so the
+Terminal Benchmark runner can authenticate without duplicating entries in `passthrough_env`.
 
 ## Running the benchmark
 

--- a/docs/guides/tbench-terminal-benchmark.md
+++ b/docs/guides/tbench-terminal-benchmark.md
@@ -1,0 +1,104 @@
+# Running VTCode with Terminal Benchmark (TBench)
+
+This guide walks through preparing VTCode to run the [Terminal Benchmark (TBench)](https://www.tbench.ai/docs)
+terminal evaluation. It covers CLI installation, configuration, and execution using the new
+`vtcode benchmark` command.
+
+> **Note:** The TBench CLI distribution may evolve. Always consult the official documentation for
+the latest installation instructions, then map the resulting CLI path into the configuration
+outlined below.
+
+## Prerequisites
+
+1. A working VTCode installation (Cargo, Homebrew, or npm).
+2. Access to at least one supported LLM provider (API keys exported in your shell).
+3. The TBench CLI installed locally. Common installation patterns include:
+
+    ```bash
+    # Example: install via uvx or pipx (adjust per official docs)
+    uvx tbench --help
+
+    # Or using npm/Node distribution
+    npm install -g tbench-cli
+    ```
+
+    After installation, confirm the binary location and export `TBENCH_CLI` for VTCode:
+
+    ```bash
+    export TBENCH_CLI="$(command -v tbench)"
+    ```
+
+4. Optional: prepare a benchmark scenario file (YAML or JSON as required by TBench).
+
+## Configure `vtcode.toml`
+
+Add or update the `[benchmark.tbench]` section in `vtcode.toml` to describe how VTCode should launch
+TBench:
+
+```toml
+[benchmark.tbench]
+enabled = true
+# command = "/usr/local/bin/tbench"          # Optional when command_env is provided
+command_env = "TBENCH_CLI"                    # Fallback environment variable for the CLI
+args = ["run", "--config", "benchmarks/vtcode.yaml"]
+config_path = "benchmarks/vtcode.yaml"        # Workspace-relative scenario definition
+results_dir = "benchmarks/results"            # Directory created before the run
+run_log = "benchmarks/logs/latest.log"        # Optional consolidated stdout/stderr log
+attach_workspace_env = true                   # Inject VT_CODE_WORKSPACE into the runner
+env = { "TBENCH_API_KEY" = "${env:TBENCH_API_KEY}" }
+passthrough_env = [
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "TBENCH_API_KEY",
+]
+```
+
+Key behaviors:
+
+- **Command resolution** – VTCode uses `command` when set; otherwise it reads `command_env` (defaults
+  to `TBENCH_CLI`). Empty values trigger a friendly error with remediation guidance.
+- **Path resolution** – `config_path`, `results_dir`, and `run_log` are resolved relative to the
+  active workspace unless absolute.
+- **Environment management** – `env` injects static key/value pairs. `passthrough_env` copies values
+  from the current process if defined (ideal for API keys). When `attach_workspace_env` is true,
+  VTCode exports `VT_CODE_WORKSPACE` pointing to the workspace root for the TBench runner.
+
+## Running the benchmark
+
+Once configuration is in place, launch the evaluation from the workspace root:
+
+```bash
+vtcode benchmark
+```
+
+The command prints the resolved CLI, scenario path, and output directories before streaming
+TBench output. VTCode mirrors stdout/stderr to your terminal and optionally writes both streams to
+`run_log` with `[stdout]`/`[stderr]` prefixes for easier triage.
+
+Successful completion returns exit code `0`. Non-zero exits propagate as errors with the recorded
+status code.
+
+## Inspecting artifacts
+
+- **Results directory** – Created automatically when `results_dir` is set. Populate this directory
+  path in your TBench configuration to collect transcripts or scores.
+- **Run log** – When `run_log` is configured, VTCode rewrites the file at each invocation and appends
+  tagged stream entries.
+- **Environment variables** – The benchmark process receives:
+  - `VT_CODE_WORKSPACE`: workspace root (when `attach_workspace_env = true`).
+  - `TBENCH_CONFIG`: resolved scenario path when `config_path` is present.
+  - `TBENCH_OUTPUT_DIR`: resolved results directory when `results_dir` is present.
+  - `TBENCH_RUN_LOG`: resolved log file when `run_log` is present.
+
+## Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| `Unable to determine benchmark CLI command` | Ensure `command` is set or export the environment variable defined in `command_env` (`TBENCH_CLI` by default). |
+| `Benchmark working directory does not exist` | Verify the workspace path or set `working_directory` under `[benchmark.tbench]` to a valid location. |
+| CLI exits immediately with missing credentials | Add the necessary keys to `env` or `passthrough_env` so they reach the TBench runner. |
+| No artifacts produced | Confirm that the scenario file references `TBENCH_OUTPUT_DIR` or the configured results path. |
+
+With these steps, VTCode becomes an orchestrator for the Terminal Benchmark suite, providing a
+repeatable way to evaluate agent performance directly from the CLI.

--- a/src/cli/benchmark.rs
+++ b/src/cli/benchmark.rs
@@ -78,9 +78,9 @@ pub async fn handle_benchmark_command(config: &VTCodeConfig, workspace: &Path) -
         command_builder.env(key, value);
     }
 
-    for key in &tbench_cfg.passthrough_env {
-        if let Ok(value) = std::env::var(key) {
-            command_builder.env(key, value);
+    for key in tbench_cfg.resolved_passthrough_env() {
+        if let Ok(value) = std::env::var(&key) {
+            command_builder.env(&key, value);
         }
     }
 

--- a/src/cli/benchmark.rs
+++ b/src/cli/benchmark.rs
@@ -1,8 +1,285 @@
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use console::style;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::fs::{self, OpenOptions};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use vtcode_core::config::TBenchConfig;
+use vtcode_core::config::constants::benchmarks::env;
+use vtcode_core::config::loader::VTCodeConfig;
 
-pub async fn handle_benchmark_command() -> Result<()> {
-    println!("{}", style("Benchmark (SWE-bench stub)").blue().bold());
-    println!("Benchmarking not implemented yet.");
+const TBENCH_GUIDE_PATH: &str = "docs/guides/tbench-terminal-benchmark.md";
+
+pub async fn handle_benchmark_command(config: &VTCodeConfig, workspace: &Path) -> Result<()> {
+    println!(
+        "{}",
+        style("Terminal Benchmark (TBench) integration")
+            .blue()
+            .bold()
+    );
+
+    let tbench_cfg = &config.benchmark.tbench;
+    if !tbench_cfg.enabled {
+        println!(
+            "{}",
+            style("TBench integration is disabled in vtcode.toml ([benchmark.tbench]).").yellow()
+        );
+        println!("{} {}", style("See guide:").cyan(), TBENCH_GUIDE_PATH);
+        return Ok(());
+    }
+
+    let command = tbench_cfg.resolved_command().with_context(|| {
+        format!(
+            "Unable to determine benchmark CLI command. Set `command` or define the `{}` \
+             environment variable in [benchmark.tbench].",
+            tbench_cfg.command_env
+        )
+    })?;
+
+    let working_dir = resolve_path(workspace, tbench_cfg.working_directory.as_ref());
+    if fs::metadata(&working_dir).await.is_err() {
+        bail!(
+            "Benchmark working directory '{}' does not exist",
+            working_dir.display()
+        );
+    }
+
+    let (resolved_config, resolved_results, log_writer, log_path) =
+        prepare_runtime_paths(workspace, tbench_cfg).await?;
+
+    let mut command_builder = Command::new(&command);
+    command_builder
+        .args(&tbench_cfg.args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(&working_dir);
+
+    if tbench_cfg.attach_workspace_env {
+        command_builder.env(env::WORKSPACE_DIR, workspace);
+    }
+
+    if let Some(config_path) = &resolved_config {
+        command_builder.env(env::TBENCH_CONFIG, config_path);
+    }
+
+    if let Some(results_path) = &resolved_results {
+        command_builder.env(env::TBENCH_OUTPUT_DIR, results_path);
+    }
+
+    if let Some(log_path) = &log_path {
+        command_builder.env(env::TBENCH_RUN_LOG, log_path);
+    }
+
+    for (key, value) in &tbench_cfg.env {
+        command_builder.env(key, value);
+    }
+
+    for key in &tbench_cfg.passthrough_env {
+        if let Ok(value) = std::env::var(key) {
+            command_builder.env(key, value);
+        }
+    }
+
+    println!(
+        "{} {}",
+        style("Command:").cyan(),
+        format_command(&command, &tbench_cfg.args)
+    );
+    if let Some(config_path) = &resolved_config {
+        println!("{} {}", style("Scenario:").cyan(), config_path.display());
+    }
+    if let Some(results_path) = &resolved_results {
+        println!(
+            "{} {}",
+            style("Results dir:").cyan(),
+            results_path.display()
+        );
+    }
+    if let Some(log_path) = &log_path {
+        println!("{} {}", style("Log file:").cyan(), log_path.display());
+    }
+
+    let mut child = command_builder
+        .spawn()
+        .with_context(|| format!("Failed to launch benchmark command '{}'.", command))?;
+
+    let stdout_handle = if let Some(stdout) = child.stdout.take() {
+        let log = log_writer.clone();
+        Some(tokio::spawn(async move {
+            forward_stream(stdout, StreamKind::Stdout, log).await
+        }))
+    } else {
+        None
+    };
+
+    let stderr_handle = if let Some(stderr) = child.stderr.take() {
+        let log = log_writer.clone();
+        Some(tokio::spawn(async move {
+            forward_stream(stderr, StreamKind::Stderr, log).await
+        }))
+    } else {
+        None
+    };
+
+    if let Some(handle) = stdout_handle {
+        handle
+            .await
+            .context("Failed to process benchmark stdout stream")??;
+    }
+
+    if let Some(handle) = stderr_handle {
+        handle
+            .await
+            .context("Failed to process benchmark stderr stream")??;
+    }
+
+    let status = child
+        .wait()
+        .await
+        .with_context(|| format!("Failed while awaiting benchmark command '{}'.", command))?;
+
+    if status.success() {
+        println!("{}", style("Benchmark run completed successfully.").green());
+        Ok(())
+    } else if let Some(code) = status.code() {
+        bail!("Benchmark process exited with status code {}.", code);
+    } else {
+        bail!("Benchmark process terminated by signal.");
+    }
+}
+
+fn resolve_path(base: &Path, candidate: Option<&PathBuf>) -> PathBuf {
+    match candidate {
+        Some(path) if path.is_absolute() => path.clone(),
+        Some(path) => base.join(path),
+        None => base.to_path_buf(),
+    }
+}
+
+fn resolve_optional_file(base: &Path, candidate: &Path) -> PathBuf {
+    if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        base.join(candidate)
+    }
+}
+
+async fn prepare_runtime_paths(
+    workspace: &Path,
+    cfg: &TBenchConfig,
+) -> Result<(
+    Option<PathBuf>,
+    Option<PathBuf>,
+    Option<Arc<Mutex<tokio::fs::File>>>,
+    Option<PathBuf>,
+)> {
+    let resolved_config = if let Some(config_path) = &cfg.config_path {
+        let resolved = resolve_optional_file(workspace, config_path);
+        fs::metadata(&resolved)
+            .await
+            .with_context(|| format!("TBench scenario file '{}' not found", resolved.display()))?;
+        Some(resolved)
+    } else {
+        None
+    };
+
+    let resolved_results = if let Some(results_dir) = &cfg.results_dir {
+        let resolved = resolve_optional_file(workspace, results_dir);
+        fs::create_dir_all(&resolved).await.with_context(|| {
+            format!(
+                "Failed to create results directory '{}'",
+                resolved.display()
+            )
+        })?;
+        Some(resolved)
+    } else {
+        None
+    };
+
+    let (log_writer, log_path) = if let Some(run_log) = &cfg.run_log {
+        let resolved = resolve_optional_file(workspace, run_log);
+        if let Some(parent) = resolved.parent() {
+            fs::create_dir_all(parent).await.with_context(|| {
+                format!("Failed to create log directory '{}'", parent.display())
+            })?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&resolved)
+            .await
+            .with_context(|| format!("Failed to create log file '{}'", resolved.display()))?;
+        (Some(Arc::new(Mutex::new(file))), Some(resolved))
+    } else {
+        (None, None)
+    };
+
+    Ok((resolved_config, resolved_results, log_writer, log_path))
+}
+
+async fn forward_stream<R>(
+    mut reader: R,
+    kind: StreamKind,
+    log: Option<Arc<Mutex<tokio::fs::File>>>,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = [0_u8; 4096];
+
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+
+        match kind {
+            StreamKind::Stdout => {
+                let mut writer = tokio::io::stdout();
+                writer.write_all(&buffer[..read]).await?;
+                writer.flush().await?;
+            }
+            StreamKind::Stderr => {
+                let mut writer = tokio::io::stderr();
+                writer.write_all(&buffer[..read]).await?;
+                writer.flush().await?;
+            }
+        }
+
+        if let Some(file) = &log {
+            let mut guard = file.lock().await;
+            guard.write_all(kind.log_prefix()).await?;
+            guard.write_all(&buffer[..read]).await?;
+            guard.flush().await?;
+        }
+    }
+
     Ok(())
+}
+
+enum StreamKind {
+    Stdout,
+    Stderr,
+}
+
+impl StreamKind {
+    fn log_prefix(&self) -> &'static [u8] {
+        match self {
+            Self::Stdout => b"[stdout] ",
+            Self::Stderr => b"[stderr] ",
+        }
+    }
+}
+
+fn format_command(command: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        command.to_string()
+    } else {
+        format!("{} {}", command, args.join(" "))
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ async fn main() -> Result<()> {
             cli::handle_init_project_command(name.clone(), *force, *migrate).await?;
         }
         Some(Commands::Benchmark) => {
-            cli::handle_benchmark_command().await?;
+            cli::handle_benchmark_command(&cfg, &workspace).await?;
         }
         Some(Commands::Man { command, output }) => {
             cli::handle_man_command(command.clone(), output.clone()).await?;

--- a/vtcode-core/src/cli/man_pages.rs
+++ b/vtcode-core/src/cli/man_pages.rs
@@ -392,6 +392,14 @@ impl ManPageGenerator {
             .text([roman(
                 "Creates result directories before invoking the benchmark",
             )])
+            .control("TP", [])
+            .text([bold("Provider credential passthrough")])
+            .text([
+                roman(
+                    "Bridges API keys (Gemini, OpenAI, Anthropic, OpenRouter, DeepSeek, xAI) via",
+                ),
+                roman(" [benchmark.tbench].providers without duplicating passthrough entries"),
+            ])
             .control("SH", ["EXAMPLES"])
             .text([roman("Run configured TBench benchmark:")])
             .text([bold("  vtcode benchmark")])

--- a/vtcode-core/src/cli/man_pages.rs
+++ b/vtcode-core/src/cli/man_pages.rs
@@ -355,7 +355,7 @@ impl ManPageGenerator {
             )
             .control("SH", ["NAME"])
             .text([roman(
-                "vtcode-benchmark - Run SWE-bench evaluation framework",
+                "vtcode-benchmark - Launch Terminal Benchmark (TBench) runner",
             )])
             .control("SH", ["SYNOPSIS"])
             .text([
@@ -367,28 +367,38 @@ impl ManPageGenerator {
             ])
             .control("SH", ["DESCRIPTION"])
             .text([
-                roman(
-                    "Run automated performance testing against the SWE-bench evaluation framework.",
-                ),
-                roman(" Provides comparative analysis across different models, benchmark scoring,"),
-                roman(" and optimization insights for coding tasks."),
+                roman("Execute the Terminal Benchmark (TBench) CLI using workspace configuration."),
+                roman(" Streams benchmark output, injects VTCode workspace metadata, and manages"),
+                roman(" environment variables required by the evaluation harness."),
             ])
             .control("SH", ["FEATURES"])
             .control("TP", [])
-            .text([bold("Automated Testing")])
-            .text([roman("Run standardized coding tasks and challenges")])
+            .text([bold("Config-driven launch")])
+            .text([roman(
+                "Resolves CLI, arguments, and scenarios from [benchmark.tbench] settings",
+            )])
             .control("TP", [])
-            .text([bold("Comparative Analysis")])
-            .text([roman("Compare performance across different models")])
+            .text([bold("Workspace metadata injection")])
+            .text([roman(
+                "Exports workspace paths and optional scenario artifacts for the runner",
+            )])
             .control("TP", [])
-            .text([bold("Benchmark Scoring")])
-            .text([roman("Quantitative performance metrics and scores")])
+            .text([bold("Streaming logs")])
+            .text([roman(
+                "Mirrors stdout/stderr locally and optionally captures them to a log file",
+            )])
             .control("TP", [])
-            .text([bold("Optimization Insights")])
-            .text([roman("Recommendations for performance improvements")])
+            .text([bold("Artifact management")])
+            .text([roman(
+                "Creates result directories before invoking the benchmark",
+            )])
             .control("SH", ["EXAMPLES"])
-            .text([roman("Run benchmark suite:")])
+            .text([roman("Run configured TBench benchmark:")])
             .text([bold("  vtcode benchmark")])
+            .text([roman(
+                "Ensure [benchmark.tbench] is enabled and references the TBench CLI per",
+            )])
+            .text([roman(" docs/guides/tbench-terminal-benchmark.md.")])
             .control("SH", ["SEE ALSO"])
             .text([
                 bold("vtcode(1)"),

--- a/vtcode-core/src/config/benchmarks.rs
+++ b/vtcode-core/src/config/benchmarks.rs
@@ -1,0 +1,112 @@
+use crate::config::constants::benchmarks::env;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+fn default_enabled() -> bool {
+    false
+}
+
+fn default_command_env_var() -> String {
+    env::TBENCH_CLI.to_string()
+}
+
+fn default_attach_workspace_env() -> bool {
+    true
+}
+
+/// Top-level benchmark configuration wrapper
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BenchmarkConfig {
+    /// Terminal benchmark (TBench) execution settings
+    #[serde(default)]
+    pub tbench: TBenchConfig,
+}
+
+impl Default for BenchmarkConfig {
+    fn default() -> Self {
+        Self {
+            tbench: TBenchConfig::default(),
+        }
+    }
+}
+
+/// Configuration for launching Terminal Benchmark (TBench) runs
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TBenchConfig {
+    /// Toggle to enable the benchmark command
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Explicit command to execute (takes precedence over environment variable)
+    #[serde(default)]
+    pub command: Option<String>,
+
+    /// Environment variable that resolves the benchmark CLI path when `command` is unset
+    #[serde(default = "default_command_env_var")]
+    pub command_env: String,
+
+    /// Arguments passed to the benchmark CLI
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Optional path to a TBench scenario/config file
+    #[serde(default)]
+    pub config_path: Option<PathBuf>,
+
+    /// Directory to execute the benchmark command from (defaults to workspace)
+    #[serde(default)]
+    pub working_directory: Option<PathBuf>,
+
+    /// Directory where benchmark artifacts/logs should be written (created automatically)
+    #[serde(default)]
+    pub results_dir: Option<PathBuf>,
+
+    /// Optional path to capture combined stdout/stderr from the benchmark runner
+    #[serde(default)]
+    pub run_log: Option<PathBuf>,
+
+    /// Additional environment variables injected into the benchmark process
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+
+    /// Environment variable keys to pass through from the current process if present
+    #[serde(default)]
+    pub passthrough_env: Vec<String>,
+
+    /// Whether to inject VTCode workspace metadata environment variables
+    #[serde(default = "default_attach_workspace_env")]
+    pub attach_workspace_env: bool,
+}
+
+impl Default for TBenchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            command: None,
+            command_env: default_command_env_var(),
+            args: Vec::new(),
+            config_path: None,
+            working_directory: None,
+            results_dir: None,
+            run_log: None,
+            env: HashMap::new(),
+            passthrough_env: Vec::new(),
+            attach_workspace_env: default_attach_workspace_env(),
+        }
+    }
+}
+
+impl TBenchConfig {
+    /// Determine the command used to launch TBench, preferring explicit configuration
+    pub fn resolved_command(&self) -> Option<String> {
+        if let Some(command) = &self.command {
+            if !command.trim().is_empty() {
+                return Some(command.clone());
+            }
+        }
+
+        let env_value = std::env::var(&self.command_env).ok();
+        env_value.filter(|value| !value.trim().is_empty())
+    }
+}

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -4,6 +4,17 @@ pub mod prompts {
     pub const CODER_SYSTEM_PROMPT_PATH: &str = "prompts/coder_system.md";
 }
 
+/// Benchmark integration environment variable constants
+pub mod benchmarks {
+    pub mod env {
+        pub const TBENCH_CLI: &str = "TBENCH_CLI";
+        pub const TBENCH_CONFIG: &str = "TBENCH_CONFIG";
+        pub const TBENCH_OUTPUT_DIR: &str = "TBENCH_OUTPUT_DIR";
+        pub const TBENCH_RUN_LOG: &str = "TBENCH_RUN_LOG";
+        pub const WORKSPACE_DIR: &str = "VT_CODE_WORKSPACE";
+    }
+}
+
 /// Model ID constants to sync with docs/models.json
 pub mod models {
     // Google/Gemini models

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -15,6 +15,16 @@ pub mod benchmarks {
     }
 }
 
+/// API key environment variables
+pub mod api_keys {
+    pub const GEMINI: &str = "GEMINI_API_KEY";
+    pub const ANTHROPIC: &str = "ANTHROPIC_API_KEY";
+    pub const OPENAI: &str = "OPENAI_API_KEY";
+    pub const OPENROUTER: &str = "OPENROUTER_API_KEY";
+    pub const XAI: &str = "XAI_API_KEY";
+    pub const DEEPSEEK: &str = "DEEPSEEK_API_KEY";
+}
+
 /// Model ID constants to sync with docs/models.json
 pub mod models {
     // Google/Gemini models

--- a/vtcode-core/src/config/loader/mod.rs
+++ b/vtcode-core/src/config/loader/mod.rs
@@ -1,3 +1,4 @@
+use crate::config::benchmarks::BenchmarkConfig;
 use crate::config::context::ContextFeaturesConfig;
 use crate::config::core::{
     AgentConfig, AutomationConfig, CommandsConfig, PromptCachingConfig, SecurityConfig, ToolsConfig,
@@ -138,6 +139,10 @@ pub struct VTCodeConfig {
     /// Model Context Protocol configuration
     #[serde(default)]
     pub mcp: McpClientConfig,
+
+    /// Benchmark integrations configuration
+    #[serde(default)]
+    pub benchmark: BenchmarkConfig,
 }
 
 impl Default for VTCodeConfig {
@@ -156,6 +161,7 @@ impl Default for VTCodeConfig {
             automation: AutomationConfig::default(),
             prompt_cache: PromptCachingConfig::default(),
             mcp: McpClientConfig::default(),
+            benchmark: BenchmarkConfig::default(),
         }
     }
 }

--- a/vtcode-core/src/config/mod.rs
+++ b/vtcode-core/src/config/mod.rs
@@ -185,7 +185,7 @@ pub mod telemetry;
 pub mod types;
 
 // Re-export main types for backward compatibility
-pub use benchmarks::{BenchmarkConfig, TBenchConfig};
+pub use benchmarks::{BenchmarkConfig, BenchmarkProvider, TBenchConfig};
 pub use context::{ContextFeaturesConfig, LedgerConfig};
 pub use core::{
     AgentConfig, AutomationConfig, CommandsConfig, FullAutoConfig, SecurityConfig, ToolPolicy,

--- a/vtcode-core/src/config/mod.rs
+++ b/vtcode-core/src/config/mod.rs
@@ -172,6 +172,7 @@
 //! command allow lists.
 
 pub mod api_keys;
+pub mod benchmarks;
 pub mod constants;
 pub mod context;
 pub mod core;
@@ -184,6 +185,7 @@ pub mod telemetry;
 pub mod types;
 
 // Re-export main types for backward compatibility
+pub use benchmarks::{BenchmarkConfig, TBenchConfig};
 pub use context::{ContextFeaturesConfig, LedgerConfig};
 pub use core::{
     AgentConfig, AutomationConfig, CommandsConfig, FullAutoConfig, SecurityConfig, ToolPolicy,

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -154,3 +154,16 @@ max_concurrent_requests = 3
 # protocol_version = "2024-11-05"
 # headers = { "Content-Type" = "application/json", "User-Agent" = "vtcode-mcp-client" }
 # max_concurrent_requests = 2
+
+[benchmark.tbench]
+# Enable Terminal Benchmark (TBench) integration via `vtcode benchmark`
+enabled = false
+# command = "/usr/local/bin/tbench"          # Explicit CLI path (optional when command_env is set)
+command_env = "TBENCH_CLI"                    # Environment variable containing the CLI path
+args = []
+# config_path = "benchmarks/vtcode.yaml"      # Scenario file passed to the TBench runner
+# results_dir = "benchmarks/results"          # Directory to store benchmark artifacts
+# run_log = "benchmarks/logs/latest.log"      # Capture stdout/stderr into a log file
+attach_workspace_env = true
+env = {}
+passthrough_env = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"]

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -165,5 +165,6 @@ args = []
 # results_dir = "benchmarks/results"          # Directory to store benchmark artifacts
 # run_log = "benchmarks/logs/latest.log"      # Capture stdout/stderr into a log file
 attach_workspace_env = true
+providers = ["gemini", "openai", "anthropic", "openrouter"]
 env = {}
-passthrough_env = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"]
+passthrough_env = ["TBENCH_API_KEY"]

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -220,3 +220,16 @@ enabled_languages = [
 
 # Performance settings
 highlight_timeout_ms = 5000
+
+[benchmark.tbench]
+# Enable Terminal Benchmark (TBench) integration via `vtcode benchmark`
+enabled = false
+# command = "/usr/local/bin/tbench"          # Explicit CLI path (optional when command_env is set)
+command_env = "TBENCH_CLI"                    # Environment variable containing the CLI path
+args = []
+# config_path = "benchmarks/vtcode.yaml"      # Scenario file passed to the TBench runner
+# results_dir = "benchmarks/results"          # Directory to store benchmark artifacts
+# run_log = "benchmarks/logs/latest.log"      # Capture stdout/stderr into a log file
+attach_workspace_env = true
+env = {}
+passthrough_env = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"]

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -231,5 +231,6 @@ args = []
 # results_dir = "benchmarks/results"          # Directory to store benchmark artifacts
 # run_log = "benchmarks/logs/latest.log"      # Capture stdout/stderr into a log file
 attach_workspace_env = true
+providers = ["gemini", "openai", "anthropic", "openrouter"]
 env = {}
-passthrough_env = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"]
+passthrough_env = ["TBENCH_API_KEY"]


### PR DESCRIPTION
## Summary
- add benchmark configuration structs and CLI support to launch the Terminal Benchmark runner with streaming output handling
- document TBench setup and surface configuration options in the sample vtcode.toml files
- refresh the manual entry to describe the benchmark workflow

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68df8935926c8323a9f84b7fb7b70e98