### PR TITLE
Add optional Swift tree-sitter integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ anstyle-ls = "1.0"
 [features]
 default = ["tool-chat"]
 tool-chat = []
+tree-sitter-swift = ["vtcode-core/swift"]
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/docs/user-guide/tree-sitter-integration.md
+++ b/docs/user-guide/tree-sitter-integration.md
@@ -44,7 +44,10 @@ The tree-sitter integration provides Research-preview code parsing and analysis 
 | TypeScript |  Full Support | `tree-sitter-typescript` |
 | Go |  Full Support | `tree-sitter-go` |
 | Java |  Full Support | `tree-sitter-java` |
-| Swift |  Planned | `tree-sitter-swift` |
+| Swift |  Full Support (feature: `tree-sitter-swift`) | `tree-sitter-swift` |
+
+Swift parsing leverages the official [tree-sitter/swift-tree-sitter](https://github.com/tree-sitter/swift-tree-sitter)
+grammar through the `tree-sitter-swift` crate, and is available when the `tree-sitter-swift` feature is enabled.
 
 ## Architecture
 

--- a/vtcode-core/src/tools/tree_sitter/analyzer.rs
+++ b/vtcode-core/src/tools/tree_sitter/analyzer.rs
@@ -7,8 +7,6 @@ use crate::tools::tree_sitter::languages::*;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-// Swift parser is currently disabled to avoid optional dependency issues
-// use tree_sitter_swift;
 use std::path::Path;
 use tree_sitter::{Language, Parser, Tree};
 
@@ -104,7 +102,7 @@ impl TreeSitterAnalyzer {
         let mut parsers = HashMap::new();
 
         // Initialize parsers for all supported languages
-        let languages = vec![
+        let mut languages = vec![
             LanguageSupport::Rust,
             LanguageSupport::Python,
             LanguageSupport::JavaScript,
@@ -112,6 +110,11 @@ impl TreeSitterAnalyzer {
             LanguageSupport::Go,
             LanguageSupport::Java,
         ];
+
+        if cfg!(feature = "swift") {
+            // Swift grammar provided by https://github.com/tree-sitter/swift-tree-sitter via the tree-sitter-swift crate
+            languages.push(LanguageSupport::Swift);
+        }
 
         for language in &languages {
             let mut parser = Parser::new();
@@ -151,7 +154,13 @@ impl TreeSitterAnalyzer {
             "jsx" => Ok(LanguageSupport::JavaScript),
             "go" => Ok(LanguageSupport::Go),
             "java" => Ok(LanguageSupport::Java),
-            "swift" => Ok(LanguageSupport::Swift),
+            "swift" => {
+                if cfg!(feature = "swift") {
+                    Ok(LanguageSupport::Swift)
+                } else {
+                    Err(TreeSitterError::UnsupportedLanguage("swift".to_string()).into())
+                }
+            }
             _ => Err(TreeSitterError::UnsupportedLanguage(extension.to_string()).into()),
         }
     }

--- a/vtcode-core/src/tools/tree_sitter/mod.rs
+++ b/vtcode-core/src/tools/tree_sitter/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Features
 //!
-//! - **Multi-language Support**: Rust, Python, JavaScript, TypeScript, Go, Java
+//! - **Multi-language Support**: Rust, Python, JavaScript, TypeScript, Go, Java, optional Swift
 //! - **Syntax Tree Analysis**: Parse code into structured syntax trees
 //! - **Symbol Extraction**: Extract functions, classes, variables, and imports
 //! - **Code Navigation**: Navigate code structures with precision


### PR DESCRIPTION
## Summary
- enable forwarding feature flag so the binary can opt into the Swift tree-sitter grammar provided by the core crate
- wire the Swift parser into the analyzer initialisation and guard language detection behind the feature flag, referencing the official upstream binding
- document Swift support as feature-gated and update module docs to reflect optional Swift coverage

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dfdb6e6e208323ac87022e1678d090