### PR TITLE
Add Zed Agent Client Protocol integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,6 +4007,7 @@ dependencies = [
  "lru",
  "once_cell",
  "pathdiff",
+ "percent-encoding",
  "rand 0.8.5",
  "ratatui",
  "rayon",
@@ -4035,6 +4036,7 @@ dependencies = [
  "tree-sitter-typescript",
  "unicode-width 0.1.14",
  "update-informer",
+ "url",
  "vtcode-core",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d24bcd53c5ff2c9c75c2d378e8a4efd6519e79e62eebc7dedd36f356f79f48"
+dependencies = [
+ "anyhow",
+ "async-broadcast",
+ "async-trait",
+ "futures",
+ "log",
+ "parking_lot",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +214,18 @@ dependencies = [
  "blake2",
  "cpufeatures",
  "password-hash",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -535,6 +564,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1094,6 +1132,27 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2182,6 +2241,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3492,6 +3557,7 @@ checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3913,6 +3979,7 @@ name = "vtcode"
 version = "0.19.0"
 dependencies = [
  "aes-gcm",
+ "agent-client-protocol",
  "anstream",
  "anstyle",
  "anstyle-git",
@@ -3956,6 +4023,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,8 @@ colorchoice = "1.0"
 anstyle-git = "1.1"
 anstyle-ls = "1.0"
 agent-client-protocol = "0.4.5"
+percent-encoding = "2.3"
+url = "2.5"
 
 [features]
 default = ["tool-chat"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { version = "1.37", features = [
     "rt-multi-thread",
     "sync",
 ] }
+tokio-util = { version = "0.7", features = ["compat"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
@@ -101,6 +102,7 @@ syntect = "5.2"
 colorchoice = "1.0"
 anstyle-git = "1.1"
 anstyle-ls = "1.0"
+agent-client-protocol = "0.4.5"
 
 [features]
 default = ["tool-chat"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ vtcode --provider openai --model gpt-5-codex ask "Refactor async fn in src/lib.r
 vtcode --debug --no-tools ask "Compute token budget for current context"  # Dry-run analysis
 ```
 
+### Zed IDE integration (Agent Client Protocol)
+1. Enable the ACP bridge by setting `acp.enabled = true` and `acp.zed.enabled = true` in `vtcode.toml` (or export `VT_ACP_ENABLED=1` and `VT_ACP_ZED_ENABLED=1`).
+2. Start the stdio bridge from the workspace root:
+
+   ```bash
+   vtcode acp  # exposes Agent Client Protocol over stdio for Zed
+   ```
+
+3. In Zed, add a custom Agent Client Protocol integration pointing to the `vtcode acp` command.
+
+The bridge streams reasoning and assistant output tokens back to Zed while reusing the model and prompt cache configuration declared in `vtcode.toml`.
+
 Configuration validation: On load, checks TOML against schema (e.g., model in `docs/models.json`); logs warnings for deprecated keys.
 
 ## Command-Line Interface
@@ -147,7 +159,6 @@ SUBCOMMANDS:
         --debug                  Enable verbose logging and metrics
         --help                   Print usage
 ```
-
 Development runs: `./run.sh` (release profile: lto=true, codegen-units=1 for opt); `./run-debug.sh` (debug symbols, hot-reload via cargo-watch).
 
 ## Development Practices

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -1,0 +1,75 @@
+# Zed Agent Client Protocol Integration
+
+This guide explains how VT Code exposes the Agent Client Protocol (ACP) bridge for the Zed
+editor. The bridge follows the reference implementations in
+[`zed-industries/claude-code-acp`](https://github.com/zed-industries/claude-code-acp) and
+[`cola-io/codex-acp`](https://github.com/cola-io/codex-acp), along with the ACP client guidance
+from [Goose](https://block.github.io/goose/docs/guides/acp-clients/).
+
+## Prerequisites
+
+- VT Code built from source or downloaded from a release that includes the ACP module.
+- Zed `v0.168` or newer with the Agent Client Protocol beta enabled.
+- A valid model and API key configured in `vtcode.toml`.
+
+## Configuration
+
+1. Open `vtcode.toml` (or `vtcode.toml.example`) and enable the ACP bridge:
+
+   ```toml
+   [acp]
+   enabled = true
+
+   [acp.zed]
+   enabled = true
+   transport = "stdio"
+   ```
+
+   Environment variables override these settings at runtime:
+
+   | Variable             | Description                          |
+   | -------------------- | ------------------------------------ |
+   | `VT_ACP_ENABLED`     | Enables or disables the ACP bridge.  |
+   | `VT_ACP_ZED_ENABLED` | Controls the Zed-specific transport. |
+
+2. Launch VT Code with the new subcommand:
+
+   ```bash
+   vtcode acp --target zed
+   ```
+
+3. In Zed, add a new Agent connection pointing at the VT Code binary. Use the `stdio` transport
+   and leave the command arguments empty. Zed will manage the lifecycle of the VT Code process.
+
+## Runtime behaviour
+
+- **Session management** – Each prompt creates a dedicated ACP session with history stored inside
+  the VT Code agent, mirroring the approach used by the Claude and Codex bridges.
+- **Context ingestion** – Linked resources with `file://`, `zed://`, or `zed-fs://` URIs are
+  resolved through Zed's `fs.readTextFile` capability, keeping the prompt text aligned with the
+  Goose ACP client guidelines.
+- **Embedded resources** – Inline text resources are wrapped in `<context>` blocks so models can
+  differentiate between primary instructions and supporting context. Binary resources are noted
+  but omitted from the language model input.
+- **Streaming updates** – Token and reasoning deltas are streamed via `session/update`
+  notifications, providing incremental feedback during generation.
+- **Graceful degradation** – Unsupported content types (images, audio, binary resources) emit
+  structured placeholders rather than failing the prompt turn, matching the behaviour in the
+  reference implementations.
+
+## Troubleshooting
+
+| Symptom                                   | Resolution |
+| ----------------------------------------- | ---------- |
+| `Only the stdio transport is supported`   | Confirm `transport = "stdio"` in the config. |
+| Zed shows empty responses                 | Set both env vars or enable ACP in the config file. |
+| File links resolve to placeholders        | Confirm the URI is reachable and VT Code can read the workspace. |
+| Prompt turns cancel unexpectedly          | Check the VT Code logs for cancellations triggered by the Zed client. |
+
+## Next steps
+
+- Extend the bridge with MCP tool forwarding when the workspace requires filesystem editing or
+  terminal execution.
+- Advertise session modes and commands once ACP clients expose richer UI affordances.
+- Share feedback or issues in the VT Code repository so the integration can track upstream ACP
+  improvements.

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,0 +1,3 @@
+mod zed;
+
+pub use zed::run_zed_agent;

--- a/src/acp/zed.rs
+++ b/src/acp/zed.rs
@@ -500,6 +500,13 @@ impl acp::Agent for ZedAgent {
                 .await
                 .map_err(acp::Error::into_internal_error)?;
 
+            if session.cancel_flag.get() {
+                return Ok(acp::PromptResponse {
+                    stop_reason: acp::StopReason::Cancelled,
+                    meta: None,
+                });
+            }
+
             if let Some(content) = response.content.clone() {
                 if !content.is_empty() {
                     self.send_update(

--- a/src/acp/zed.rs
+++ b/src/acp/zed.rs
@@ -1,0 +1,405 @@
+use agent_client_protocol as acp;
+use agent_client_protocol::Client;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::json;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use tracing::error;
+
+use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
+use vtcode_core::llm::factory::{create_provider_for_model, create_provider_with_config};
+use vtcode_core::llm::provider::{FinishReason, LLMRequest, LLMStreamEvent, Message, ToolChoice};
+use vtcode_core::prompts::read_system_prompt_from_md;
+
+const SESSION_PREFIX: &str = "vtcode-zed-session";
+
+#[derive(Clone)]
+struct SessionHandle {
+    data: Rc<RefCell<SessionData>>,
+    cancel_flag: Rc<Cell<bool>>,
+}
+
+struct SessionData {
+    messages: Vec<Message>,
+}
+
+struct NotificationEnvelope {
+    notification: acp::SessionNotification,
+    completion: oneshot::Sender<()>,
+}
+
+pub async fn run_zed_agent(config: &CoreAgentConfig) -> Result<()> {
+    let outgoing = tokio::io::stdout().compat_write();
+    let incoming = tokio::io::stdin().compat();
+    let system_prompt = read_system_prompt_from_md().unwrap_or_else(|_| String::new());
+
+    let local_set = tokio::task::LocalSet::new();
+    let config_clone = config.clone();
+
+    local_set
+        .run_until(async move {
+            let (tx, mut rx) = mpsc::unbounded_channel::<NotificationEnvelope>();
+            let agent = ZedAgent::new(config_clone, system_prompt, tx);
+            let (conn, io_task) = acp::AgentSideConnection::new(agent, outgoing, incoming, |fut| {
+                tokio::task::spawn_local(fut);
+            });
+
+            let notifications = tokio::task::spawn_local(async move {
+                while let Some(envelope) = rx.recv().await {
+                    let result = conn.session_notification(envelope.notification).await;
+                    if let Err(error) = result {
+                        error!(%error, "Failed to forward ACP session notification");
+                    }
+                    let _ = envelope.completion.send(());
+                }
+            });
+
+            let io_result = io_task.await;
+            notifications.abort();
+            io_result
+        })
+        .await
+        .context("ACP stdio bridge task failed")?;
+
+    Ok(())
+}
+
+struct ZedAgent {
+    config: CoreAgentConfig,
+    system_prompt: String,
+    sessions: Rc<RefCell<HashMap<acp::SessionId, SessionHandle>>>,
+    next_session_id: Cell<u64>,
+    session_update_tx: mpsc::UnboundedSender<NotificationEnvelope>,
+}
+
+impl ZedAgent {
+    fn new(
+        config: CoreAgentConfig,
+        system_prompt: String,
+        session_update_tx: mpsc::UnboundedSender<NotificationEnvelope>,
+    ) -> Self {
+        Self {
+            config,
+            system_prompt,
+            sessions: Rc::new(RefCell::new(HashMap::new())),
+            next_session_id: Cell::new(0),
+            session_update_tx,
+        }
+    }
+
+    fn register_session(&self) -> acp::SessionId {
+        let raw_id = self.next_session_id.get();
+        self.next_session_id.set(raw_id + 1);
+        let session_id = acp::SessionId(Arc::from(format!("{SESSION_PREFIX}-{raw_id}")));
+        let handle = SessionHandle {
+            data: Rc::new(RefCell::new(SessionData {
+                messages: Vec::new(),
+            })),
+            cancel_flag: Rc::new(Cell::new(false)),
+        };
+        self.sessions
+            .borrow_mut()
+            .insert(session_id.clone(), handle);
+        session_id
+    }
+
+    fn session_handle(&self, session_id: &acp::SessionId) -> Option<SessionHandle> {
+        self.sessions.borrow().get(session_id).cloned()
+    }
+
+    fn push_message(&self, session: &SessionHandle, message: Message) {
+        session.data.borrow_mut().messages.push(message);
+    }
+
+    fn resolved_messages(&self, session: &SessionHandle) -> Vec<Message> {
+        let mut messages = Vec::new();
+        if !self.system_prompt.trim().is_empty() {
+            messages.push(Message::system(self.system_prompt.clone()));
+        }
+
+        let history = session.data.borrow();
+        messages.extend(history.messages.iter().cloned());
+        messages
+    }
+
+    fn stop_reason_from_finish(finish: FinishReason) -> acp::StopReason {
+        match finish {
+            FinishReason::Stop | FinishReason::ToolCalls => acp::StopReason::EndTurn,
+            FinishReason::Length => acp::StopReason::MaxTokens,
+            FinishReason::ContentFilter | FinishReason::Error(_) => acp::StopReason::Refusal,
+        }
+    }
+
+    fn join_prompt(prompt: &[acp::ContentBlock]) -> Result<String, acp::Error> {
+        let mut aggregated = String::new();
+
+        for block in prompt {
+            match block {
+                acp::ContentBlock::Text(text) => aggregated.push_str(&text.text),
+                acp::ContentBlock::ResourceLink(link) => {
+                    if !aggregated.is_empty() {
+                        aggregated.push('\n');
+                    }
+                    aggregated.push_str(&format!("Resource {} ({})", link.name, link.uri));
+                }
+                acp::ContentBlock::Resource(resource) => match &resource.resource {
+                    acp::EmbeddedResourceResource::TextResourceContents(text) => {
+                        if !aggregated.is_empty() {
+                            aggregated.push('\n');
+                        }
+                        aggregated.push_str(&text.text);
+                    }
+                    _ => {
+                        return Err(acp::Error::invalid_params()
+                            .with_data(json!({ "reason": "unsupported_resource" })));
+                    }
+                },
+                _ => {
+                    return Err(acp::Error::invalid_params()
+                        .with_data(json!({ "reason": "unsupported_content" })));
+                }
+            }
+        }
+
+        Ok(aggregated)
+    }
+
+    async fn send_update(
+        &self,
+        session_id: &acp::SessionId,
+        update: acp::SessionUpdate,
+    ) -> Result<(), acp::Error> {
+        let (completion, completion_rx) = oneshot::channel();
+        let notification = acp::SessionNotification {
+            session_id: session_id.clone(),
+            update,
+            meta: None,
+        };
+
+        self.session_update_tx
+            .send(NotificationEnvelope {
+                notification,
+                completion,
+            })
+            .map_err(|_| acp::Error::internal_error())?;
+
+        completion_rx
+            .await
+            .map_err(|_| acp::Error::internal_error())
+    }
+}
+
+#[async_trait(?Send)]
+impl acp::Agent for ZedAgent {
+    async fn initialize(
+        &self,
+        _args: acp::InitializeRequest,
+    ) -> Result<acp::InitializeResponse, acp::Error> {
+        Ok(acp::InitializeResponse {
+            protocol_version: acp::V1,
+            agent_capabilities: acp::AgentCapabilities::default(),
+            auth_methods: Vec::new(),
+            meta: None,
+        })
+    }
+
+    async fn authenticate(
+        &self,
+        _args: acp::AuthenticateRequest,
+    ) -> Result<acp::AuthenticateResponse, acp::Error> {
+        Ok(acp::AuthenticateResponse::default())
+    }
+
+    async fn new_session(
+        &self,
+        _args: acp::NewSessionRequest,
+    ) -> Result<acp::NewSessionResponse, acp::Error> {
+        let session_id = self.register_session();
+        Ok(acp::NewSessionResponse {
+            session_id,
+            modes: None,
+            meta: None,
+        })
+    }
+
+    async fn prompt(&self, args: acp::PromptRequest) -> Result<acp::PromptResponse, acp::Error> {
+        let Some(session) = self.session_handle(&args.session_id) else {
+            return Err(
+                acp::Error::invalid_params().with_data(json!({ "reason": "unknown_session" }))
+            );
+        };
+
+        session.cancel_flag.set(false);
+
+        let user_message = Self::join_prompt(&args.prompt)?;
+        self.push_message(&session, Message::user(user_message.clone()));
+
+        let provider = match create_provider_for_model(
+            &self.config.model,
+            self.config.api_key.clone(),
+            Some(self.config.prompt_cache.clone()),
+        ) {
+            Ok(provider) => provider,
+            Err(_) => create_provider_with_config(
+                &self.config.provider,
+                Some(self.config.api_key.clone()),
+                None,
+                Some(self.config.model.clone()),
+                Some(self.config.prompt_cache.clone()),
+            )
+            .map_err(acp::Error::into_internal_error)?,
+        };
+
+        let supports_streaming = provider.supports_streaming();
+        let reasoning_effort = if provider.supports_reasoning_effort(&self.config.model) {
+            Some(self.config.reasoning_effort.as_str().to_string())
+        } else {
+            None
+        };
+
+        let messages = self.resolved_messages(&session);
+        let request = LLMRequest {
+            messages,
+            system_prompt: None,
+            tools: None,
+            model: self.config.model.clone(),
+            max_tokens: None,
+            temperature: None,
+            stream: supports_streaming,
+            tool_choice: Some(ToolChoice::none()),
+            parallel_tool_calls: None,
+            parallel_tool_config: None,
+            reasoning_effort,
+        };
+
+        let mut stop_reason = acp::StopReason::EndTurn;
+        let mut assistant_message = String::new();
+
+        if supports_streaming {
+            let mut stream = provider
+                .stream(request)
+                .await
+                .map_err(acp::Error::into_internal_error)?;
+
+            while let Some(event) = stream.next().await {
+                let event = event.map_err(acp::Error::into_internal_error)?;
+
+                if session.cancel_flag.get() {
+                    stop_reason = acp::StopReason::Cancelled;
+                    break;
+                }
+
+                match event {
+                    LLMStreamEvent::Token { delta } => {
+                        if !delta.is_empty() {
+                            assistant_message.push_str(&delta);
+                            self.send_update(
+                                &args.session_id,
+                                acp::SessionUpdate::AgentMessageChunk {
+                                    content: delta.into(),
+                                },
+                            )
+                            .await?;
+                        }
+                    }
+                    LLMStreamEvent::Reasoning { delta } => {
+                        if !delta.is_empty() {
+                            self.send_update(
+                                &args.session_id,
+                                acp::SessionUpdate::AgentThoughtChunk {
+                                    content: delta.into(),
+                                },
+                            )
+                            .await?;
+                        }
+                    }
+                    LLMStreamEvent::Completed { response } => {
+                        if let Some(content) = response.content {
+                            if assistant_message.is_empty() {
+                                assistant_message.push_str(&content);
+                                if !content.is_empty() {
+                                    self.send_update(
+                                        &args.session_id,
+                                        acp::SessionUpdate::AgentMessageChunk {
+                                            content: content.into(),
+                                        },
+                                    )
+                                    .await?;
+                                }
+                            }
+                        }
+
+                        if let Some(reasoning) = response.reasoning {
+                            if !reasoning.is_empty() {
+                                self.send_update(
+                                    &args.session_id,
+                                    acp::SessionUpdate::AgentThoughtChunk {
+                                        content: reasoning.into(),
+                                    },
+                                )
+                                .await?;
+                            }
+                        }
+
+                        stop_reason = Self::stop_reason_from_finish(response.finish_reason);
+                        break;
+                    }
+                }
+            }
+        } else {
+            let response = provider
+                .generate(request)
+                .await
+                .map_err(acp::Error::into_internal_error)?;
+
+            if let Some(content) = response.content.clone() {
+                if !content.is_empty() {
+                    self.send_update(
+                        &args.session_id,
+                        acp::SessionUpdate::AgentMessageChunk {
+                            content: content.clone().into(),
+                        },
+                    )
+                    .await?;
+                }
+                assistant_message = content;
+            }
+
+            if let Some(reasoning) = response.reasoning {
+                if !reasoning.is_empty() {
+                    self.send_update(
+                        &args.session_id,
+                        acp::SessionUpdate::AgentThoughtChunk {
+                            content: reasoning.into(),
+                        },
+                    )
+                    .await?;
+                }
+            }
+
+            stop_reason = Self::stop_reason_from_finish(response.finish_reason);
+        }
+
+        if stop_reason != acp::StopReason::Cancelled && !assistant_message.is_empty() {
+            self.push_message(&session, Message::assistant(assistant_message));
+        }
+
+        Ok(acp::PromptResponse {
+            stop_reason,
+            meta: None,
+        })
+    }
+
+    async fn cancel(&self, args: acp::CancelNotification) -> Result<(), acp::Error> {
+        if let Some(session) = self.session_handle(&args.session_id) {
+            session.cancel_flag.set(true);
+        }
+        Ok(())
+    }
+}

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -1,0 +1,34 @@
+use anyhow::{Result, bail};
+use vtcode_core::cli::args::AgentClientProtocolTarget;
+use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
+use vtcode_core::config::{AgentClientProtocolTransport, VTCodeConfig};
+
+pub async fn handle_acp_command(
+    config: &CoreAgentConfig,
+    vt_cfg: &VTCodeConfig,
+    target: AgentClientProtocolTarget,
+) -> Result<()> {
+    if !vt_cfg.acp.enabled {
+        bail!(
+            "Agent Client Protocol integration is disabled. Enable it via [acp] in vtcode.toml or set VT_ACP_ENABLED=1."
+        );
+    }
+
+    match target {
+        AgentClientProtocolTarget::Zed => {
+            if !vt_cfg.acp.zed.enabled {
+                bail!(
+                    "Zed integration is disabled. Enable it via [acp.zed] in vtcode.toml or set VT_ACP_ZED_ENABLED=1."
+                );
+            }
+
+            if vt_cfg.acp.zed.transport != AgentClientProtocolTransport::Stdio {
+                bail!("Only the stdio transport is currently supported for Zed ACP integration.");
+            }
+
+            crate::acp::run_zed_agent(config).await?
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command implementations with modular architecture
 
 // Feature-gated tool-capable chat; fallback to minimal REPL
+pub mod acp;
 pub mod analyze;
 pub mod ask;
 pub mod benchmark;
@@ -17,6 +18,7 @@ pub mod snapshots;
 pub mod trajectory;
 
 // Re-export command handlers for backward compatibility
+pub use acp::handle_acp_command;
 pub use analyze::handle_analyze_command;
 pub use ask::handle_ask_command as handle_ask_single_command;
 pub use benchmark::handle_benchmark_command;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, ModelSelectionS
 use vtcode_core::ui::theme::{self as ui_theme, DEFAULT_THEME_ID};
 use vtcode_core::{initialize_dot_folder, load_user_config, update_theme_preference};
 
+mod acp;
 mod agent;
 mod cli; // local CLI handlers in src/cli // agent runloops (single-agent only)
 mod workspace_trust;
@@ -160,6 +161,9 @@ async fn main() -> Result<()> {
     };
 
     match &args.command {
+        Some(Commands::AgentClientProtocol { target }) => {
+            cli::handle_acp_command(&core_cfg, &cfg, *target).await?;
+        }
         Some(Commands::ToolPolicy { command }) => {
             vtcode_core::cli::tool_policy_commands::handle_tool_policy_command(command.clone())
                 .await?;

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -1,7 +1,7 @@
 //! CLI argument parsing and configuration
 
 use crate::config::models::ModelId;
-use clap::{ColorChoice, Parser, Subcommand, ValueHint};
+use clap::{ColorChoice, Parser, Subcommand, ValueEnum, ValueHint};
 use colorchoice_clap::Color as ColorSelection;
 use std::path::PathBuf;
 
@@ -204,6 +204,14 @@ pub struct Cli {
 /// Available commands with comprehensive features
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Start Agent Client Protocol bridge for IDE integrations
+    #[command(name = "acp")]
+    AgentClientProtocol {
+        /// Client to connect over ACP
+        #[arg(value_enum, default_value_t = AgentClientProtocolTarget::Zed)]
+        target: AgentClientProtocolTarget,
+    },
+
     /// **Interactive AI coding assistant** with advanced capabilities
     ///
     /// Features:
@@ -466,6 +474,13 @@ pub enum Commands {
         #[arg(short, long)]
         output: Option<std::path::PathBuf>,
     },
+}
+
+/// Supported Agent Client Protocol clients
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum AgentClientProtocolTarget {
+    /// Zed IDE integration
+    Zed,
 }
 
 /// Model management commands with concise, actionable help

--- a/vtcode-core/src/config/acp.rs
+++ b/vtcode-core/src/config/acp.rs
@@ -1,0 +1,98 @@
+use crate::config::constants::env::acp::AgentClientProtocolEnvKey;
+use serde::{Deserialize, Serialize};
+
+fn parse_env_bool(key: AgentClientProtocolEnvKey, default: bool) -> bool {
+    std::env::var(key.as_str())
+        .ok()
+        .and_then(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "1" | "true" | "yes" | "on" => Some(true),
+                "0" | "false" | "no" | "off" => Some(false),
+                _ => None,
+            }
+        })
+        .unwrap_or(default)
+}
+
+fn default_enabled() -> bool {
+    parse_env_bool(AgentClientProtocolEnvKey::Enabled, false)
+}
+
+fn default_zed_enabled() -> bool {
+    parse_env_bool(AgentClientProtocolEnvKey::ZedEnabled, default_enabled())
+}
+
+fn default_transport() -> AgentClientProtocolTransport {
+    AgentClientProtocolTransport::Stdio
+}
+
+/// Agent Client Protocol configuration root
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentClientProtocolConfig {
+    /// Globally enable the ACP bridge
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Zed IDE integration settings
+    #[serde(default)]
+    pub zed: AgentClientProtocolZedConfig,
+}
+
+impl Default for AgentClientProtocolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            zed: AgentClientProtocolZedConfig::default(),
+        }
+    }
+}
+
+/// Transport options supported by the ACP bridge
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentClientProtocolTransport {
+    /// Communicate over stdio (spawned process model)
+    Stdio,
+}
+
+impl Default for AgentClientProtocolTransport {
+    fn default() -> Self {
+        default_transport()
+    }
+}
+
+/// Zed-specific configuration
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentClientProtocolZedConfig {
+    /// Enable Zed integration
+    #[serde(default = "default_zed_enabled")]
+    pub enabled: bool,
+
+    /// Transport used to communicate with the Zed client
+    #[serde(default = "default_transport")]
+    pub transport: AgentClientProtocolTransport,
+}
+
+impl Default for AgentClientProtocolZedConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_zed_enabled(),
+            transport: default_transport(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_use_stdio_transport() {
+        let cfg = AgentClientProtocolConfig::default();
+        assert!(matches!(
+            cfg.zed.transport,
+            AgentClientProtocolTransport::Stdio
+        ));
+    }
+}

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -242,6 +242,24 @@ pub mod model_helpers {
 pub mod env {
     /// Toggle automatic update checks in the onboarding banner.
     pub const UPDATE_CHECK: &str = "VT_UPDATE_CHECK";
+
+    /// Agent Client Protocol specific environment keys
+    pub mod acp {
+        #[derive(Debug, Clone, Copy)]
+        pub enum AgentClientProtocolEnvKey {
+            Enabled,
+            ZedEnabled,
+        }
+
+        impl AgentClientProtocolEnvKey {
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    Self::Enabled => "VT_ACP_ENABLED",
+                    Self::ZedEnabled => "VT_ACP_ZED_ENABLED",
+                }
+            }
+        }
+    }
 }
 
 /// Default configuration values

--- a/vtcode-core/src/config/loader/mod.rs
+++ b/vtcode-core/src/config/loader/mod.rs
@@ -1,3 +1,4 @@
+use crate::config::acp::AgentClientProtocolConfig;
 use crate::config::context::ContextFeaturesConfig;
 use crate::config::core::{
     AgentConfig, AutomationConfig, CommandsConfig, PromptCachingConfig, SecurityConfig, ToolsConfig,
@@ -138,6 +139,10 @@ pub struct VTCodeConfig {
     /// Model Context Protocol configuration
     #[serde(default)]
     pub mcp: McpClientConfig,
+
+    /// Agent Client Protocol configuration
+    #[serde(default)]
+    pub acp: AgentClientProtocolConfig,
 }
 
 impl Default for VTCodeConfig {
@@ -156,6 +161,7 @@ impl Default for VTCodeConfig {
             automation: AutomationConfig::default(),
             prompt_cache: PromptCachingConfig::default(),
             mcp: McpClientConfig::default(),
+            acp: AgentClientProtocolConfig::default(),
         }
     }
 }

--- a/vtcode-core/src/config/mod.rs
+++ b/vtcode-core/src/config/mod.rs
@@ -171,6 +171,7 @@
 //! It provides a centralized way to manage agent policies, tool permissions, and
 //! command allow lists.
 
+pub mod acp;
 pub mod api_keys;
 pub mod constants;
 pub mod context;
@@ -184,6 +185,9 @@ pub mod telemetry;
 pub mod types;
 
 // Re-export main types for backward compatibility
+pub use acp::{
+    AgentClientProtocolConfig, AgentClientProtocolTransport, AgentClientProtocolZedConfig,
+};
 pub use context::{ContextFeaturesConfig, LedgerConfig};
 pub use core::{
     AgentConfig, AutomationConfig, CommandsConfig, FullAutoConfig, SecurityConfig, ToolPolicy,

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -131,7 +131,10 @@ pub use config::types::{
     AnalysisDepth, CapabilityLevel, CommandResult, CompressionLevel, ContextConfig, LoggingConfig,
     OutputFormat, PerformanceMetrics, ReasoningEffortLevel, SessionInfo, ToolConfig,
 };
-pub use config::{AgentConfig, VTCodeConfig};
+pub use config::{
+    AgentClientProtocolConfig, AgentClientProtocolTransport, AgentClientProtocolZedConfig,
+    AgentConfig, VTCodeConfig,
+};
 pub use core::agent::core::Agent;
 pub use core::context_compression::{
     CompressedContext, ContextCompressionConfig, ContextCompressor,

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -38,6 +38,13 @@ enabled = false
 require_profile_ack = true
 profile_path = "automation/full_auto_profile.toml"
 
+[acp]
+enabled = false
+
+    [acp.zed]
+    enabled = false
+    transport = "stdio"
+
 
 [tools]
 default_policy = "prompt"

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -220,3 +220,10 @@ enabled_languages = [
 
 # Performance settings
 highlight_timeout_ms = 5000
+
+[acp]
+enabled = false
+
+    [acp.zed]
+    enabled = false
+    transport = "stdio"


### PR DESCRIPTION
## Summary
- add Agent Client Protocol configuration and environment bindings for Zed support
- implement a stdio-based Zed bridge and wire it through a new `vtcode acp` CLI command
- document configuration defaults and expose ACP settings in project templates

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68df87b6e3608323a23454729e0d2a7b