### PR TITLE
Prune unused dependencies and simplify performance monitor initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,41 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "agent-client-protocol"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,18 +163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "argon2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
-dependencies = [
- "base64ct",
- "blake2",
- "cpufeatures",
- "password-hash",
-]
-
-[[package]]
 name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,12 +253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,15 +281,6 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "block-buffer"
@@ -476,16 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,15 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,15 +554,6 @@ dependencies = [
  "serde_json",
  "time",
  "url",
-]
-
-[[package]]
-name = "coolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
-dependencies = [
- "crossterm 0.29.0",
 ]
 
 [[package]]
@@ -717,54 +627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crokey"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51360853ebbeb3df20c76c82aecf43d387a62860f1a59ba65ab51f00eea85aad"
-dependencies = [
- "crokey-proc_macros",
- "crossterm 0.29.0",
- "once_cell",
- "serde",
- "strict",
-]
-
-[[package]]
-name = "crokey-proc_macros"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf1a727caeb5ee5e0a0826a97f205a9cf84ee964b0b48239fef5214a00ae439"
-dependencies = [
- "crossterm 0.29.0",
- "proc-macro2",
- "quote",
- "strict",
- "syn",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,15 +641,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -831,24 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "derive_more",
- "document-features",
- "mio 1.0.4",
- "parking_lot",
- "rustix 1.1.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,17 +705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -976,27 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,7 +833,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1364,16 +1167,6 @@ dependencies = [
  "r-efi",
  "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
 ]
 
 [[package]]
@@ -1785,15 +1578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "instability"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,29 +1675,6 @@ checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "lazy-regex"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn",
 ]
 
 [[package]]
@@ -2028,15 +1789,6 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "minimad"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -2229,12 +1981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2323,17 +2069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,12 +2079,6 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2434,18 +2163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
 ]
 
 [[package]]
