### PR TITLE
Add interactive model picker workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2028,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimad"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2045,12 @@ checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2079,6 +2112,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2249,6 +2292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2357,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2749,6 +2821,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -2772,6 +2845,48 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rig-core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fda909fffdc506e22541e7221d2bd56f21b94ccea218adb4e1bb3677706669a"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "glob",
+ "mime_guess",
+ "ordered-float",
+ "reqwest",
+ "reqwest-eventsource",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
 ]
 
 [[package]]
@@ -3779,6 +3894,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,6 +4325,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "rig-core",
  "rmcp",
  "roff",
  "serde",

--- a/src/agent/runloop/mod.rs
+++ b/src/agent/runloop/mod.rs
@@ -59,7 +59,9 @@ fn apply_runtime_overrides(vt_cfg: Option<&mut VTCodeConfig>, runtime_cfg: &Core
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
     use vtcode_core::config::core::PromptCachingConfig;
+    use vtcode_core::config::models::Provider;
     use vtcode_core::config::types::{ReasoningEffortLevel, UiSurfacePreference};
 
     #[test]
@@ -78,6 +80,7 @@ mod tests {
             model: OVERRIDE_MODEL.to_string(),
             api_key: String::new(),
             provider: "cli-provider".to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: std::env::current_dir().unwrap(),
             verbose: false,
             theme: String::new(),
@@ -85,6 +88,7 @@ mod tests {
             ui_surface: UiSurfacePreference::default(),
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::CliOverride,
+            custom_api_keys: BTreeMap::new(),
         };
 
         apply_runtime_overrides(Some(&mut vt_cfg), &runtime_cfg);
@@ -107,6 +111,7 @@ mod tests {
             model: "config-standard".to_string(),
             api_key: String::new(),
             provider: "config-provider".to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: std::env::current_dir().unwrap(),
             verbose: false,
             theme: String::new(),
@@ -114,6 +119,7 @@ mod tests {
             ui_surface: UiSurfacePreference::default(),
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
 
         apply_runtime_overrides(Some(&mut vt_cfg), &runtime_cfg);

--- a/src/agent/runloop/mod.rs
+++ b/src/agent/runloop/mod.rs
@@ -5,6 +5,7 @@ use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, ModelSelectionS
 mod context;
 mod git;
 mod mcp_events;
+mod model_picker;
 mod prompt;
 mod slash_commands;
 mod telemetry;
@@ -25,8 +26,7 @@ pub async fn run_single_agent_loop(
 
     apply_runtime_overrides(vt_cfg.as_mut(), config);
 
-    unified::run_single_agent_loop_unified(config, vt_cfg.as_ref(), skip_confirmations, full_auto)
-        .await
+    unified::run_single_agent_loop_unified(config, vt_cfg, skip_confirmations, full_auto).await
 }
 
 pub(crate) fn is_context_overflow_error(message: &str) -> bool {

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -1,0 +1,510 @@
+use anyhow::{Context, Result, anyhow};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
+use vtcode_core::config::models::{ModelId, Provider};
+use vtcode_core::config::types::ReasoningEffortLevel;
+use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
+use vtcode_core::utils::dot_config::update_model_preference;
+
+#[derive(Clone, Copy)]
+struct ModelOption {
+    index: usize,
+    provider: Provider,
+    id: &'static str,
+    display: &'static str,
+    description: &'static str,
+    supports_reasoning: bool,
+}
+
+static MODEL_OPTIONS: Lazy<Vec<ModelOption>> = Lazy::new(|| {
+    let mut index = 1usize;
+    let mut options = Vec::new();
+    for model in ModelId::all_models() {
+        options.push(ModelOption {
+            index,
+            provider: model.provider(),
+            id: model.as_str(),
+            display: model.display_name(),
+            description: model.description(),
+            supports_reasoning: model.supports_reasoning_effort(),
+        });
+        index += 1;
+    }
+    options
+});
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PickerStep {
+    AwaitModel,
+    AwaitReasoning,
+    AwaitApiKey,
+}
+
+#[derive(Clone)]
+struct SelectionDetail {
+    provider_key: String,
+    provider_label: String,
+    provider_enum: Option<Provider>,
+    model_id: String,
+    model_display: String,
+    known_model: bool,
+    reasoning_supported: bool,
+    reasoning_optional: bool,
+    requires_api_key: bool,
+    env_key: String,
+}
+
+pub struct ModelSelectionResult {
+    pub provider: String,
+    pub provider_label: String,
+    pub provider_enum: Option<Provider>,
+    pub model: String,
+    pub model_display: String,
+    pub known_model: bool,
+    pub reasoning_supported: bool,
+    pub reasoning: ReasoningEffortLevel,
+    pub reasoning_changed: bool,
+    pub api_key: Option<String>,
+    pub env_key: String,
+    pub requires_api_key: bool,
+}
+
+pub enum ModelPickerProgress {
+    InProgress,
+    Completed(ModelSelectionResult),
+    Cancelled,
+}
+
+pub struct ModelPickerState {
+    options: &'static [ModelOption],
+    step: PickerStep,
+    current_reasoning: ReasoningEffortLevel,
+    selection: Option<SelectionDetail>,
+    selected_reasoning: Option<ReasoningEffortLevel>,
+    pending_api_key: Option<String>,
+}
+
+impl ModelPickerState {
+    pub fn new(
+        renderer: &mut AnsiRenderer,
+        current_reasoning: ReasoningEffortLevel,
+    ) -> Result<Self> {
+        let options = MODEL_OPTIONS.as_slice();
+        render_step_one(renderer, options)?;
+        Ok(Self {
+            options,
+            step: PickerStep::AwaitModel,
+            current_reasoning,
+            selection: None,
+            selected_reasoning: None,
+            pending_api_key: None,
+        })
+    }
+
+    pub fn handle_input(
+        &mut self,
+        renderer: &mut AnsiRenderer,
+        input: &str,
+    ) -> Result<ModelPickerProgress> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            renderer.line(
+                MessageStyle::Error,
+                "Please enter a value or type 'cancel'.",
+            )?;
+            return Ok(ModelPickerProgress::InProgress);
+        }
+        if is_cancel_command(trimmed) {
+            renderer.line(MessageStyle::Info, "Model picker cancelled.")?;
+            return Ok(ModelPickerProgress::Cancelled);
+        }
+
+        match self.step {
+            PickerStep::AwaitModel => self.handle_model_selection(renderer, trimmed),
+            PickerStep::AwaitReasoning => self.handle_reasoning(renderer, trimmed),
+            PickerStep::AwaitApiKey => self.handle_api_key(renderer, trimmed),
+        }
+    }
+
+    pub fn persist_selection(
+        &self,
+        workspace: &std::path::Path,
+        selection: &ModelSelectionResult,
+    ) -> Result<VTCodeConfig> {
+        let manager = ConfigManager::load_from_workspace(workspace).with_context(|| {
+            format!(
+                "Failed to load vtcode configuration for workspace {}",
+                workspace.display()
+            )
+        })?;
+        let mut config = manager.config().clone();
+        config.agent.provider = selection.provider.clone();
+        config.agent.default_model = selection.model.clone();
+        config.agent.reasoning_effort = selection.reasoning;
+        config.router.models.simple = selection.model.clone();
+        config.router.models.standard = selection.model.clone();
+        config.router.models.complex = selection.model.clone();
+        config.router.models.codegen_heavy = selection.model.clone();
+        config.router.models.retrieval_heavy = selection.model.clone();
+        manager.save_config(&config)?;
+        update_model_preference(&selection.provider, &selection.model).ok();
+        Ok(config)
+    }
+
+    fn handle_model_selection(
+        &mut self,
+        renderer: &mut AnsiRenderer,
+        input: &str,
+    ) -> Result<ModelPickerProgress> {
+        let selection = match parse_model_selection(self.options, input) {
+            Ok(detail) => detail,
+            Err(err) => {
+                renderer.line(MessageStyle::Error, &err.to_string())?;
+                renderer.line(
+                    MessageStyle::Info,
+                    "Try again with a model number or '<provider> <model-id>'.",
+                )?;
+                return Ok(ModelPickerProgress::InProgress);
+            }
+        };
+
+        let message = format!(
+            "Selected {} ({}) from {}.",
+            selection.model_display, selection.model_id, selection.provider_label
+        );
+        renderer.line(MessageStyle::Info, &message)?;
+
+        self.selection = Some(selection);
+        if self
+            .selection
+            .as_ref()
+            .map(|detail| detail.reasoning_supported)
+            .unwrap_or(false)
+        {
+            self.step = PickerStep::AwaitReasoning;
+            prompt_reasoning(
+                renderer,
+                self.selection.as_ref().unwrap(),
+                self.current_reasoning,
+            )?;
+            return Ok(ModelPickerProgress::InProgress);
+        }
+
+        if self
+            .selection
+            .as_ref()
+            .map(|detail| detail.requires_api_key)
+            .unwrap_or(false)
+        {
+            self.step = PickerStep::AwaitApiKey;
+            prompt_api_key(renderer, self.selection.as_ref().unwrap())?;
+            return Ok(ModelPickerProgress::InProgress);
+        }
+
+        let result = self.build_result();
+        Ok(ModelPickerProgress::Completed(result?))
+    }
+
+    fn handle_reasoning(
+        &mut self,
+        renderer: &mut AnsiRenderer,
+        input: &str,
+    ) -> Result<ModelPickerProgress> {
+        let Some(selection) = self.selection.as_ref() else {
+            return Err(anyhow!("Reasoning requested before selecting a model"));
+        };
+
+        let normalized = input.to_ascii_lowercase();
+        let level = match normalized.as_str() {
+            "easy" | "low" => Some(ReasoningEffortLevel::Low),
+            "medium" => Some(ReasoningEffortLevel::Medium),
+            "hard" | "high" => Some(ReasoningEffortLevel::High),
+            "skip" => Some(self.current_reasoning),
+            _ => None,
+        };
+
+        let Some(selected) = level else {
+            renderer.line(
+                MessageStyle::Error,
+                "Unknown reasoning level. Use easy, medium, hard, or skip.",
+            )?;
+            prompt_reasoning(renderer, selection, self.current_reasoning)?;
+            return Ok(ModelPickerProgress::InProgress);
+        };
+
+        self.selected_reasoning = Some(selected);
+        if selection.requires_api_key {
+            self.step = PickerStep::AwaitApiKey;
+            prompt_api_key(renderer, selection)?;
+            return Ok(ModelPickerProgress::InProgress);
+        }
+
+        let result = self.build_result();
+        Ok(ModelPickerProgress::Completed(result?))
+    }
+
+    fn handle_api_key(
+        &mut self,
+        renderer: &mut AnsiRenderer,
+        input: &str,
+    ) -> Result<ModelPickerProgress> {
+        let Some(selection) = self.selection.as_ref() else {
+            return Err(anyhow!("API key requested before selecting a model"));
+        };
+
+        if input.eq_ignore_ascii_case("skip") {
+            match std::env::var(&selection.env_key) {
+                Ok(value) if !value.trim().is_empty() => {
+                    renderer.line(
+                        MessageStyle::Info,
+                        &format!(
+                            "Using existing environment variable {} for {}.",
+                            selection.env_key, selection.provider_label
+                        ),
+                    )?;
+                    self.pending_api_key = None;
+                    let result = self.build_result();
+                    return Ok(ModelPickerProgress::Completed(result?));
+                }
+                _ => {
+                    renderer.line(
+                        MessageStyle::Error,
+                        &format!(
+                            "Environment variable {} is not set. Please provide an API key.",
+                            selection.env_key
+                        ),
+                    )?;
+                    prompt_api_key(renderer, selection)?;
+                    return Ok(ModelPickerProgress::InProgress);
+                }
+            }
+        }
+
+        self.pending_api_key = Some(input.to_string());
+        let result = self.build_result();
+        Ok(ModelPickerProgress::Completed(result?))
+    }
+
+    fn build_result(&self) -> Result<ModelSelectionResult> {
+        let selection = self
+            .selection
+            .as_ref()
+            .ok_or_else(|| anyhow!("Model selection missing"))?;
+        let chosen_reasoning = self.selected_reasoning.unwrap_or(self.current_reasoning);
+        let reasoning_changed = chosen_reasoning != self.current_reasoning;
+
+        Ok(ModelSelectionResult {
+            provider: selection.provider_key.clone(),
+            provider_label: selection.provider_label.clone(),
+            provider_enum: selection.provider_enum,
+            model: selection.model_id.clone(),
+            model_display: selection.model_display.clone(),
+            known_model: selection.known_model,
+            reasoning_supported: selection.reasoning_supported,
+            reasoning: chosen_reasoning,
+            reasoning_changed,
+            api_key: self.pending_api_key.clone(),
+            env_key: selection.env_key.clone(),
+            requires_api_key: selection.requires_api_key,
+        })
+    }
+}
+
+fn render_step_one(renderer: &mut AnsiRenderer, options: &[ModelOption]) -> Result<()> {
+    renderer.line(
+        MessageStyle::Info,
+        "Model picker – Step 1: select the model you want to use.",
+    )?;
+    renderer.line(
+        MessageStyle::Info,
+        "Enter the number next to a model or type '<provider> <model-id>' for custom entries.",
+    )?;
+    renderer.line(
+        MessageStyle::Info,
+        "Type 'cancel' to exit the picker at any time.",
+    )?;
+
+    let mut grouped: HashMap<Provider, Vec<&ModelOption>> = HashMap::new();
+    for option in options {
+        grouped.entry(option.provider).or_default().push(option);
+    }
+
+    for provider in Provider::all_providers() {
+        let Some(list) = grouped.get(&provider) else {
+            continue;
+        };
+        renderer.line(MessageStyle::Info, &format!("[{}]", provider.label()))?;
+        for option in list {
+            renderer.line(
+                MessageStyle::Info,
+                &format!("  ({}) {} • {}", option.index, option.display, option.id),
+            )?;
+            renderer.line(MessageStyle::Info, &format!("      {}", option.description))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn prompt_reasoning(
+    renderer: &mut AnsiRenderer,
+    selection: &SelectionDetail,
+    current: ReasoningEffortLevel,
+) -> Result<()> {
+    if selection.reasoning_optional {
+        renderer.line(
+            MessageStyle::Info,
+            &format!(
+                "Step 2 – reasoning effort (current: {}). Choose easy/medium/hard or type 'skip' if the model does not expose configurable reasoning.",
+                current
+            ),
+        )?
+    } else {
+        renderer.line(
+            MessageStyle::Info,
+            &format!(
+                "Step 2 – select reasoning effort for {} (easy/medium/hard). Current: {}.",
+                selection.model_display, current
+            ),
+        )?
+    }
+    Ok(())
+}
+
+fn prompt_api_key(renderer: &mut AnsiRenderer, selection: &SelectionDetail) -> Result<()> {
+    renderer.line(
+        MessageStyle::Info,
+        &format!(
+            "Step 3 – enter an API key for {} (env: {}).",
+            selection.provider_label, selection.env_key
+        ),
+    )?;
+    renderer.line(
+        MessageStyle::Info,
+        "Paste the API key now or type 'skip' to reuse the existing environment value.",
+    )?;
+    Ok(())
+}
+
+fn parse_model_selection(options: &[ModelOption], input: &str) -> Result<SelectionDetail> {
+    if let Ok(index) = input.parse::<usize>() {
+        if let Some(option) = options.iter().find(|candidate| candidate.index == index) {
+            return Ok(selection_from_option(option));
+        }
+        return Err(anyhow!("No model with number {}", index));
+    }
+
+    let mut parts = input.split_whitespace();
+    let Some(provider_token) = parts.next() else {
+        return Err(anyhow!("Please provide a provider and model identifier."));
+    };
+    let model_token = parts.collect::<Vec<&str>>().join(" ");
+    if model_token.trim().is_empty() {
+        return Err(anyhow!(
+            "Provide both provider and model. Example: 'openai gpt-5'"
+        ));
+    }
+
+    let provider_lower = provider_token.to_ascii_lowercase();
+    let provider_enum = Provider::from_str(&provider_lower).ok();
+
+    if let Some(option) = options
+        .iter()
+        .find(|candidate| candidate.id.eq_ignore_ascii_case(model_token.trim()))
+    {
+        if let Some(provider) = provider_enum {
+            if provider == option.provider {
+                return Ok(selection_from_option(option));
+            }
+        }
+    }
+
+    let provider_label = provider_enum
+        .map(|provider| provider.label().to_string())
+        .unwrap_or_else(|| title_case(&provider_lower));
+    let env_key = provider_enum
+        .map(|provider| provider.default_api_key_env().to_string())
+        .unwrap_or_else(|| derive_env_key(&provider_lower));
+    let reasoning_supported = provider_enum
+        .map(|provider| provider.supports_reasoning_effort(model_token.trim()))
+        .unwrap_or(true);
+    let requires_api_key = match std::env::var(&env_key) {
+        Ok(value) => value.trim().is_empty(),
+        Err(_) => true,
+    };
+
+    Ok(SelectionDetail {
+        provider_key: provider_lower,
+        provider_label,
+        provider_enum,
+        model_id: model_token.trim().to_string(),
+        model_display: model_token.trim().to_string(),
+        known_model: false,
+        reasoning_supported,
+        reasoning_optional: true,
+        requires_api_key,
+        env_key,
+    })
+}
+
+fn selection_from_option(option: &ModelOption) -> SelectionDetail {
+    let env_key = option.provider.default_api_key_env().to_string();
+    let requires_api_key = match std::env::var(&env_key) {
+        Ok(value) => value.trim().is_empty(),
+        Err(_) => true,
+    };
+    SelectionDetail {
+        provider_key: option.provider.to_string(),
+        provider_label: option.provider.label().to_string(),
+        provider_enum: Some(option.provider),
+        model_id: option.id.to_string(),
+        model_display: option.display.to_string(),
+        known_model: true,
+        reasoning_supported: option.supports_reasoning,
+        reasoning_optional: false,
+        requires_api_key,
+        env_key,
+    }
+}
+
+fn is_cancel_command(input: &str) -> bool {
+    matches!(
+        input.to_ascii_lowercase().as_str(),
+        "cancel" | "/cancel" | "abort" | "quit"
+    )
+}
+
+fn derive_env_key(provider: &str) -> String {
+    let mut key = String::new();
+    for ch in provider.chars() {
+        if ch.is_ascii_alphanumeric() {
+            key.push(ch.to_ascii_uppercase());
+        } else if !key.ends_with('_') {
+            key.push('_');
+        }
+    }
+    if key.is_empty() {
+        key.push_str("LLM");
+    }
+    if !key.ends_with("_API_KEY") {
+        if !key.ends_with('_') {
+            key.push('_');
+        }
+        key.push_str("API_KEY");
+    }
+    key
+}
+
+fn title_case(value: &str) -> String {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    let mut result = String::new();
+    result.push(first.to_ascii_uppercase());
+    result.push_str(&chars.as_str().to_ascii_lowercase());
+    result
+}

--- a/src/agent/runloop/prompt.rs
+++ b/src/agent/runloop/prompt.rs
@@ -156,7 +156,9 @@ fn keyword_set(text: &str) -> HashSet<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
     use vtcode_core::config::core::PromptCachingConfig;
+    use vtcode_core::config::models::Provider;
     use vtcode_core::config::types::{
         ModelSelectionSource, ReasoningEffortLevel, UiSurfacePreference,
     };
@@ -172,6 +174,7 @@ mod tests {
                 .to_string(),
             api_key: "test".to_string(),
             provider: "gemini".to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: std::env::current_dir().unwrap(),
             verbose: false,
             theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
@@ -179,6 +182,7 @@ mod tests {
             ui_surface: UiSurfacePreference::default(),
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
 
         let mut vt = VTCodeConfig::default();

--- a/src/agent/runloop/slash_commands.rs
+++ b/src/agent/runloop/slash_commands.rs
@@ -20,6 +20,7 @@ pub enum SlashCommandOutcome {
     },
     ShowConfig,
     Exit,
+    StartModelSelection,
 }
 
 pub fn handle_slash_command(
@@ -121,6 +122,7 @@ pub fn handle_slash_command(
             Ok(SlashCommandOutcome::InitializeWorkspace { force })
         }
         "config" => Ok(SlashCommandOutcome::ShowConfig),
+        "model" => Ok(SlashCommandOutcome::StartModelSelection),
         "sessions" => {
             let limit = parts
                 .next()

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use toml::Value as TomlValue;
 use tracing::warn;
 use vtcode_core::SimpleIndexer;
+use vtcode_core::config::api_keys::{ApiKeySources, get_api_key};
 use vtcode_core::config::constants::tools as tool_names;
 use vtcode_core::config::constants::{defaults, ui};
 use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
@@ -28,6 +29,7 @@ use vtcode_core::core::decision_tracker::{Action as DTAction, DecisionOutcome};
 use vtcode_core::core::router::{Router, TaskClass};
 use vtcode_core::core::token_budget::{ContextComponent, TokenBudgetManager};
 use vtcode_core::llm::error_display;
+use vtcode_core::llm::factory::create_provider_with_config;
 use vtcode_core::llm::provider::{self as uni, LLMStreamEvent};
 use vtcode_core::tool_policy::ToolPolicy;
 use vtcode_core::tools::registry::{ToolErrorType, ToolExecutionError, ToolPermissionDecision};
@@ -45,6 +47,9 @@ use crate::agent::runloop::context::{
 };
 use crate::agent::runloop::git::confirm_changes_with_git_diff;
 use crate::agent::runloop::is_context_overflow_error;
+use crate::agent::runloop::model_picker::{
+    ModelPickerProgress, ModelPickerState, ModelSelectionResult,
+};
 use crate::agent::runloop::prompt::refine_user_prompt_if_enabled;
 use crate::agent::runloop::slash_commands::{SlashCommandOutcome, handle_slash_command};
 use crate::agent::runloop::text_tools::detect_textual_tool_call;
@@ -55,6 +60,7 @@ use super::display::{display_user_message, ensure_turn_bottom_gap, persist_theme
 use super::session_setup::{SessionState, initialize_session};
 use super::shell::{derive_recent_tool_output, should_short_circuit_shell};
 use crate::agent::runloop::mcp_events;
+use crate::agent::runloop::welcome::SessionBootstrap;
 
 #[derive(Default)]
 struct SessionStats {
@@ -251,6 +257,154 @@ fn build_curator_tools(tools: &[uni::ToolDefinition]) -> Vec<CuratorToolDefiniti
             }
         })
         .collect()
+}
+
+fn finalize_model_selection(
+    renderer: &mut AnsiRenderer,
+    picker: &ModelPickerState,
+    selection: ModelSelectionResult,
+    config: &mut CoreAgentConfig,
+    vt_cfg: &mut Option<VTCodeConfig>,
+    provider_client: &mut Box<dyn uni::LLMProvider>,
+    session_bootstrap: &SessionBootstrap,
+    handle: &InlineHandle,
+    full_auto: bool,
+) -> Result<()> {
+    let workspace = config.workspace.clone();
+
+    let api_key = if let Some(key) = selection.api_key.as_ref() {
+        persist_env_value(&workspace, &selection.env_key, key)?;
+        unsafe {
+            // SAFETY: we only write ASCII-alphanumeric keys derived from known providers or
+            // sanitized user input, and values are supplied directly by the user.
+            std::env::set_var(&selection.env_key, key);
+        }
+        key.clone()
+    } else {
+        let key = get_api_key(&selection.provider, &ApiKeySources::default())
+            .with_context(|| format!("API key not found for provider '{}'", selection.provider))?;
+        unsafe {
+            // SAFETY: see above. Keys are sanitized and values come from configuration sources.
+            std::env::set_var(&selection.env_key, &key);
+        }
+        key
+    };
+
+    let updated_cfg = picker.persist_selection(&workspace, &selection)?;
+    *vt_cfg = Some(updated_cfg);
+
+    if let Some(provider_enum) = selection.provider_enum {
+        let provider_name = selection.provider.clone();
+        let new_client = create_provider_with_config(
+            &provider_name,
+            Some(api_key.clone()),
+            None,
+            Some(selection.model.clone()),
+            Some(config.prompt_cache.clone()),
+        )
+        .context("Failed to initialize provider for the selected model")?;
+        *provider_client = new_client;
+        config.provider = provider_enum.to_string();
+    } else {
+        renderer.line(
+            MessageStyle::Info,
+            "Saved selection, but custom providers require manual configuration before taking effect.",
+        )?;
+        config.provider = selection.provider.clone();
+    }
+
+    config.model = selection.model.clone();
+    config.api_key = api_key;
+    config.reasoning_effort = selection.reasoning;
+
+    let reasoning_label = selection.reasoning.as_str().to_string();
+    let mode_label = resolve_mode_label(config.ui_surface, full_auto);
+    let header_context = build_inline_header_context(
+        config,
+        session_bootstrap,
+        selection.provider_label.clone(),
+        selection.model.clone(),
+        mode_label,
+        reasoning_label.clone(),
+    )?;
+    handle.set_header_context(header_context);
+
+    renderer.line(
+        MessageStyle::Info,
+        &format!(
+            "Model set to {} ({}) via {}.",
+            selection.model_display, selection.model, selection.provider_label
+        ),
+    )?;
+
+    if !selection.known_model {
+        renderer.line(
+            MessageStyle::Info,
+            "The selected model is not part of VTCode's curated list; capabilities may vary.",
+        )?;
+    }
+
+    if selection.reasoning_supported {
+        let message = if selection.reasoning_changed {
+            format!("Reasoning effort updated to '{}'.", selection.reasoning)
+        } else {
+            format!("Reasoning effort remains '{}'.", selection.reasoning)
+        };
+        renderer.line(MessageStyle::Info, &message)?;
+    }
+
+    if selection.api_key.is_some() {
+        renderer.line(
+            MessageStyle::Info,
+            &format!(
+                "Stored credential under {} and updated the active environment.",
+                selection.env_key
+            ),
+        )?;
+    } else if selection.requires_api_key {
+        renderer.line(
+            MessageStyle::Info,
+            &format!(
+                "Using environment variable {} for authentication.",
+                selection.env_key
+            ),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn persist_env_value(workspace: &Path, key: &str, value: &str) -> Result<()> {
+    let env_path = workspace.join(".env");
+    let mut lines: Vec<String> = if env_path.exists() {
+        std::fs::read_to_string(&env_path)
+            .with_context(|| format!("Failed to read {}", env_path.display()))?
+            .lines()
+            .map(|line| line.to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let mut replaced = false;
+    for line in lines.iter_mut() {
+        if let Some((existing_key, _)) = line.split_once('=') {
+            if existing_key.trim() == key {
+                *line = format!("{key}={value}");
+                replaced = true;
+            }
+        }
+    }
+
+    if !replaced {
+        lines.push(format!("{key}={value}"));
+    }
+
+    let mut content = lines.join("\n");
+    content.push('\n');
+    std::fs::write(&env_path, content)
+        .with_context(|| format!("Failed to write {}", env_path.display()))?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1175,7 +1329,7 @@ fn is_sensitive_key(key: &str) -> bool {
 
 pub(crate) async fn run_single_agent_loop_unified(
     config: &CoreAgentConfig,
-    vt_cfg: Option<&VTCodeConfig>,
+    mut vt_cfg: Option<VTCodeConfig>,
     skip_confirmations: bool,
     full_auto: bool,
 ) -> Result<()> {
@@ -1187,9 +1341,10 @@ pub(crate) async fn run_single_agent_loop_unified(
         // The cleanup will happen in the Drop implementations
         original_hook(panic_info);
     }));
+    let mut config = config.clone();
     let SessionState {
         session_bootstrap,
-        provider_client,
+        mut provider_client,
         mut tool_registry,
         tools,
         trim_config,
@@ -1204,7 +1359,7 @@ pub(crate) async fn run_single_agent_loop_unified(
         token_budget,
         token_budget_enabled,
         mut curator,
-    } = initialize_session(config, vt_cfg, full_auto).await?;
+    } = initialize_session(&config, vt_cfg.as_ref(), full_auto).await?;
 
     let curator_tool_catalog = build_curator_tools(&tools);
 
@@ -1212,9 +1367,11 @@ pub(crate) async fn run_single_agent_loop_unified(
     let theme_spec = theme_from_styles(&active_styles);
     let default_placeholder = session_bootstrap.placeholder.clone();
     let inline_rows = vt_cfg
+        .as_ref()
         .map(|cfg| cfg.ui.inline_viewport_rows)
         .unwrap_or(ui::DEFAULT_INLINE_VIEWPORT_ROWS);
     let show_timeline_pane = vt_cfg
+        .as_ref()
         .map(|cfg| cfg.ui.show_timeline_pane)
         .unwrap_or(ui::INLINE_SHOW_TIMELINE_PANE);
     let session = spawn_session(
@@ -1227,6 +1384,7 @@ pub(crate) async fn run_single_agent_loop_unified(
     .context("failed to launch inline session")?;
     let handle = session.handle.clone();
     let highlight_config = vt_cfg
+        .as_ref()
         .map(|cfg| cfg.syntax_highlighting.clone())
         .unwrap_or_default();
     let mut renderer = AnsiRenderer::with_inline_ui(handle.clone(), highlight_config);
@@ -1268,19 +1426,20 @@ pub(crate) async fn run_single_agent_loop_unified(
     handle.set_placeholder(default_placeholder.clone());
 
     let reasoning_label = vt_cfg
+        .as_ref()
         .map(|cfg| cfg.agent.reasoning_effort.as_str().to_string())
         .unwrap_or_else(|| config.reasoning_effort.as_str().to_string());
 
     render_session_banner(
         &mut renderer,
-        config,
+        &config,
         &session_bootstrap,
         &config.model,
         &reasoning_label,
     )?;
     let mode_label = resolve_mode_label(config.ui_surface, full_auto);
     let header_context = build_inline_header_context(
-        config,
+        &config,
         &session_bootstrap,
         header_provider_label,
         config.model.clone(),
@@ -1363,6 +1522,7 @@ pub(crate) async fn run_single_agent_loop_unified(
     }
 
     let mut session_stats = SessionStats::default();
+    let mut model_picker_state: Option<ModelPickerState> = None;
     let mut events = session.events;
     let mut last_forced_redraw = Instant::now();
     loop {
@@ -1451,6 +1611,31 @@ pub(crate) async fn run_single_agent_loop_unified(
                             apply_prompt_style(&handle);
                             continue;
                         }
+                        SlashCommandOutcome::StartModelSelection => {
+                            if model_picker_state.is_some() {
+                                renderer.line(
+                                    MessageStyle::Error,
+                                    "A model picker session is already active. Complete or type 'cancel' to exit it before starting another.",
+                                )?;
+                                continue;
+                            }
+                            let reasoning = vt_cfg
+                                .as_ref()
+                                .map(|cfg| cfg.agent.reasoning_effort)
+                                .unwrap_or(config.reasoning_effort);
+                            match ModelPickerState::new(&mut renderer, reasoning) {
+                                Ok(picker) => {
+                                    model_picker_state = Some(picker);
+                                }
+                                Err(err) => {
+                                    renderer.line(
+                                        MessageStyle::Error,
+                                        &format!("Failed to start model picker: {}", err),
+                                    )?;
+                                }
+                            }
+                            continue;
+                        }
                         SlashCommandOutcome::InitializeWorkspace { force } => {
                             let workspace_path = config.workspace.clone();
                             let workspace_label = workspace_path.display().to_string();
@@ -1518,7 +1703,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                         }
                         SlashCommandOutcome::ShowConfig => {
                             let workspace_path = config.workspace.clone();
-                            let vt_snapshot = vt_cfg.cloned();
+                            let vt_snapshot = vt_cfg.clone();
                             match load_config_modal_content(workspace_path, vt_snapshot).await {
                                 Ok(content) => {
                                     if renderer.prefers_untruncated_output() {
@@ -1602,9 +1787,40 @@ pub(crate) async fn run_single_agent_loop_unified(
             _ => {}
         }
 
+        if let Some(picker) = model_picker_state.as_mut() {
+            let progress = picker.handle_input(&mut renderer, input_owned.as_str())?;
+            match progress {
+                ModelPickerProgress::InProgress => continue,
+                ModelPickerProgress::Cancelled => {
+                    model_picker_state = None;
+                    continue;
+                }
+                ModelPickerProgress::Completed(selection) => {
+                    let picker_state = model_picker_state.take().unwrap();
+                    if let Err(err) = finalize_model_selection(
+                        &mut renderer,
+                        &picker_state,
+                        selection,
+                        &mut config,
+                        &mut vt_cfg,
+                        &mut provider_client,
+                        &session_bootstrap,
+                        &handle,
+                        full_auto,
+                    ) {
+                        renderer.line(
+                            MessageStyle::Error,
+                            &format!("Failed to apply model selection: {}", err),
+                        )?;
+                    }
+                    continue;
+                }
+            }
+        }
+
         let input = input_owned.as_str();
 
-        let refined_user = refine_user_prompt_if_enabled(input, config, vt_cfg).await;
+        let refined_user = refine_user_prompt_if_enabled(input, &config, vt_cfg.as_ref()).await;
         // Display the user message with inline border decoration
         display_user_message(&mut renderer, &refined_user)?;
         conversation_history.push(uni::Message::user(refined_user));
@@ -1626,6 +1842,7 @@ pub(crate) async fn run_single_agent_loop_unified(
 
         let mut working_history = conversation_history.clone();
         let max_tool_loops = vt_cfg
+            .as_ref()
             .map(|cfg| cfg.tools.max_tool_loops)
             .filter(|&value| value > 0)
             .unwrap_or(defaults::DEFAULT_MAX_TOOL_LOOPS);
@@ -1659,10 +1876,10 @@ pub(crate) async fn run_single_agent_loop_unified(
 
             let _ = enforce_unified_context_window(&mut working_history, trim_config);
 
-            let decision = if let Some(cfg) = vt_cfg.filter(|cfg| cfg.router.enabled) {
-                Router::route_async(cfg, config, &config.api_key, input).await
+            let decision = if let Some(cfg) = vt_cfg.as_ref().filter(|cfg| cfg.router.enabled) {
+                Router::route_async(cfg, &config, &config.api_key, input).await
             } else {
-                Router::route(&VTCodeConfig::default(), config, input)
+                Router::route(&VTCodeConfig::default(), &config, input)
             };
             traj.log_route(
                 working_history.len(),
@@ -1678,7 +1895,7 @@ pub(crate) async fn run_single_agent_loop_unified(
             );
 
             let active_model = decision.selected_model;
-            let (max_tokens_opt, parallel_cfg_opt) = if let Some(vt) = vt_cfg {
+            let (max_tokens_opt, parallel_cfg_opt) = if let Some(vt) = vt_cfg.as_ref() {
                 let key = match decision.class {
                     TaskClass::Simple => "simple",
                     TaskClass::Standard => "standard",
@@ -1768,7 +1985,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                 }
 
                 let use_streaming = provider_client.supports_streaming();
-                let reasoning_effort = vt_cfg.and_then(|cfg| {
+                let reasoning_effort = vt_cfg.as_ref().and_then(|cfg| {
                     if provider_client.supports_reasoning_effort(&active_model) {
                         Some(cfg.agent.reasoning_effort.as_str().to_string())
                     } else {
@@ -2035,7 +2252,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                                         &mut renderer,
                                         Some(name),
                                         &tool_output,
-                                        vt_cfg,
+                                        vt_cfg.as_ref(),
                                     )?;
                                     last_tool_stdout = tool_output
                                         .get("stdout")
@@ -2242,7 +2459,12 @@ pub(crate) async fn run_single_agent_loop_unified(
                             )
                             .to_json_value();
                             traj.log_tool_call(working_history.len(), name, &args_val, false);
-                            render_tool_output(&mut renderer, Some(name), &denial, vt_cfg)?;
+                            render_tool_output(
+                                &mut renderer,
+                                Some(name),
+                                &denial,
+                                vt_cfg.as_ref(),
+                            )?;
                             let content =
                                 serde_json::to_string(&denial).unwrap_or("{}".to_string());
                             working_history
@@ -2310,9 +2532,11 @@ pub(crate) async fn run_single_agent_loop_unified(
 
             if let Some(mut text) = final_text.clone() {
                 let do_review = vt_cfg
+                    .as_ref()
                     .map(|cfg| cfg.agent.enable_self_review)
                     .unwrap_or(false);
                 let review_passes = vt_cfg
+                    .as_ref()
                     .map(|cfg| cfg.agent.max_review_passes)
                     .unwrap_or(1)
                     .max(1);
@@ -2333,7 +2557,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                             tool_choice: Some(uni::ToolChoice::none()),
                             parallel_tool_calls: None,
                             parallel_tool_config: None,
-                            reasoning_effort: vt_cfg.and_then(|cfg| {
+                            reasoning_effort: vt_cfg.as_ref().and_then(|cfg| {
                                 if provider_client.supports_reasoning_effort(&active_model) {
                                     Some(cfg.agent.reasoning_effort.as_str().to_string())
                                 } else {

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -367,9 +367,11 @@ fn should_check_for_updates() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
     use std::fs;
     use tempfile::tempdir;
     use vtcode_core::config::core::PromptCachingConfig;
+    use vtcode_core::config::models::Provider;
     use vtcode_core::config::types::{
         ModelSelectionSource, ReasoningEffortLevel, UiSurfacePreference,
     };
@@ -414,6 +416,7 @@ mod tests {
                 .to_string(),
             api_key: "test".to_string(),
             provider: "gemini".to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: tmp.path().to_path_buf(),
             verbose: false,
             theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
@@ -421,6 +424,7 @@ mod tests {
             ui_surface: UiSurfacePreference::default(),
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
 
         let bootstrap = prepare_session_bootstrap(&runtime_cfg, Some(&vt_cfg), None);
@@ -468,6 +472,7 @@ mod tests {
                 .to_string(),
             api_key: "test".to_string(),
             provider: "gemini".to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: tmp.path().to_path_buf(),
             verbose: false,
             theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
@@ -475,6 +480,7 @@ mod tests {
             ui_surface: UiSurfacePreference::default(),
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
 
         let vt_cfg = VTCodeConfig::default();
@@ -515,6 +521,7 @@ mod tests {
                 .to_string(),
             api_key: "test".to_string(),
             provider: "gemini".to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: tmp.path().to_path_buf(),
             verbose: false,
             theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
@@ -522,6 +529,7 @@ mod tests {
             ui_surface: UiSurfacePreference::default(),
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
 
         let bootstrap = prepare_session_bootstrap(&runtime_cfg, Some(&vt_cfg), None);

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,10 +1,12 @@
 use crate::cli::handle_chat_command;
 use anyhow::{Context, Result};
 use console::style;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use vtcode_core::config::core::PromptCachingConfig;
 use vtcode_core::config::loader::VTCodeConfig;
+use vtcode_core::config::models::Provider;
 use vtcode_core::config::types::{
     AgentConfig as CoreAgentConfig, ModelSelectionSource, ReasoningEffortLevel, UiSurfacePreference,
 };
@@ -36,6 +38,7 @@ pub async fn handle_init_command(workspace: &Path, force: bool, run: bool) -> Re
             model: String::new(),
             api_key: String::new(),
             provider: String::new(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: workspace.to_path_buf(),
             verbose: false,
             theme: DEFAULT_THEME_ID.to_string(),
@@ -43,6 +46,7 @@ pub async fn handle_init_command(workspace: &Path, force: bool, run: bool) -> Re
             ui_surface: UiSurfacePreference::default(),
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
         handle_chat_command(&config, false, false)
             .await

--- a/tests/stats_command_test.rs
+++ b/tests/stats_command_test.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::BTreeMap;
 use tempfile::TempDir;
 use tokio::time::{Duration, sleep};
 use vtcode_core::{
@@ -19,6 +20,7 @@ async fn test_handle_stats_command_returns_agent_metrics() -> Result<()> {
         model: GEMINI_2_5_FLASH_PREVIEW.to_string(),
         api_key: "test_key".to_string(),
         provider: "gemini".to_string(),
+        api_key_env: "GEMINI_API_KEY".to_string(),
         workspace: temp_dir.path().to_path_buf(),
         verbose: false,
         theme: DEFAULT_THEME_ID.to_string(),
@@ -26,6 +28,7 @@ async fn test_handle_stats_command_returns_agent_metrics() -> Result<()> {
         ui_surface: UiSurfacePreference::default(),
         prompt_cache: PromptCachingConfig::default(),
         model_source: ModelSelectionSource::WorkspaceConfig,
+        custom_api_keys: BTreeMap::new(),
     };
     let mut agent = Agent::new(config)?;
     agent.update_session_stats(5, 3, 1);

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -97,6 +97,7 @@ pulldown-cmark = { version = "0.9", default-features = false, features = [
     "simd",
 ] }
 catppuccin = { version = "2.5", default-features = false }
+rig = { package = "rig-core", version = "0.21", default-features = false, features = ["reqwest-rustls"] }
 
 # MCP (Model Context Protocol) support
 rmcp = { version = "0.7.0", features = ["client", "transport-child-process"] }

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -1,6 +1,7 @@
 use crate::config::constants::{defaults, project_doc};
 use crate::config::types::{ReasoningEffortLevel, UiSurfacePreference};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Agent-wide configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -8,6 +9,10 @@ pub struct AgentConfig {
     /// AI provider for single agent mode (gemini, openai, anthropic, openrouter, xai)
     #[serde(default = "default_provider")]
     pub provider: String,
+
+    /// Environment variable that stores the API key for the active provider
+    #[serde(default = "default_api_key_env")]
+    pub api_key_env: String,
 
     /// Default model to use
     #[serde(default = "default_model")]
@@ -61,12 +66,17 @@ pub struct AgentConfig {
     /// Maximum bytes of AGENTS.md content to load from project hierarchy
     #[serde(default = "default_project_doc_max_bytes")]
     pub project_doc_max_bytes: usize,
+
+    /// Provider-specific API keys captured from interactive configuration flows
+    #[serde(default)]
+    pub custom_api_keys: BTreeMap<String, String>,
 }
 
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             provider: default_provider(),
+            api_key_env: default_api_key_env(),
             default_model: default_model(),
             theme: default_theme(),
             todo_planning_mode: default_todo_planning_mode(),
@@ -80,12 +90,17 @@ impl Default for AgentConfig {
             refine_prompts_model: String::new(),
             onboarding: AgentOnboardingConfig::default(),
             project_doc_max_bytes: default_project_doc_max_bytes(),
+            custom_api_keys: BTreeMap::new(),
         }
     }
 }
 
 fn default_provider() -> String {
     defaults::DEFAULT_PROVIDER.to_string()
+}
+
+fn default_api_key_env() -> String {
+    defaults::DEFAULT_API_KEY_ENV.to_string()
 }
 fn default_model() -> String {
     defaults::DEFAULT_MODEL.to_string()

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::str::FromStr;
 
 /// Supported AI model providers
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum Provider {
     /// Google Gemini models
     #[default]
@@ -50,6 +50,32 @@ impl Provider {
             Provider::XAI,
         ]
     }
+
+    /// Human-friendly label for display purposes
+    pub fn label(&self) -> &'static str {
+        match self {
+            Provider::Gemini => "Gemini",
+            Provider::OpenAI => "OpenAI",
+            Provider::Anthropic => "Anthropic",
+            Provider::DeepSeek => "DeepSeek",
+            Provider::OpenRouter => "OpenRouter",
+            Provider::XAI => "xAI",
+        }
+    }
+
+    /// Determine if the provider supports configurable reasoning effort for the model
+    pub fn supports_reasoning_effort(&self, model: &str) -> bool {
+        use crate::config::constants::models;
+
+        match self {
+            Provider::Gemini => model == models::google::GEMINI_2_5_PRO,
+            Provider::OpenAI => models::openai::REASONING_MODELS.contains(&model),
+            Provider::Anthropic => models::anthropic::SUPPORTED_MODELS.contains(&model),
+            Provider::DeepSeek => model == models::deepseek::DEEPSEEK_REASONER,
+            Provider::OpenRouter => models::openrouter::REASONING_MODELS.contains(&model),
+            Provider::XAI => model == models::xai::GROK_2_REASONING,
+        }
+    }
 }
 
 impl fmt::Display for Provider {
@@ -82,7 +108,7 @@ impl FromStr for Provider {
 }
 
 /// Centralized enum for all supported model identifiers
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModelId {
     // Gemini models
     /// Gemini 2.5 Flash Preview - Latest fast model with advanced capabilities
@@ -213,6 +239,11 @@ impl ModelId {
             | ModelId::OpenRouterAnthropicClaudeSonnet45
             | ModelId::OpenRouterAnthropicClaudeSonnet4 => Provider::OpenRouter,
         }
+    }
+
+    /// Whether this model supports configurable reasoning effort levels
+    pub fn supports_reasoning_effort(&self) -> bool {
+        self.provider().supports_reasoning_effort(self.as_str())
     }
 
     /// Get the display name for the model (human-readable)

--- a/vtcode-core/src/config/types/mod.rs
+++ b/vtcode-core/src/config/types/mod.rs
@@ -4,7 +4,7 @@ use crate::config::constants::reasoning;
 use crate::config::core::PromptCachingConfig;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 /// Supported reasoning effort levels configured via vtcode.toml
@@ -170,6 +170,7 @@ pub struct AgentConfig {
     pub model: String,
     pub api_key: String,
     pub provider: String,
+    pub api_key_env: String,
     pub workspace: std::path::PathBuf,
     pub verbose: bool,
     pub theme: String,
@@ -177,6 +178,7 @@ pub struct AgentConfig {
     pub ui_surface: UiSurfacePreference,
     pub prompt_cache: PromptCachingConfig,
     pub model_source: ModelSelectionSource,
+    pub custom_api_keys: BTreeMap<String, String>,
 }
 
 /// Workshop agent capability levels

--- a/vtcode-core/src/core/agent/bootstrap.rs
+++ b/vtcode-core/src/core/agent/bootstrap.rs
@@ -195,6 +195,7 @@ mod tests {
     use crate::config::core::PromptCachingConfig;
     use crate::config::models::Provider;
     use crate::config::types::{ModelSelectionSource, ReasoningEffortLevel, UiSurfacePreference};
+    use std::collections::BTreeMap;
 
     #[test]
     fn builds_default_component_set() {
@@ -203,6 +204,7 @@ mod tests {
             model: models::GEMINI_2_5_FLASH_PREVIEW.to_string(),
             api_key: "test-api-key".to_string(),
             provider: Provider::Gemini.to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: temp_dir.path().to_path_buf(),
             verbose: false,
             theme: "default".to_string(),
@@ -210,6 +212,7 @@ mod tests {
             ui_surface: UiSurfacePreference::Inline,
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
 
         let components = AgentComponentBuilder::new(&agent_config)
@@ -228,6 +231,7 @@ mod tests {
             model: models::GEMINI_2_5_FLASH_PREVIEW.to_string(),
             api_key: "test-api-key".to_string(),
             provider: Provider::Gemini.to_string(),
+            api_key_env: Provider::Gemini.default_api_key_env().to_string(),
             workspace: temp_dir.path().to_path_buf(),
             verbose: true,
             theme: "custom".to_string(),
@@ -235,6 +239,7 @@ mod tests {
             ui_surface: UiSurfacePreference::Alternate,
             prompt_cache: PromptCachingConfig::default(),
             model_source: ModelSelectionSource::WorkspaceConfig,
+            custom_api_keys: BTreeMap::new(),
         };
 
         let custom_session = SessionInfo {

--- a/vtcode-core/src/core/agent/core.rs
+++ b/vtcode-core/src/core/agent/core.rs
@@ -1,7 +1,7 @@
 //! Core agent implementation and orchestration
 
 use crate::config::core::PromptCachingConfig;
-use crate::config::models::ModelId;
+use crate::config::models::{ModelId, Provider};
 use crate::config::types::*;
 use crate::core::agent::bootstrap::{AgentComponentBuilder, AgentComponentSet};
 use crate::core::agent::compaction::CompactionEngine;
@@ -13,6 +13,7 @@ use crate::tools::ToolRegistry;
 use crate::tools::tree_sitter::{CodeAnalysis, TreeSitterAnalyzer};
 use anyhow::{Result, anyhow};
 use console::style;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 /// Main agent orchestrator
@@ -444,7 +445,8 @@ impl AgentBuilder {
             config: AgentConfig {
                 model: ModelId::default().as_str().to_string(),
                 api_key: String::new(),
-                provider: "gemini".to_string(),
+                provider: Provider::Gemini.to_string(),
+                api_key_env: Provider::Gemini.default_api_key_env().to_string(),
                 workspace: std::env::current_dir()
                     .unwrap_or_else(|_| std::path::PathBuf::from(".")),
                 verbose: false,
@@ -453,6 +455,7 @@ impl AgentBuilder {
                 ui_surface: UiSurfacePreference::default(),
                 prompt_cache: PromptCachingConfig::default(),
                 model_source: ModelSelectionSource::WorkspaceConfig,
+                custom_api_keys: BTreeMap::new(),
             },
         }
     }

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -186,7 +186,7 @@ pub use ui::diff_renderer::DiffRenderer;
 pub use utils::dot_config::{
     CacheConfig, DotConfig, DotManager, ProviderConfigs, UiConfig, UserPreferences,
     WorkspaceTrustLevel, WorkspaceTrustRecord, WorkspaceTrustStore, initialize_dot_folder,
-    load_user_config, save_user_config, update_theme_preference,
+    load_user_config, save_user_config, update_model_preference, update_theme_preference,
 };
 pub use utils::vtcodegitignore::initialize_vtcode_gitignore;
 

--- a/vtcode-core/src/llm/mod.rs
+++ b/vtcode-core/src/llm/mod.rs
@@ -166,6 +166,7 @@ pub mod error_display;
 pub mod factory;
 pub mod provider;
 pub mod providers;
+pub mod rig_adapter;
 pub mod types;
 
 #[cfg(test)]

--- a/vtcode-core/src/llm/rig_adapter.rs
+++ b/vtcode-core/src/llm/rig_adapter.rs
@@ -1,0 +1,90 @@
+use crate::config::models::Provider;
+use crate::config::types::ReasoningEffortLevel;
+use anyhow::Result;
+use rig::client::CompletionClient;
+use rig::providers::gemini::completion::gemini_api_types::ThinkingConfig;
+use rig::providers::{anthropic, deepseek, gemini, openai, openrouter, xai};
+use serde_json::{Value, json};
+
+/// Result of validating a provider/model combination through rig-core.
+#[derive(Debug, Clone)]
+pub struct RigValidationSummary {
+    pub provider: Provider,
+    pub model: String,
+}
+
+/// Attempt to construct a rig-core client for the given provider and
+/// instantiate the requested model. This performs a lightweight validation
+/// without issuing a network request, ensuring that downstream calls can
+/// reuse the rig client configuration paths.
+pub fn verify_model_with_rig(
+    provider: Provider,
+    model: &str,
+    api_key: &str,
+) -> Result<RigValidationSummary> {
+    match provider {
+        Provider::Gemini => {
+            let client = gemini::Client::new(api_key);
+            let _ = client.completion_model(model);
+        }
+        Provider::OpenAI => {
+            let client = openai::Client::new(api_key);
+            let _ = client.completion_model(model);
+        }
+        Provider::Anthropic => {
+            let client = anthropic::Client::new(api_key);
+            let _ = client.completion_model(model);
+        }
+        Provider::DeepSeek => {
+            let client = deepseek::Client::new(api_key);
+            let _ = client.completion_model(model);
+        }
+        Provider::OpenRouter => {
+            let client = openrouter::Client::new(api_key);
+            let _ = client.completion_model(model);
+        }
+        Provider::XAI => {
+            let client = xai::Client::new(api_key);
+            let _ = client.completion_model(model);
+        }
+    }
+
+    Ok(RigValidationSummary {
+        provider,
+        model: model.to_string(),
+    })
+}
+
+/// Convert a vtcode reasoning effort level to provider-specific parameters
+/// using rig-core data structures. The resulting JSON payload can be merged
+/// into provider requests when supported.
+pub fn reasoning_parameters_for(provider: Provider, effort: ReasoningEffortLevel) -> Option<Value> {
+    match provider {
+        Provider::OpenAI => {
+            let mut reasoning = openai::responses_api::Reasoning::new();
+            let mapped = match effort {
+                ReasoningEffortLevel::Low => openai::responses_api::ReasoningEffort::Low,
+                ReasoningEffortLevel::Medium => openai::responses_api::ReasoningEffort::Medium,
+                ReasoningEffortLevel::High => openai::responses_api::ReasoningEffort::High,
+            };
+            reasoning = reasoning.with_effort(mapped);
+            serde_json::to_value(reasoning).ok()
+        }
+        Provider::Gemini => {
+            let include_thoughts = matches!(effort, ReasoningEffortLevel::High);
+            let budget = match effort {
+                ReasoningEffortLevel::Low => 64,
+                ReasoningEffortLevel::Medium => 128,
+                ReasoningEffortLevel::High => 256,
+            };
+            let config = ThinkingConfig {
+                thinking_budget: budget,
+                include_thoughts: Some(include_thoughts),
+            };
+            serde_json::to_value(config)
+                .ok()
+                .map(|value| json!({ "thinking_config": value }))
+        }
+        _ => None,
+    }
+}

--- a/vtcode-core/src/ui/slash.rs
+++ b/vtcode-core/src/ui/slash.rs
@@ -19,6 +19,10 @@ pub static SLASH_COMMANDS: Lazy<Vec<SlashCommandInfo>> = Lazy::new(|| {
             description: "View the effective vtcode.toml configuration",
         },
         SlashCommandInfo {
+            name: "model",
+            description: "Launch the interactive model picker",
+        },
+        SlashCommandInfo {
             name: "theme",
             description: "Switch UI theme (usage: /theme <theme-id>)",
         },

--- a/vtcode-core/src/utils/dot_config.rs
+++ b/vtcode-core/src/utils/dot_config.rs
@@ -494,6 +494,15 @@ pub fn update_theme_preference(theme: &str) -> Result<(), DotError> {
     manager.update_config(|cfg| cfg.preferences.theme = theme.to_string())
 }
 
+/// Persist the preferred provider and model combination.
+pub fn update_model_preference(provider: &str, model: &str) -> Result<(), DotError> {
+    let manager = get_dot_manager().lock().unwrap();
+    manager.update_config(|cfg| {
+        cfg.preferences.default_provider = provider.to_string();
+        cfg.preferences.default_model = model.to_string();
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vtcode-core/tests/router_test.rs
+++ b/vtcode-core/tests/router_test.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use vtcode_core::config::core::PromptCachingConfig;
 use vtcode_core::config::loader::VTCodeConfig;
 use vtcode_core::config::types::{
@@ -10,6 +12,7 @@ fn core_cfg(model: &str) -> CoreAgentConfig {
         model: model.to_string(),
         api_key: "test".to_string(),
         provider: "gemini".to_string(),
+        api_key_env: "GEMINI_API_KEY".to_string(),
         workspace: std::env::current_dir().unwrap(),
         verbose: false,
         theme: vtcode_core::ui::theme::DEFAULT_THEME_ID.to_string(),
@@ -17,6 +20,7 @@ fn core_cfg(model: &str) -> CoreAgentConfig {
         ui_surface: UiSurfacePreference::default(),
         prompt_cache: PromptCachingConfig::default(),
         model_source: ModelSelectionSource::WorkspaceConfig,
+        custom_api_keys: BTreeMap::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- add a `/model` slash command that launches an interactive picker for providers, models, reasoning effort, and optional API keys
- persist chosen provider/model combinations into vtcode.toml, dot-config defaults, and updated inline UI headers
- expose provider metadata helpers and config save utilities so selections can be stored and reloaded across sessions

## Testing
- cargo fmt
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e0bb7f481483239cc969e7a207d6b5