### PR TITLE
Add Terminal-Bench automation support

### DIFF
--- a/docs/guides/terminal-bench-setup.md
+++ b/docs/guides/terminal-bench-setup.md
@@ -20,6 +20,13 @@ running the `hello-world` task with the custom agent shipped in this repository.
    ```
    Log out and back in (or restart your shell) after adding your user to the `docker` group.
 
+   Pull the official Terminal-Bench Ubuntu base image so future runs reuse the cached layers:
+   ```bash
+   docker pull ghcr.io/laude-institute/terminal-bench/t-bench/ubuntu-24-04:latest
+   ```
+   Terminal-Bench tasks reference this image when building their client containers, so pre-pulling it
+   prevents the harness from compiling the stack from scratch during the first run.
+
 2. **Install uv** (Python launcher used by the project tooling).
    ```bash
    curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/docs/guides/terminal-bench-setup.md
+++ b/docs/guides/terminal-bench-setup.md
@@ -1,8 +1,16 @@
 # Terminal-Bench Integration Guide
 
-This guide explains how to evaluate VT Code with [Terminal-Bench](https://github.com/terminal-bench).
-It covers local prerequisites, configuration updates for automated runs, and the workflow for
-running the `hello-world` task with the custom agent shipped in this repository.
+This guide explains how to evaluate VT Code with
+[Terminal-Bench](https://github.com/terminal-bench). It is intentionally focused on the
+**VT Code** agent that lives in this repository—no third-party coding assistants (for example,
+Claude Code or GitHub Copilot) are required or referenced. The steps below cover local
+prerequisites, configuration updates for automated runs, and the workflow for running the
+`hello-world` task with the custom agent.
+
+> **Why call out VT Code explicitly?** Terminal-Bench ships harness integrations for many hosted
+> agents, but this project is evaluated as a self-contained coding agent. All commands and
+> configuration snippets in this guide call `VTCodeTerminalBenchAgent`, ensuring the benchmark runs
+> against the first-party VT Code experience.
 
 ## 1. Prerequisites
 
@@ -20,12 +28,15 @@ running the `hello-world` task with the custom agent shipped in this repository.
    ```
    Log out and back in (or restart your shell) after adding your user to the `docker` group.
 
-   Pull the official Terminal-Bench Ubuntu base image so future runs reuse the cached layers:
+   Pull the official Terminal-Bench Ubuntu base image so future runs reuse the cached layers. VT
+   Code is tested against the same image, so pinning to it avoids surprises when reproducing
+   benchmark results:
    ```bash
    docker pull ghcr.io/laude-institute/terminal-bench/t-bench/ubuntu-24-04:latest
    ```
    Terminal-Bench tasks reference this image when building their client containers, so pre-pulling it
-   prevents the harness from compiling the stack from scratch during the first run.
+   prevents the harness from compiling the stack from scratch during the first run and guarantees the
+   runtime matches the environment we validate in CI.
 
 2. **Install uv** (Python launcher used by the project tooling).
    ```bash

--- a/docs/guides/terminal-bench-setup.md
+++ b/docs/guides/terminal-bench-setup.md
@@ -1,0 +1,127 @@
+# Terminal-Bench Integration Guide
+
+This guide explains how to evaluate VT Code with [Terminal-Bench](https://github.com/terminal-bench).
+It covers local prerequisites, configuration updates for automated runs, and the workflow for
+running the `hello-world` task with the custom agent shipped in this repository.
+
+## 1. Prerequisites
+
+1. **Install Docker** (required by Terminal-Bench tasks).
+   ```bash
+   # Debian/Ubuntu
+   sudo apt-get update
+   sudo apt-get install -y ca-certificates curl gnupg
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+       | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   sudo apt-get update
+   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   sudo usermod -aG docker "$USER"
+   ```
+   Log out and back in (or restart your shell) after adding your user to the `docker` group.
+
+2. **Install uv** (Python launcher used by the project tooling).
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+3. **Install the Terminal-Bench CLI**.
+   ```bash
+   uv tool install terminal-bench
+   ```
+
+4. **Install Rust (stable toolchain)** if it is not already available.
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+   source "$HOME/.cargo/env"
+   ```
+
+## 2. Configure VT Code for unattended runs
+
+Terminal-Bench interacts with VT Code through full-auto mode. Ensure the workspace configuration
+enables automation, allows the tools required by Terminal-Bench tasks, and renders logs using the
+inline UI to avoid TUI escape sequences.
+
+1. Copy the example configuration if you do not already have one:
+   ```bash
+   mkdir -p .vtcode
+   cp vtcode.toml.example .vtcode/vtcode.toml
+   ```
+
+2. Edit `.vtcode/vtcode.toml` and enable full-auto execution:
+   ```toml
+   [automation.full_auto]
+   enabled = true
+   require_profile_ack = false
+   allowed_tools = [
+       "run_terminal_cmd",
+       "bash",
+       "read_file",
+       "list_files",
+       "write_file",
+       "apply_patch"
+   ]
+
+   [agent]
+   ui_surface = "inline"
+   ```
+   Adjust the allowlist based on the tasks you plan to evaluate. The inline surface keeps the
+   output readable when Terminal-Bench captures the session transcript.
+
+3. Export the API key for your preferred model provider before running the benchmark. For example:
+   ```bash
+   export GEMINI_API_KEY="your-google-api-key"
+   ```
+   The agent automatically forwards the standard provider environment variables listed in
+   `tools/terminal_bench/vtcode_agent.py`.
+
+## 3. Custom Terminal-Bench agent
+
+The repository ships a reusable agent wrapper at
+`tools/terminal_bench/vtcode_agent.py`. It installs VT Code inside the task container and boots the
+CLI in full-auto mode with a seeded task description. Key files:
+
+- `tools/terminal_bench/setup.sh`: installation script executed in the task container.
+- `tools/terminal_bench/vtcode_agent.py`: `AbstractInstalledAgent` implementation.
+- `vtcode-core/src/config/constants.rs`: exposes the
+  `VTCODE_AUTOMATION_INPUT_SEQUENCE` environment key so the runloop can seed prompts.
+- `src/agent/runloop/unified/turn.rs`: loads the automation sequence and replays each entry as if it
+  were typed by the user. Entries are parsed from a JSON array and executed in order. The agent
+  appends an `exit` command after the main instruction so the process terminates cleanly once the
+  task finishes.
+
+## 4. Running the `hello-world` task
+
+1. Ensure Docker is running locally and that you can execute `docker ps` without sudo.
+
+2. From the VT Code repository root, run the Terminal-Bench harness with the custom agent:
+   ```bash
+   tb run \
+       --dataset terminal-bench-core==head \
+       --agent-import-path tools.terminal_bench.vtcode_agent:VTCodeTerminalBenchAgent \
+       --agent-kwarg config_path=$PWD/.vtcode/vtcode.toml \
+       --task-id hello-world
+   ```
+   The harness performs the following steps automatically:
+   - builds a container for the task,
+   - copies `tools/terminal_bench/setup.sh` into the container and installs VT Code,
+   - exports provider credentials,
+   - sets `VTCODE_AUTOMATION_INPUT_SEQUENCE` to `["<task description>", "exit"]`,
+   - runs `vtcode --full-auto --skip-confirmations --no-color chat`.
+
+3. When the run completes, inspect the summary produced by Terminal-Bench. Logs are stored in the
+   directory printed by the harness (inside `~/.terminal-bench/runs/`).
+
+## 5. Troubleshooting checklist
+
+- **Docker permissions:** run `docker ps` to verify your shell session is in the `docker` group.
+- **API keys:** confirm the expected environment variable is exported before running `tb run`.
+- **Model configuration:** adjust the `--provider` and `--model` CLI flags if your workspace
+  defaults differ from the desired evaluation setup.
+- **Long tasks:** increase `max_timeout_sec` on the agent command inside
+  `tools/terminal_bench/vtcode_agent.py` if the benchmark times out before completion.
+- **Multiple prompts:** edit the JSON sequence constructed in `_run_agent_commands` if you need more
+  scripted turns (for example, add intermediate confirmation strings before the final `exit`).
+
+Following the steps above allows you to evaluate VT Code against Terminal-Bench tasks without manual
+intervention.

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, anyhow};
 use futures::StreamExt;
 use indicatif::ProgressStyle;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::fmt::Write as FmtWrite;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -17,7 +17,7 @@ use toml::Value as TomlValue;
 use tracing::warn;
 use vtcode_core::SimpleIndexer;
 use vtcode_core::config::constants::tools as tool_names;
-use vtcode_core::config::constants::{defaults, ui};
+use vtcode_core::config::constants::{defaults, env, ui};
 use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
 use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, UiSurfacePreference};
 use vtcode_core::core::context_curator::{
@@ -1233,6 +1233,33 @@ pub(crate) async fn run_single_agent_loop_unified(
 
     transcript::clear();
 
+    let mut automation_inputs: VecDeque<String> = VecDeque::new();
+    if let Ok(raw_sequence) = std::env::var(env::AUTOMATION_INPUT_SEQUENCE) {
+        match serde_json::from_str::<Vec<String>>(&raw_sequence) {
+            Ok(entries) => {
+                for value in entries {
+                    let trimmed = value.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    automation_inputs.push_back(trimmed.to_string());
+                }
+            }
+            Err(error) => {
+                warn!(
+                    "Failed to parse automation input sequence from {}: {}",
+                    env::AUTOMATION_INPUT_SEQUENCE,
+                    error
+                );
+            }
+        }
+        // SAFETY: the automation sequence is scoped to this process and removed immediately after
+        // reading to avoid contaminating subsequent turns. No other threads mutate the variable.
+        unsafe {
+            std::env::remove_var(env::AUTOMATION_INPUT_SEQUENCE);
+        }
+    }
+
     let workspace_label = config
         .workspace
         .file_name()
@@ -1370,11 +1397,15 @@ pub(crate) async fn run_single_agent_loop_unified(
             break;
         }
 
-        let maybe_event = tokio::select! {
-            biased;
+        let maybe_event = if let Some(queued_input) = automation_inputs.pop_front() {
+            Some(InlineEvent::Submit(queued_input))
+        } else {
+            tokio::select! {
+                biased;
 
-            _ = ctrl_c_notify.notified(), if ctrl_c_state.is_cancel_requested() => None,
-            event = events.recv() => event,
+                _ = ctrl_c_notify.notified(), if ctrl_c_state.is_cancel_requested() => None,
+                event = events.recv() => event,
+            }
         };
 
         if ctrl_c_state.is_cancel_requested() {

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -1254,7 +1254,7 @@ pub(crate) async fn run_single_agent_loop_unified(
             }
         }
         // SAFETY: the automation sequence is scoped to this process and removed immediately after
-        // reading to avoid contaminating subsequent turns. No other threads mutate the variable.
+        // loading so future turns do not inherit stale instructions from this process environment.
         unsafe {
             std::env::remove_var(env::AUTOMATION_INPUT_SEQUENCE);
         }

--- a/tools/terminal_bench/__init__.py
+++ b/tools/terminal_bench/__init__.py
@@ -1,0 +1,3 @@
+from .vtcode_agent import VTCodeTerminalBenchAgent
+
+__all__ = ['VTCodeTerminalBenchAgent']

--- a/tools/terminal_bench/setup.sh
+++ b/tools/terminal_bench/setup.sh
@@ -17,4 +17,7 @@ fi
 # shellcheck disable=SC1091
 source "$HOME/.cargo/env"
 
-cargo install --locked vtcode
+script_dir=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/../.." && pwd)
+
+cargo install --locked --path "$repo_root"

--- a/tools/terminal_bench/setup.sh
+++ b/tools/terminal_bench/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo 'apt-get is required to install vtcode dependencies' >&2
+    exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y build-essential curl git pkg-config libssl-dev
+
+if ! command -v rustup >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain stable
+fi
+
+# shellcheck disable=SC1091
+source "$HOME/.cargo/env"
+
+cargo install --locked vtcode

--- a/tools/terminal_bench/vtcode_agent.py
+++ b/tools/terminal_bench/vtcode_agent.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from enum import Enum
+from pathlib import Path
+from typing import Final
+
+from terminal_bench.agents.installed_agents.abstract_installed_agent import (
+    AbstractInstalledAgent,
+)
+from terminal_bench.terminal.models import TerminalCommand
+
+
+class EnvVar(Enum):
+    AUTOMATION_SEQUENCE = 'VTCODE_AUTOMATION_INPUT_SEQUENCE'
+    CONFIG_PATH = 'VTCODE_CONFIG_PATH'
+
+
+class ApiKeyEnv(Enum):
+    ANTHROPIC = 'ANTHROPIC_API_KEY'
+    GEMINI = 'GEMINI_API_KEY'
+    OPENAI = 'OPENAI_API_KEY'
+    DEEPSEEK = 'DEEPSEEK_API_KEY'
+    OPENROUTER = 'OPENROUTER_API_KEY'
+    XAI = 'XAI_API_KEY'
+
+
+class ExecutionFlag(Enum):
+    FULL_AUTO = '--full-auto'
+    NO_COLOR = '--no-color'
+    SKIP_CONFIRMATIONS = '--skip-confirmations'
+
+
+class Subcommand(Enum):
+    CHAT = 'chat'
+
+
+class CliOption(Enum):
+    CONFIG = '--config'
+
+
+class Binary(Enum):
+    VTCODE = 'vtcode'
+
+
+class AutomationToken(Enum):
+    EXIT = 'exit'
+
+
+class VTCodeTerminalBenchAgent(AbstractInstalledAgent):
+    """Terminal-Bench integration that runs vtcode in full-auto mode."""
+
+    INSTALL_SCRIPT_NAME: Final[str] = 'setup.sh'
+
+    def __init__(self, config_path: str | None = None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._config_path = Path(config_path).expanduser() if config_path else None
+
+    @staticmethod
+    def name() -> str:
+        return 'VT Code Terminal-Bench Agent'
+
+    @property
+    def _env(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+        for api_key in ApiKeyEnv:
+            value = os.environ.get(api_key.value)
+            if value:
+                env[api_key.value] = value
+        if self._config_path:
+            env[EnvVar.CONFIG_PATH.value] = str(self._config_path)
+        return env
+
+    @property
+    def _install_agent_script_path(self) -> Path:
+        return Path(__file__).parent / self.INSTALL_SCRIPT_NAME
+
+    def _run_agent_commands(self, instruction: str) -> list[TerminalCommand]:
+        command_sequence = json.dumps([instruction, AutomationToken.EXIT.value])
+        export_sequence = TerminalCommand(
+            command=self._format_export(EnvVar.AUTOMATION_SEQUENCE.value, command_sequence),
+            block=True,
+            min_timeout_sec=0.1,
+        )
+        vtcode_command = TerminalCommand(
+            command=self._build_vtcode_command(),
+            block=True,
+            min_timeout_sec=0.1,
+            max_timeout_sec=float('inf'),
+        )
+        return [export_sequence, vtcode_command]
+
+    @staticmethod
+    def _format_export(key: str, value: str) -> str:
+        return f"export {key}={shlex.quote(value)}"
+
+    def _build_vtcode_command(self) -> str:
+        parts: list[str] = [Binary.VTCODE.value]
+        if self._config_path:
+            parts.extend([CliOption.CONFIG.value, shlex.quote(str(self._config_path))])
+        parts.extend(flag.value for flag in ExecutionFlag)
+        parts.append(Subcommand.CHAT.value)
+        return ' '.join(parts)

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -180,6 +180,7 @@ pub mod models {
     pub const DEEPSEEK_REASONER: &str = deepseek::DEEPSEEK_REASONER;
 }
 
+/// Environment variable keys used for runtime automation features
 /// Prompt caching defaults shared across features and providers
 pub mod prompt_cache {
     pub const DEFAULT_ENABLED: bool = true;
@@ -244,6 +245,9 @@ pub mod model_helpers {
 
 /// Environment variable names shared across the application.
 pub mod env {
+    /// JSON encoded automation sequence executed at startup.
+    pub const AUTOMATION_INPUT_SEQUENCE: &str = "VTCODE_AUTOMATION_INPUT_SEQUENCE";
+
     /// Toggle automatic update checks in the onboarding banner.
     pub const UPDATE_CHECK: &str = "VT_UPDATE_CHECK";
 


### PR DESCRIPTION
## Summary
- allow the agent runloop to replay scripted prompts from the VTCODE_AUTOMATION_INPUT_SEQUENCE env var
- add a Terminal-Bench installed agent wrapper and install script for vtcode
- document the workflow for running the hello-world task via the new agent

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e08d29f2a4832394a5dd8ecd794c89