@@ -3362,12 +3079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
-name = "strict"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,38 +3210,6 @@ dependencies = [
  "once_cell",
  "rustix 1.1.2",
  "windows-sys 0.61.1",
-]
-
-[[package]]
-name = "termimad"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7301d9c2c4939c97f25376b70d3c13311f8fefdee44092fc361d2a98adc2cbb6"
-dependencies = [
- "coolor",
- "crokey",
- "crossbeam",
- "lazy-regex",
- "minimad",
- "serde",
- "thiserror 2.0.16",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "termimad"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ff5ca043d65d4ea43b65cdb4e3aba119657d0d12caf44f93212ec3168a8e20"
-dependencies = [
- "coolor",
- "crokey",
- "crossbeam",
- "lazy-regex",
- "minimad",
- "serde",
- "thiserror 2.0.16",
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -4100,16 +3779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,64 +3889,37 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vtcode"
 version = "0.20.9"
 dependencies = [
- "aes-gcm",
  "agent-client-protocol",
- "anstream",
  "anstyle",
  "anstyle-git",
  "anstyle-ls",
- "anstyle-query",
  "anyhow",
- "argon2",
  "async-trait",
  "chrono",
  "clap",
  "colorchoice",
- "colored",
  "console 0.15.11",
  "criterion",
- "dashmap",
  "dialoguer 0.9.0",
- "flate2",
  "futures",
- "glob",
  "indexmap",
  "indicatif",
  "is-terminal",
  "itertools 0.13.0",
- "lazy_static",
- "lru",
  "once_cell",
  "path-clean",
- "pathdiff",
  "percent-encoding",
  "rand 0.8.5",
- "ratatui",
- "rayon",
  "regex",
- "reqwest",
  "serde",
  "serde_json",
- "sha2",
- "syntect",
  "sysinfo",
  "tempfile",
- "termimad 0.31.3",
- "terminal_size",
- "thiserror 1.0.69",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
- "tree-sitter",
- "tree-sitter-go",
- "tree-sitter-java",
- "tree-sitter-javascript",
- "tree-sitter-rust",
- "tree-sitter-typescript",
- "unicode-width 0.1.14",
  "update-informer",
  "url",
  "vtcode-core",
@@ -4288,7 +3930,6 @@ dependencies = [
 name = "vtcode-core"
 version = "0.20.9"
 dependencies = [
- "aes-gcm",
  "anstream",
  "anstyle",
  "anstyle-git",
@@ -4296,7 +3937,6 @@ dependencies = [
  "anstyle-query",
  "anstyle-syntect",
  "anyhow",
- "argon2",
  "async-stream",
  "async-trait",
  "catppuccin",
@@ -4318,17 +3958,13 @@ dependencies = [
  "indexmap",
  "is-terminal",
  "itertools 0.13.0",
- "lazy_static",
- "lru",
  "nucleo-matcher",
  "once_cell",
  "parking_lot",
- "pathdiff",
  "pulldown-cmark",
  "quick_cache",
  "rand 0.8.5",
  "ratatui",
- "rayon",
  "regex",
  "reqwest",
  "rig-core",
@@ -4342,12 +3978,10 @@ dependencies = [
  "similar",
  "syntect",
  "tempfile",
- "termimad 0.34.0",
  "terminal_size",
  "thiserror 1.0.69",
  "tiktoken-rs",
  "tokio",
- "tokio-stream",
  "toml",
  "tracing",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,60 +47,27 @@ tokio = { version = "1.37", features = [
     "sync",
 ] }
 tokio-util = { version = "0.7", features = ["compat"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
-tokio-stream = { version = "0.1", features = ["io-util"] }
 futures = "0.3"
 walkdir = "2.5"
-glob = "0.3"
-thiserror = "1.0"
 console = "0.15"
-colored = "2.1"
-indexmap = { version = "2.2", features = ["serde"] }
 itertools = "0.13"
-termimad = "0.31"
 update-informer = "1.3.0"
-regex = "1.10"
-tree-sitter = "0.25"
-tree-sitter-rust = "0.23"
-tree-sitter-javascript = "0.23"
-tree-sitter-typescript = "0.23"
-tree-sitter-go = "0.23"
-tree-sitter-java = "0.23"
-flate2 = "1.0"
-pathdiff = "0.2" # For path operations
 tempfile = "3.0"
-rayon = "1.8" # For parallel processing
-lru = "0.12"
-dashmap = "5.5" # For concurrent hash maps
 once_cell = "1.19"
-lazy_static = "1.4" # For lazy static initialization
-sha2 = "0.10"
 chrono = { version = "0.4", features = [
     "serde",
 ] } # For timestamp handling in CLI
 path-clean = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-aes-gcm = "0.10"
-argon2 = "0.5"
-rand = "0.8"
-terminal_size = "0.4.3"
 indicatif = { version = "0.18", default-features = false }
 is-terminal = "0.4.16"
 async-trait = "0.1.89"
-unicode-width = "0.1"
 # ANSI styling
 anstyle = "1.0"
-anstyle-query = "1.0"
-anstream = "0.6"
-ratatui = { version = "0.29", default-features = false, features = [
-    "crossterm",
-    "unstable-rendered-line-info",
-] }
 sysinfo = "0.37.0"
-syntect = "5.2"
 colorchoice = "1.0"
 anstyle-git = "1.1"
 anstyle-ls = "1.0"
@@ -130,3 +97,6 @@ path = "src/main.rs"
 criterion = "0.5"
 tempfile = "3.0"
 dialoguer = "0.9"
+indexmap = { version = "2.2", features = ["serde"] }
+rand = "0.8"
+regex = "1.10"

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -27,7 +27,6 @@ tokio = { version = "1.37", features = [
     "sync",
     "process",
 ] }
-tokio-stream = { version = "0.1", features = ["io-util"] }
 futures = "0.3"
 async-stream = "0.3"
 walkdir = "2.5"
@@ -36,7 +35,6 @@ thiserror = "1.0"
 console = "0.15"
 dialoguer = "0.11"
 colored = "2.1"
-termimad = "0.34"
 regex = "1.10"
 shell-words = "1.1"
 tree-sitter = "0.25"
@@ -49,21 +47,15 @@ tree-sitter-java = "0.23"
 flate2 = "1.0"
 indexmap = { version = "2.2", features = ["serde"] }
 itertools = "0.13"
-pathdiff = "0.2" # For path operations
 tempfile = "3.0"
-rayon = "1.8" # For parallel processing
-lru = "0.12"
 dashmap = "5.5" # For concurrent hash maps
 once_cell = "1.19"
-lazy_static = "1.4" # For lazy static initialization
 parking_lot = "0.12"
 sha2 = "0.10"
 chrono = { version = "0.4", features = [
     "serde",
 ] } # For timestamp handling in CLI
-aes-gcm = "0.10"
 humantime = "2.1"
-argon2 = "0.5"
 rand = "0.8"
 terminal_size = "0.4.3"
 is-terminal = "0.4.16"

--- a/vtcode-core/src/core/performance_monitor.rs
+++ b/vtcode-core/src/core/performance_monitor.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -174,31 +174,25 @@ impl PerformanceMonitor {
         let avg_response = self.average_response_time().await;
         let p95_response = self.percentile_95_response_time().await;
         let metrics = self.get_metrics().await;
-        let status = self.check_phase1_targets().await;
 
         format!(
             "Performance Report - Phase 1 Targets\n\n\
              Response Times:\n\
-             • Average: {:.2}ms (Target: <500ms) {}\n\
+             • Average: {:.2}ms (Target: <500ms)\n\
              • 95th percentile: {:.2}ms\n\n\
              💾 Resource Usage:\n\
-             • Memory: {}MB (Target: <100MB) {}\n\
-             • Cache Hit Rate: {:.1}% (Target: ≥60%) {}\n\n\
+             • Memory: {}MB (Target: <100MB)\n\
+             • Cache Hit Rate: {:.1}% (Target: ≥60%)\n\n\
               System Health:\n\
-             • Error Rate: {:.1}% (Target: ≤10%) {}\n\
-             • Context Accuracy: {:.1}% (Target: ≥80%) {}\n\n\
+             • Error Rate: {:.1}% (Target: ≤10%)\n\
+             • Context Accuracy: {:.1}% (Target: ≥80%)\n\n\
              Throughput: {} req/sec",
             avg_response.as_millis(),
-            if status.response_time_target { "" } else { "" },
             p95_response.as_millis(),
             metrics.memory_usage,
-            if status.memory_target { "" } else { "" },
             metrics.cache_hit_rate * 100.0,
-            if status.cache_target { "" } else { "" },
             metrics.error_rate * 100.0,
-            if status.error_recovery_target { "" } else { "" },
             metrics.context_accuracy * 100.0,
-            if status.context_target { "" } else { "" },
             metrics.throughput
         )
     }
@@ -238,7 +232,5 @@ impl Phase1Status {
     }
 }
 
-// /// Global performance monitor instance
-lazy_static! {
-    pub static ref PERFORMANCE_MONITOR: PerformanceMonitor = PerformanceMonitor::new();
-}
+/// Global performance monitor instance
+pub static PERFORMANCE_MONITOR: Lazy<PerformanceMonitor> = Lazy::new(PerformanceMonitor::new);


### PR DESCRIPTION
## Summary
- remove unused direct dependencies from the CLI crate and move test-only crates into dev-dependencies
- drop unused crates from the vtcode-core library manifest and consolidate on once_cell for lazy initialization
- simplify the performance monitor report generation and replace lazy_static with once_cell::Lazy
- refresh Cargo.lock to reflect the trimmed dependency graph

## Testing
- cargo fmt
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e480569e4083238eda255ae8aad55c