### PR TITLE
feat: show write_file diff preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4205,6 +4211,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "shell-words",
+ "similar",
  "syntect",
  "tempfile",
  "termimad 0.34.0",

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -97,6 +97,7 @@ pulldown-cmark = { version = "0.9", default-features = false, features = [
     "simd",
 ] }
 catppuccin = { version = "2.5", default-features = false }
+similar = "2.4"
 
 # MCP (Model Context Protocol) support
 rmcp = { version = "0.7.0", features = ["client", "transport-child-process"] }

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -457,3 +457,21 @@ pub mod chunking {
     /// Chunk size for write operations (in bytes)
     pub const WRITE_CHUNK_SIZE: usize = 50_000; // 50KB chunks
 }
+
+/// Diff preview controls for file operations
+pub mod diff {
+    /// Maximum number of bytes allowed in diff preview inputs
+    pub const MAX_PREVIEW_BYTES: usize = 200_000;
+
+    /// Number of context lines to include around changes in unified diff output
+    pub const CONTEXT_RADIUS: usize = 3;
+
+    /// Maximum number of diff lines to keep in preview output before condensation
+    pub const MAX_PREVIEW_LINES: usize = 160;
+
+    /// Number of leading diff lines to retain when condensing previews
+    pub const HEAD_LINE_COUNT: usize = 96;
+
+    /// Number of trailing diff lines to retain when condensing previews
+    pub const TAIL_LINE_COUNT: usize = 32;
+}


### PR DESCRIPTION
## Summary
- generate unified diff previews for write_file operations with size-aware truncation and skip handling
- render write_file diff previews in the TUI with git-style highlighting and preview metadata
- add diff preview configuration constants, supporting tests, and bring in the similar crate for diff generation

## Testing
- cargo fmt
- cargo check
- cargo test --package vtcode-core --lib *(fails: interactive PTY permission prompts/timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bab82b9083238da5db201d6cd71a