### PR TITLE
fix: render welcome highlights in inline header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3920,6 +3920,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.1.14",
  "update-informer",
  "url",
  "vtcode-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ anstyle-ls = "1.0"
 agent-client-protocol = "0.4.5"
 percent-encoding = "2.3"
 url = "2.5"
+unicode-width = "0.1"
 
 [features]
 default = ["tool-chat"]

--- a/src/agent/runloop/ui.rs
+++ b/src/agent/runloop/ui.rs
@@ -242,6 +242,7 @@ pub(crate) fn build_inline_header_context(
         tools: tools_value,
         languages: languages_value,
         mcp: mcp_value,
+        highlights: session_bootstrap.header_highlights.clone(),
     })
 }
 

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -1839,11 +1839,6 @@ pub(crate) async fn run_single_agent_loop_unified(
         reasoning_label.clone(),
     )?;
     handle.set_header_context(header_context);
-    if let Some(text) = session_bootstrap.welcome_text.as_ref() {
-        renderer.line(MessageStyle::Response, text)?;
-        renderer.line_if_not_empty(MessageStyle::Output)?;
-    }
-
     // MCP events are now rendered as message blocks in the conversation history
 
     if let Some(message) = session_archive_error.take() {

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -316,7 +316,7 @@ pub mod ui {
     pub const INLINE_CONTENT_MIN_WIDTH: u16 = 48;
     pub const INLINE_STACKED_NAVIGATION_PERCENT: u16 = INLINE_NAVIGATION_PERCENT;
     pub const INLINE_SCROLLBAR_EDGE_PADDING: u16 = 1;
-    pub const INLINE_TRANSCRIPT_BOTTOM_PADDING: u16 = 2;
+    pub const INLINE_TRANSCRIPT_BOTTOM_PADDING: u16 = 6;
     pub const INLINE_PREVIEW_MAX_CHARS: usize = 56;
     pub const INLINE_PREVIEW_ELLIPSIS: &str = "…";
     pub const INLINE_AGENT_MESSAGE_LEFT_PADDING: &str = "  ";
@@ -350,6 +350,7 @@ pub mod ui {
     pub const HEADER_SHORTCUT_HINT: &str =
         "Shortcuts: Ctrl+Enter to submit • Esc to cancel • Ctrl+C to interrupt";
     pub const HEADER_META_SEPARATOR: &str = "   ";
+    pub const WELCOME_TEXT_WIDTH: usize = 80;
     pub const WELCOME_SHORTCUT_SECTION_TITLE: &str = "Keyboard Shortcuts";
     pub const WELCOME_SHORTCUT_HINT_PREFIX: &str = "Shortcuts:";
     pub const WELCOME_SHORTCUT_SEPARATOR: &str = "•";

--- a/vtcode-core/src/core/agent/runner.rs
+++ b/vtcode-core/src/core/agent/runner.rs
@@ -344,10 +344,7 @@ impl AgentRunner {
                 parallel_tool_config: Some(
                     crate::llm::provider::ParallelToolConfig::anthropic_optimized(),
                 ),
-                reasoning_effort: if self
-                    .provider_client
-                    .supports_reasoning_effort(&self.model)
-                {
+                reasoning_effort: if self.provider_client.supports_reasoning_effort(&self.model) {
                     self.reasoning_effort
                 } else {
                     None

--- a/vtcode-core/src/ui/tui.rs
+++ b/vtcode-core/src/ui/tui.rs
@@ -10,9 +10,9 @@ mod types;
 
 pub use style::{convert_style, theme_from_styles};
 pub use types::{
-    InlineCommand, InlineEvent, InlineHandle, InlineHeaderContext, InlineListItem,
-    InlineListSelection, InlineMessageKind, InlineSegment, InlineSession, InlineTextStyle,
-    InlineTheme,
+    InlineCommand, InlineEvent, InlineHandle, InlineHeaderContext, InlineHeaderHighlight,
+    InlineListItem, InlineListSelection, InlineMessageKind, InlineSegment, InlineSession,
+    InlineTextStyle, InlineTheme,
 };
 
 use tui::run_tui;

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -19,8 +19,8 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use super::types::{
-    InlineCommand, InlineEvent, InlineHeaderContext, InlineListItem, InlineListSelection,
-    InlineMessageKind, InlineSegment, InlineTextStyle, InlineTheme,
+    InlineCommand, InlineEvent, InlineHeaderContext, InlineHeaderHighlight, InlineListItem,
+    InlineListSelection, InlineMessageKind, InlineSegment, InlineTextStyle, InlineTheme,
 };
 use crate::config::constants::ui;
 use crate::ui::slash::{SlashCommandInfo, suggestions_for};
@@ -669,7 +669,20 @@ impl Session {
     }
 
     fn header_lines(&self) -> Vec<Line<'static>> {
-        vec![self.header_title_line(), self.header_meta_line()]
+        let mut lines = vec![self.header_title_line(), self.header_meta_line()];
+        if !self.header_context.highlights.is_empty() {
+            lines.push(Line::default());
+        }
+
+        for (index, highlight) in self.header_context.highlights.iter().enumerate() {
+            lines.push(self.header_highlight_title_line(highlight));
+            lines.extend(self.header_highlight_body_lines(highlight));
+            if index + 1 < self.header_context.highlights.len() {
+                lines.push(Line::default());
+            }
+        }
+
+        lines
     }
 
     fn header_height_from_lines(&self, width: u16, lines: &[Line<'static>]) -> u16 {
@@ -937,6 +950,29 @@ impl Session {
         }
 
         Line::from(spans)
+    }
+
+    fn header_highlight_title_line(&self, highlight: &InlineHeaderHighlight) -> Line<'static> {
+        let mut style = self.header_secondary_style();
+        style = style.add_modifier(Modifier::BOLD);
+        Line::from(vec![Span::styled(highlight.title.clone(), style)])
+    }
+
+    fn header_highlight_body_lines(&self, highlight: &InlineHeaderHighlight) -> Vec<Line<'static>> {
+        if highlight.lines.is_empty() {
+            return vec![Line::default()];
+        }
+
+        highlight
+            .lines
+            .iter()
+            .map(|line| {
+                Line::from(vec![Span::styled(
+                    line.clone(),
+                    self.header_primary_style(),
+                )])
+            })
+            .collect()
     }
 
     fn push_meta_entry(&self, spans: &mut Vec<Span<'static>>, label: &str, value: &str) {
@@ -2779,6 +2815,9 @@ impl Session {
         }
 
         let mut lines = self.wrap_line(base_line, max_width);
+        if !lines.is_empty() {
+            lines = self.justify_wrapped_lines(lines, max_width, message.kind);
+        }
         if lines.is_empty() {
             lines.push(Line::default());
         }
@@ -2894,6 +2933,73 @@ impl Session {
         rows
     }
 
+    fn justify_wrapped_lines(
+        &self,
+        lines: Vec<Line<'static>>,
+        max_width: usize,
+        kind: InlineMessageKind,
+    ) -> Vec<Line<'static>> {
+        if max_width == 0 || kind != InlineMessageKind::Agent {
+            return lines;
+        }
+
+        let total = lines.len();
+        let mut justified = Vec::with_capacity(total);
+        for (index, line) in lines.into_iter().enumerate() {
+            let is_last = index + 1 == total;
+            if self.should_justify_message_line(&line, max_width, is_last) {
+                justified.push(self.justify_message_line(&line, max_width));
+            } else {
+                justified.push(line);
+            }
+        }
+
+        justified
+    }
+
+    fn should_justify_message_line(
+        &self,
+        line: &Line<'static>,
+        max_width: usize,
+        is_last: bool,
+    ) -> bool {
+        if is_last || max_width == 0 {
+            return false;
+        }
+        if line.spans.len() != 1 {
+            return false;
+        }
+        let text = line.spans[0].content.as_ref();
+        if text.trim().is_empty() {
+            return false;
+        }
+        if text.starts_with(char::is_whitespace) {
+            return false;
+        }
+        let trimmed = text.trim();
+        if trimmed.starts_with(|ch: char| matches!(ch, '-' | '*' | '`' | '>' | '#')) {
+            return false;
+        }
+        if trimmed.contains("```") {
+            return false;
+        }
+        let width = UnicodeWidthStr::width(trimmed);
+        if width >= max_width || width < max_width / 2 {
+            return false;
+        }
+
+        justify_plain_text(text, max_width).is_some()
+    }
+
+    fn justify_message_line(&self, line: &Line<'static>, max_width: usize) -> Line<'static> {
+        let span = &line.spans[0];
+        if let Some(justified) = justify_plain_text(span.content.as_ref(), max_width) {
+            Line::from(vec![Span::styled(justified, span.style)])
+        } else {
+            line.clone()
+        }
+    }
+
     fn prepare_transcript_scroll(
         &mut self,
         total_rows: usize,
@@ -2922,6 +3028,47 @@ impl Session {
         }
         self.enforce_scroll_bounds();
     }
+}
+
+fn justify_plain_text(text: &str, max_width: usize) -> Option<String> {
+    let trimmed = text.trim();
+    let words: Vec<&str> = trimmed.split_whitespace().collect();
+    if words.len() <= 1 {
+        return None;
+    }
+
+    let total_word_width: usize = words.iter().map(|word| UnicodeWidthStr::width(*word)).sum();
+    if total_word_width >= max_width {
+        return None;
+    }
+
+    let gaps = words.len() - 1;
+    let spaces_needed = max_width.saturating_sub(total_word_width);
+    if spaces_needed <= gaps {
+        return None;
+    }
+
+    let base_space = spaces_needed / gaps;
+    if base_space == 0 {
+        return None;
+    }
+    let extra = spaces_needed % gaps;
+
+    let mut output = String::with_capacity(max_width + gaps);
+    for (index, word) in words.iter().enumerate() {
+        output.push_str(word);
+        if index < gaps {
+            let mut count = base_space;
+            if index < extra {
+                count += 1;
+            }
+            for _ in 0..count {
+                output.push(' ');
+            }
+        }
+    }
+
+    Some(output)
 }
 
 #[cfg(test)]

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -14,6 +14,7 @@ pub struct InlineHeaderContext {
     pub tools: String,
     pub languages: String,
     pub mcp: String,
+    pub highlights: Vec<InlineHeaderHighlight>,
 }
 
 impl Default for InlineHeaderContext {
@@ -63,8 +64,15 @@ impl Default for InlineHeaderContext {
             tools,
             languages,
             mcp,
+            highlights: Vec::new(),
         }
     }
+}
+
+#[derive(Clone, Default)]
+pub struct InlineHeaderHighlight {
+    pub title: String,
+    pub lines: Vec<String>,
 }
 
 #[derive(Clone, Default, PartialEq)]


### PR DESCRIPTION
## Summary
- move onboarding welcome text into inline header highlights focused on the project overview and slash commands
- teach the TUI session header to render highlight bodies and justify agent transcript paragraphs while increasing transcript padding
- clean up the welcome bootstrap by removing the old banner renderer and unused formatting helpers

## Testing
- cargo fmt
- cargo clippy --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e5d78bf4448323afe7f4c2c7f80df7