### PR TITLE
Add permission requests for ACP read_file tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/vinhnx/vtcode"
 repository = "https://github.com/vinhnx/vtcode"
+documentation = "https://docs.rs/vtcode"
 keywords = ["ai", "coding", "agent", "llm", "cli"]
 categories = ["command-line-utilities", "development-tools", "api-bindings"]
 exclude = [

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ If the binary is not on `PATH`, note the absolute location (`target/release/vtco
 
     Disable the tool bridge when your provider does not expose function calling (for example
     `openai/gpt-oss-20b:free` on OpenRouter). VT Code streams a reasoning notice back to Zed when it
-    detects unsupported tool calls and automatically downgrades to plain completions.
+    detects unsupported tool calls and automatically downgrades to plain completions. When enabled,
+    Zed now prompts for approval before each `read_file` tool invocation so you can gate sensitive
+    paths.
 
 2. Run a manual smoke test:
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ If the binary is not on `PATH`, note the absolute location (`target/release/vtco
     proceeding without consent. All `read_file` arguments must reference absolute workspace paths;
     relative values are rejected before reaching the client. Cancelling a turn in Zed immediately sets
     the ACP stop reason to `cancelled`, short-circuits pending tool executions, and reports the tool
-    calls as cancelled so no additional output is sent after you abort the run.
+    calls as cancelled so no additional output is sent after you abort the run. Each prompt also
+    publishes an ACP execution plan that tracks when VT Code is analysing the request, gathering
+    workspace context, and composing the final reply so Zed's UI mirrors the bridge's progress.
 
 2. Run a manual smoke test:
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,10 @@ vtcode --debug --no-tools ask "Compute token budget for current context"  # Dry-
 
 ### Zed IDE integration (Agent Client Protocol)
 
-The ACP bridge lets Zed treat VT Code as an external agent. The full walkthrough lives in
-[`docs/guides/zed-acp.md`](docs/guides/zed-acp.md); the summary below captures the critical steps.
+The ACP bridge lets Zed treat VT Code as an external agent. Review the
+[Zed ACP integration guide](https://github.com/vinhnx/vtcode/blob/main/docs/guides/zed-acp.md)
+and the [docs.rs ACP reference](https://docs.rs/vtcode/latest/vtcode/#agent-client-protocol-acp)
+for the complete workflow; the summary below captures the critical steps.
 
 #### Setup overview
 - Ensure a VT Code binary is built and reachable (either on `PATH` or via an absolute path).

--- a/README.md
+++ b/README.md
@@ -184,9 +184,11 @@ If the binary is not on `PATH`, note the absolute location (`target/release/vtco
     `openai/gpt-oss-20b:free` on OpenRouter). VT Code streams a reasoning notice back to Zed when it
     detects unsupported tool calls and automatically downgrades to plain completions. When enabled,
     Zed now prompts for approval before each `read_file` tool invocation so you can gate sensitive
-    paths. Cancelling a turn in Zed immediately sets the ACP stop reason to `cancelled`, short-circuits
-    pending tool executions, and reports the tool calls as cancelled so no additional output is sent
-    after you abort the run.
+    paths. If the permission dialog cannot be presented, the tool call is cancelled rather than
+    proceeding without consent. All `read_file` arguments must reference absolute workspace paths;
+    relative values are rejected before reaching the client. Cancelling a turn in Zed immediately sets
+    the ACP stop reason to `cancelled`, short-circuits pending tool executions, and reports the tool
+    calls as cancelled so no additional output is sent after you abort the run.
 
 2. Run a manual smoke test:
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ If the binary is not on `PATH`, note the absolute location (`target/release/vtco
     | `VT_ACP_ZED_ENABLED` | Enables the Zed transport. |
     | `VT_ACP_ZED_TOOLS_READ_FILE_ENABLED` | Controls the `read_file` tool forwarding. |
 
+    Zed must advertise the `fs.read_text_file` capability during the ACP handshake. If the
+    initialization request omits it, VT Code leaves the `read_file` tool disabled and surfaces a
+    reasoning notice inside the turn.
+
     Disable the tool bridge when your provider does not expose function calling (for example
     `openai/gpt-oss-20b:free` on OpenRouter). VT Code streams a reasoning notice back to Zed when it
     detects unsupported tool calls and automatically downgrades to plain completions. When enabled,

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ If the binary is not on `PATH`, note the absolute location (`target/release/vtco
     `openai/gpt-oss-20b:free` on OpenRouter). VT Code streams a reasoning notice back to Zed when it
     detects unsupported tool calls and automatically downgrades to plain completions. When enabled,
     Zed now prompts for approval before each `read_file` tool invocation so you can gate sensitive
-    paths.
+    paths. Cancelling a turn in Zed immediately sets the ACP stop reason to `cancelled`, short-circuits
+    pending tool executions, and reports the tool calls as cancelled so no additional output is sent
+    after you abort the run.
 
 2. Run a manual smoke test:
 

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -117,6 +117,9 @@ Edit `settings.json` (Command Palette → `zed: open settings`) and add a custom
   invocation.
 - **Permission prompts** – The bridge requests explicit approval in Zed before each `read_file`
   invocation so you can confirm access to sensitive paths.
+- **Cancellations** – When you stop a turn in Zed, VT Code stops streaming tokens, aborts pending
+  tool execution with cancellation notices, and responds to the prompt with the ACP `cancelled`
+  stop reason so no extra output appears after you abort the run.
 - **Graceful degradation** – Unsupported payloads (images, binary blobs) emit structured
   placeholders rather than failing the prompt turn.
 

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -18,6 +18,9 @@ below to configure, launch, and validate the integration end to end.
 - Rust toolchain pinned by `rust-toolchain.toml`.
 - VT Code configuration with provider, model, and credentials.
 - Zed `v0.201` or later with the Agent Client Protocol feature flag enabled.
+- An ACP client that advertises the `fs.read_text_file` capability so VT Code can proxy
+  `read_file` requests. If the handshake omits it, the bridge keeps the tool disabled and reports a
+  reasoning notice.
 
 ## Build VT Code
 

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -114,9 +114,11 @@ Edit `settings.json` (Command Palette → `zed: open settings`) and add a custom
   notifications, keeping Zed's UI responsive during generation.
 - **Tool execution** – The `read_file` tool forwards to Zed when enabled. When the model lacks
   function calling or the tool toggle is disabled, VT Code surfaces a reasoning notice and skips the
-  invocation.
+  invocation. Arguments must point at absolute workspace paths; the bridge rejects relative values
+  before they reach the client.
 - **Permission prompts** – The bridge requests explicit approval in Zed before each `read_file`
-  invocation so you can confirm access to sensitive paths.
+  invocation so you can confirm access to sensitive paths. If Zed cannot surface the prompt, the tool
+  call is cancelled instead of executing without consent.
 - **Cancellations** – When you stop a turn in Zed, VT Code stops streaming tokens, aborts pending
   tool execution with cancellation notices, and responds to the prompt with the ACP `cancelled`
   stop reason so no extra output appears after you abort the run.

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -112,6 +112,9 @@ Edit `settings.json` (Command Palette → `zed: open settings`) and add a custom
   prompt payload.
 - **Streaming updates** – Token deltas and reasoning updates arrive via `session/update`
   notifications, keeping Zed's UI responsive during generation.
+- **Plan tracking** – Every prompt emits an ACP plan describing analysis, optional context gathering,
+  and final response drafting. VT Code updates each entry as it progresses so Zed can visualise the
+  bridge's workflow in real time.
 - **Tool execution** – The `read_file` tool forwards to Zed when enabled. When the model lacks
   function calling or the tool toggle is disabled, VT Code surfaces a reasoning notice and skips the
   invocation. Arguments must point at absolute workspace paths; the bridge rejects relative values

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -128,6 +128,27 @@ Edit `settings.json` (Command Palette → `zed: open settings`) and add a custom
 - **Graceful degradation** – Unsupported payloads (images, binary blobs) emit structured
   placeholders rather than failing the prompt turn.
 
+### Capability negotiation and safety
+
+- VT Code inspects the Zed initialization payload before enabling each tool. When
+  `fs.read_text_file` is absent, the bridge refuses to expose `read_file` and inserts a
+  reasoning notice so transcripts document the downgrade.
+- Every filesystem request is paired with a `session/request_permission` call so the user
+  approves or rejects path access inside Zed. Denials and cancellations are surfaced as ACP
+  tool updates rather than silent failures.
+- Arguments are validated as absolute workspace paths prior to invoking the client method,
+  preventing accidental traversal outside the project boundary.
+
+### Telemetry and auditing
+
+- Plan updates enumerate analysis, context gathering, and response drafting so audit trails
+  show exactly how a turn progressed.
+- Cancellation signals from Zed immediately cut off streaming, mark pending tool calls as
+  cancelled, and end the turn with `StopReason::Cancelled`, providing a clean timeline in the
+  transcript.
+- Downgrades (such as models without tool calling) are emitted as explicit reasoning notices
+  so reviewers can understand why a turn completed without filesystem access.
+
 ## Debugging and verification
 
 | Symptom | Resolution |

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -112,6 +112,8 @@ Edit `settings.json` (Command Palette → `zed: open settings`) and add a custom
 - **Tool execution** – The `read_file` tool forwards to Zed when enabled. When the model lacks
   function calling or the tool toggle is disabled, VT Code surfaces a reasoning notice and skips the
   invocation.
+- **Permission prompts** – The bridge requests explicit approval in Zed before each `read_file`
+  invocation so you can confirm access to sensitive paths.
 - **Graceful degradation** – Unsupported payloads (images, binary blobs) emit structured
   placeholders rather than failing the prompt turn.
 

--- a/src/acp/zed.rs
+++ b/src/acp/zed.rs
@@ -715,15 +715,16 @@ impl ZedAgent {
                 }
             },
             Err(error) => {
-                warn!(
+                error!(
                     %error,
                     tool = tool.function_name(),
                     "{}",
                     TOOL_PERMISSION_REQUEST_FAILURE_LOG
                 );
+                let failure_message = format!("{TOOL_PERMISSION_REQUEST_FAILURE_MESSAGE}: {error}");
                 Ok(Some(ToolExecutionReport::failure(
                     tool.function_name(),
-                    TOOL_PERMISSION_REQUEST_FAILURE_MESSAGE,
+                    &failure_message,
                 )))
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,27 @@
 //! }
 //! ```
 //!
+//! ## Agent Client Protocol (ACP)
+//!
+//! VT Code ships an ACP bridge tailored for Zed. Enable it via the `[acp]` section in
+//! `vtcode.toml`, launch `vtcode acp`, and register the binary inside Zed's
+//! `agent_servers` list. The full walkthrough lives in `docs/guides/zed-acp.md`.
+//!
+//! ### Bridge guarantees
+//!
+//! - Filesystem tooling stays disabled unless Zed advertises `fs.read_text_file`, so the agent
+//!   never emits unsupported requests.
+//! - Each `read_file` call is wrapped in `session/request_permission`, letting you approve or
+//!   deny access to sensitive paths before any data leaves the editor.
+//! - Cancellation signals from Zed halt streaming, mark pending tools as cancelled, and end the
+//!   turn with `StopReason::Cancelled` for clean transcripts.
+//! - ACP `plan` updates broadcast analysis, optional context gathering, and response drafting
+//!   progress so Zed mirrors the agent's workflow.
+//! - Strict absolute-path validation blocks relative or out-of-workspace arguments before they
+//!   reach the client.
+//! - When the model lacks tool calling, VT Code emits reasoning notices and downgrades to plain
+//!   completions while keeping the plan timeline consistent.
+
 //! VT Code binary package
 //!
 //! This package contains the binary executable for VT Code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,10 @@
 //!
 //! VT Code ships an ACP bridge tailored for Zed. Enable it via the `[acp]` section in
 //! `vtcode.toml`, launch `vtcode acp`, and register the binary inside Zed's
-//! `agent_servers` list. The full walkthrough lives in `docs/guides/zed-acp.md`.
+//! `agent_servers` list. The full walkthrough lives in the
+//! [Zed ACP integration guide](https://github.com/vinhnx/vtcode/blob/main/docs/guides/zed-acp.md),
+//! and the rendered API guarantees appear on
+//! [docs.rs](https://docs.rs/vtcode/latest/vtcode/#agent-client-protocol-acp).
 //!
 //! ### Bridge guarantees
 //!

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 readme = "../README.md"
 homepage = "https://github.com/vinhnx/vtcode"
 repository = "https://github.com/vinhnx/vtcode"
+documentation = "https://docs.rs/vtcode-core"
 keywords = ["ai", "coding", "agent", "llm", "rust"]
 categories = ["development-tools", "api-bindings"]
 

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -97,8 +97,10 @@
 //!
 //! VT Code's binary exposes an ACP bridge for Zed. Enable it via the `[acp]` section in
 //! `vtcode.toml`, launch the `vtcode acp` subcommand, and register the binary under
-//! `agent_servers` in Zed's `settings.json`. Detailed instructions and troubleshooting live in
-//! `docs/guides/zed-acp.md`.
+//! `agent_servers` in Zed's `settings.json`. Detailed instructions and troubleshooting live in the
+//! [Zed ACP integration guide](https://github.com/vinhnx/vtcode/blob/main/docs/guides/zed-acp.md),
+//! with a rendered summary on
+//! [docs.rs](https://docs.rs/vtcode/latest/vtcode/#agent-client-protocol-acp).
 
 //! ### Bridge guarantees
 //!

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -100,6 +100,20 @@
 //! `agent_servers` in Zed's `settings.json`. Detailed instructions and troubleshooting live in
 //! `docs/guides/zed-acp.md`.
 
+//! ### Bridge guarantees
+//!
+//! - Tool exposure follows capability negotiation: `read_file` stays disabled unless Zed
+//!   advertises `fs.read_text_file`.
+//! - Each filesystem request invokes `session/request_permission`, ensuring explicit approval
+//!   within the editor before data flows.
+//! - Cancellation signals propagate into VT Code, cancelling active tool calls and ending the
+//!   turn with `StopReason::Cancelled`.
+//! - ACP `plan` entries track analysis, context gathering, and response drafting for timeline
+//!   parity with Zed.
+//! - Absolute-path checks guard every `read_file` argument before forwarding it to the client.
+//! - Non-tool-capable models trigger reasoning notices and an automatic downgrade to plain
+//!   completions without losing plan consistency.
+
 //! VTCode Core Library
 //!
 //! This crate provides the core functionality for the VTCode agent,


### PR DESCRIPTION
## Summary
- request ACP client approval before running the Zed `read_file` tool and surface clear failure messages
- add helper utilities for building ACP permission options and handling client responses
- document the new permission prompts in the Zed ACP guide and README

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e0744df090832393169786cefcd81e