### PR TITLE
feat: enhance onboarding welcome hints

### DIFF
--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -461,9 +461,8 @@ fn format_provider_label(value: &str) -> String {
             let Some(first) = chars.next() else {
                 return String::new();
             };
-            let mut formatted = String::new();
-            formatted.push(first.to_ascii_uppercase());
-            formatted.push_str(&chars.as_str().to_ascii_lowercase());
+            let mut formatted: String = first.to_uppercase().collect();
+            formatted.push_str(chars.as_str());
             formatted
         })
 }

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -5,6 +5,7 @@ use indicatif::ProgressStyle;
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write as FmtWrite;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -21,6 +22,7 @@ use vtcode_core::config::api_keys::{ApiKeySources, get_api_key};
 use vtcode_core::config::constants::tools as tool_names;
 use vtcode_core::config::constants::{defaults, ui};
 use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
+use vtcode_core::config::models::Provider;
 use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, UiSurfacePreference};
 use vtcode_core::core::context_curator::{
     ConversationPhase, CuratedContext, Message as CuratorMessage,
@@ -446,6 +448,26 @@ fn resolve_mode_label(preference: UiSurfacePreference, full_auto: bool) -> Strin
     }
 }
 
+fn format_provider_label(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    Provider::from_str(trimmed)
+        .map(|provider| provider.label().to_string())
+        .unwrap_or_else(|_| {
+            let mut chars = trimmed.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            let mut formatted = String::new();
+            formatted.push(first.to_ascii_uppercase());
+            formatted.push_str(&chars.as_str().to_ascii_lowercase());
+            formatted
+        })
+}
+
 fn build_curated_sections(context: &CuratedContext) -> Vec<CuratedPromptSection> {
     let mut sections = Vec::new();
 
@@ -619,7 +641,8 @@ fn finalize_model_selection(
             _ if selection.requires_api_key => {
                 return Err(anyhow!(
                     "API key not found for provider '{}'. Set {} or enter a key to continue.",
-                    selection.provider, selection.env_key
+                    selection.provider,
+                    selection.env_key
                 ));
             }
             _ => String::new(),
@@ -1769,9 +1792,9 @@ pub(crate) async fn run_single_agent_loop_unified(
         .unwrap_or_else(|| "workspace".to_string());
     let workspace_path = config.workspace.to_string_lossy().into_owned();
     let provider_label = if config.provider.trim().is_empty() {
-        provider_client.name().to_string()
+        format_provider_label(provider_client.name())
     } else {
-        config.provider.clone()
+        format_provider_label(&config.provider)
     };
     let header_provider_label = provider_label.clone();
     let archive_metadata = SessionArchiveMetadata::new(

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -146,7 +146,7 @@ fn render_welcome_text(
 
         if !details.is_empty() {
             let mut section = Vec::with_capacity(details.len() + 1);
-            section.push("**Project Overview**".to_string());
+            section.push(style_section_title("Project Overview"));
             section.extend(details);
             sections.push(SectionBlock::new(section, SectionSpacing::Normal));
         }
@@ -159,7 +159,7 @@ fn render_welcome_text(
         if !trimmed.is_empty() {
             add_section(
                 &mut sections,
-                "Detected Languages",
+                style_section_title("Detected Languages"),
                 vec![trimmed.to_string()],
                 SectionSpacing::Normal,
             );
@@ -363,7 +363,7 @@ fn add_list_section(
         .map(|entry| format!("- {}", entry))
         .collect();
 
-    add_section(sections, title, body, spacing);
+    add_section(sections, style_section_title(title), body, spacing);
 }
 
 fn add_keyboard_shortcut_section(sections: &mut Vec<SectionBlock>) {
@@ -431,13 +431,17 @@ fn add_slash_command_section(sections: &mut Vec<SectionBlock>) {
     let mut body = Vec::with_capacity(entries.len() + 1);
     let intro = ui_constants::WELCOME_SLASH_COMMAND_INTRO.trim();
     if !intro.is_empty() {
-        body.push(intro.to_string());
+        body.push(format!(
+            "{}{}",
+            ui_constants::WELCOME_SLASH_COMMAND_INDENT,
+            intro
+        ));
     }
     body.extend(entries);
 
     add_section(
         sections,
-        ui_constants::WELCOME_SLASH_COMMAND_SECTION_TITLE,
+        style_section_title(ui_constants::WELCOME_SLASH_COMMAND_SECTION_TITLE),
         body,
         SectionSpacing::Compact,
     );
@@ -607,7 +611,8 @@ mod tests {
             ui_constants::WELCOME_SHORTCUT_SECTION_TITLE
         );
 
-        assert!(welcome.contains("**Project Overview**"));
+        let styled_overview = style_section_title("Project Overview");
+        assert!(welcome.contains(&styled_overview));
         assert!(welcome.contains("**Project:"));
         assert!(welcome.contains("Tip one"));
         assert!(welcome.contains("Follow workspace guidelines"));
@@ -615,10 +620,17 @@ mod tests {
         assert!(welcome.contains(&styled_shortcuts));
         assert!(plain.contains("Keyboard Shortcuts"));
         assert!(plain.contains("Key Guidelines"));
-        assert!(welcome.contains("Slash Commands"));
+        let styled_slash_commands =
+            style_section_title(ui_constants::WELCOME_SLASH_COMMAND_SECTION_TITLE);
+        assert!(welcome.contains(&styled_slash_commands));
         assert!(welcome.contains(ui_constants::WELCOME_SLASH_COMMAND_INTRO));
         assert!(welcome.contains(&format!(
             "{}{}init",
+            ui_constants::WELCOME_SLASH_COMMAND_INDENT,
+            ui_constants::WELCOME_SLASH_COMMAND_PREFIX
+        )));
+        assert!(!welcome.contains(&format!(
+            "{}{}help",
             ui_constants::WELCOME_SLASH_COMMAND_INDENT,
             ui_constants::WELCOME_SLASH_COMMAND_PREFIX
         )));
@@ -698,6 +710,11 @@ mod tests {
         assert!(welcome.contains(ui_constants::WELCOME_SLASH_COMMAND_INTRO));
         assert!(welcome.contains(&format!(
             "{}{}command",
+            ui_constants::WELCOME_SLASH_COMMAND_INDENT,
+            ui_constants::WELCOME_SLASH_COMMAND_PREFIX
+        )));
+        assert!(!welcome.contains(&format!(
+            "{}{}help",
             ui_constants::WELCOME_SLASH_COMMAND_INDENT,
             ui_constants::WELCOME_SLASH_COMMAND_PREFIX
         )));

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -406,11 +406,7 @@ fn add_slash_command_section(sections: &mut Vec<SectionBlock>) {
         return;
     }
 
-    let command_iter = if limit >= SLASH_COMMANDS.len() {
-        SLASH_COMMANDS.iter()
-    } else {
-        SLASH_COMMANDS.iter().take(limit)
-    };
+    let command_iter = SLASH_COMMANDS.iter().take(limit);
 
     let entries: Vec<String> = command_iter
         .map(|info| {

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -98,7 +98,6 @@ pulldown-cmark = { version = "0.9", default-features = false, features = [
 ] }
 catppuccin = { version = "2.5", default-features = false }
 similar = "2.4"
-similar = "2.4"
 rig = { package = "rig-core", version = "0.21", default-features = false, features = ["reqwest-rustls"] }
 
 # MCP (Model Context Protocol) support

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -350,6 +350,12 @@ pub mod ui {
     pub const HEADER_SHORTCUT_HINT: &str =
         "Shortcuts: Ctrl+Enter to submit • Esc to cancel • Ctrl+C to interrupt";
     pub const HEADER_META_SEPARATOR: &str = "   ";
+    pub const WELCOME_SHORTCUT_SECTION_TITLE: &str = "Keyboard Shortcuts";
+    pub const WELCOME_SHORTCUT_HINT_PREFIX: &str = "Shortcuts:";
+    pub const WELCOME_SHORTCUT_SEPARATOR: &str = "•";
+    pub const WELCOME_SLASH_COMMAND_SECTION_TITLE: &str = "Slash Commands";
+    pub const WELCOME_SLASH_COMMAND_LIMIT: usize = 3;
+    pub const WELCOME_SLASH_COMMAND_PREFIX: &str = "/";
     pub const NAVIGATION_BLOCK_TITLE: &str = "Timeline";
     pub const NAVIGATION_EMPTY_LABEL: &str = "Waiting for activity";
     pub const NAVIGATION_INDEX_PREFIX: &str = "#";

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -353,9 +353,13 @@ pub mod ui {
     pub const WELCOME_SHORTCUT_SECTION_TITLE: &str = "Keyboard Shortcuts";
     pub const WELCOME_SHORTCUT_HINT_PREFIX: &str = "Shortcuts:";
     pub const WELCOME_SHORTCUT_SEPARATOR: &str = "•";
+    pub const WELCOME_SHORTCUT_INDENT: &str = "  ";
     pub const WELCOME_SLASH_COMMAND_SECTION_TITLE: &str = "Slash Commands";
-    pub const WELCOME_SLASH_COMMAND_LIMIT: usize = 3;
+    pub const WELCOME_SLASH_COMMAND_LIMIT: usize = usize::MAX;
     pub const WELCOME_SLASH_COMMAND_PREFIX: &str = "/";
+    pub const WELCOME_SLASH_COMMAND_INTRO: &str =
+        "To get started, describe a task or try one of these commands:";
+    pub const WELCOME_SLASH_COMMAND_INDENT: &str = "  ";
     pub const NAVIGATION_BLOCK_TITLE: &str = "Timeline";
     pub const NAVIGATION_EMPTY_LABEL: &str = "Waiting for activity";
     pub const NAVIGATION_INDEX_PREFIX: &str = "#";

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -355,7 +355,7 @@ pub mod ui {
     pub const WELCOME_SHORTCUT_SEPARATOR: &str = "•";
     pub const WELCOME_SHORTCUT_INDENT: &str = "  ";
     pub const WELCOME_SLASH_COMMAND_SECTION_TITLE: &str = "Slash Commands";
-    pub const WELCOME_SLASH_COMMAND_LIMIT: usize = usize::MAX;
+    pub const WELCOME_SLASH_COMMAND_LIMIT: usize = 6;
     pub const WELCOME_SLASH_COMMAND_PREFIX: &str = "/";
     pub const WELCOME_SLASH_COMMAND_INTRO: &str =
         "To get started, describe a task or try one of these commands:";


### PR DESCRIPTION
## Summary
- surface keyboard shortcut and slash command hints in the onboarding welcome panel with tighter spacing between suggestion sections
- add reusable UI constants to describe the new hints
- normalize provider display names so the inline header shows capitalized labels

## Testing
- rustfmt src/agent/runloop/welcome.rs src/agent/runloop/unified/turn.rs vtcode-core/src/config/constants.rs
- cargo fmt *(fails: duplicate key in vtcode-core/Cargo.toml)*
- cargo test test_prepare_session_bootstrap_builds_sections *(fails: duplicate key in vtcode-core/Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68e10180d7808323943dccc573d06946