### PR TITLE
Add Z.AI provider integration

### DIFF
--- a/docs/models.json
+++ b/docs/models.json
@@ -343,6 +343,129 @@
       }
     }
   },
+  "zai": {
+    "id": "zai",
+    "env": [
+      "ZAI_API_KEY"
+    ],
+    "api": "https://api.z.ai/api",
+    "name": "Z.AI",
+    "doc": "https://docs.z.ai/guides/llm/glm-4.6",
+    "models": {
+      "glm-4.6": {
+        "id": "glm-4.6",
+        "name": "GLM 4.6",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 200000,
+        "max_output_tokens": 128000
+      },
+      "glm-4.5": {
+        "id": "glm-4.5",
+        "name": "GLM 4.5",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-air": {
+        "id": "glm-4.5-air",
+        "name": "GLM 4.5 Air",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-x": {
+        "id": "glm-4.5-x",
+        "name": "GLM 4.5 X",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-airx": {
+        "id": "glm-4.5-airx",
+        "name": "GLM 4.5 AirX",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-flash": {
+        "id": "glm-4.5-flash",
+        "name": "GLM 4.5 Flash",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4-32b-0414-128k": {
+        "id": "glm-4-32b-0414-128k",
+        "name": "GLM 4 32B 0414 128K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": null
+      }
+    }
+  },
   "openrouter": {
     "id": "openrouter",
     "env": [

--- a/src/main_modular.rs
+++ b/src/main_modular.rs
@@ -102,6 +102,7 @@ async fn main() -> Result<()> {
     api_key_sources.openai_env = "OPENAI_API_KEY".to_string();
     api_key_sources.openrouter_env = "OPENROUTER_API_KEY".to_string();
     api_key_sources.xai_env = "XAI_API_KEY".to_string();
+    api_key_sources.zai_env = "ZAI_API_KEY".to_string();
 
     // Parse model
     let model = ModelId::from_str(&args.model)?;

--- a/tests/models_sync.rs
+++ b/tests/models_sync.rs
@@ -47,6 +47,10 @@ fn constants_cover_models_json() {
                 validated_providers.insert("google");
                 Some(models::google::SUPPORTED_MODELS)
             }
+            "zai" => {
+                validated_providers.insert("zai");
+                Some(models::zai::SUPPORTED_MODELS)
+            }
             _ => None, // Skip providers we don't have constants for yet
         };
 
@@ -120,7 +124,7 @@ fn constants_cover_models_json() {
     }
 
     // Ensure we validated the expected providers
-    let expected_providers = ["openai", "anthropic", "google", "openrouter"];
+    let expected_providers = ["openai", "anthropic", "google", "openrouter", "zai"];
     for expected in &expected_providers {
         assert!(
             validated_providers.contains(expected),
@@ -165,6 +169,7 @@ fn model_helpers_validation_edge_cases() {
         "openrouter",
         models::openrouter::DEFAULT_MODEL
     ));
+    assert!(model_helpers::is_valid("zai", models::zai::DEFAULT_MODEL));
 }
 
 #[test]

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -51,12 +51,13 @@ pub struct Cli {
     ///   • deepseek - DeepSeek models
     ///   • openrouter - OpenRouter marketplace models
     ///   • xai - xAI Grok models
+    ///   • zai - Z.AI GLM models
     ///
     /// Example: --provider deepseek
     #[arg(long, global = true)]
     pub provider: Option<String>,
 
-    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
+    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n• Z.AI: `ZAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
     #[arg(long, global = true, default_value = crate::config::constants::defaults::DEFAULT_API_KEY_ENV)]
     pub api_key_env: String,
 

--- a/vtcode-core/src/config/api_keys.rs
+++ b/vtcode-core/src/config/api_keys.rs
@@ -23,6 +23,8 @@ pub struct ApiKeySources {
     pub xai_env: String,
     /// DeepSeek API key environment variable name
     pub deepseek_env: String,
+    /// Z.AI API key environment variable name
+    pub zai_env: String,
     /// Gemini API key from configuration file
     pub gemini_config: Option<String>,
     /// Anthropic API key from configuration file
@@ -35,6 +37,8 @@ pub struct ApiKeySources {
     pub xai_config: Option<String>,
     /// DeepSeek API key from configuration file
     pub deepseek_config: Option<String>,
+    /// Z.AI API key from configuration file
+    pub zai_config: Option<String>,
 }
 
 impl Default for ApiKeySources {
@@ -46,12 +50,14 @@ impl Default for ApiKeySources {
             openrouter_env: "OPENROUTER_API_KEY".to_string(),
             xai_env: "XAI_API_KEY".to_string(),
             deepseek_env: "DEEPSEEK_API_KEY".to_string(),
+            zai_env: "ZAI_API_KEY".to_string(),
             gemini_config: None,
             anthropic_config: None,
             openai_config: None,
             openrouter_config: None,
             xai_config: None,
             deepseek_config: None,
+            zai_config: None,
         }
     }
 }
@@ -66,6 +72,7 @@ impl ApiKeySources {
             "deepseek" => ("DEEPSEEK_API_KEY", vec![]),
             "openrouter" => ("OPENROUTER_API_KEY", vec![]),
             "xai" => ("XAI_API_KEY", vec![]),
+            "zai" => ("ZAI_API_KEY", vec![]),
             _ => ("GEMINI_API_KEY", vec!["GOOGLE_API_KEY"]),
         };
 
@@ -101,12 +108,18 @@ impl ApiKeySources {
             } else {
                 "DEEPSEEK_API_KEY".to_string()
             },
+            zai_env: if provider == "zai" {
+                primary_env.to_string()
+            } else {
+                "ZAI_API_KEY".to_string()
+            },
             gemini_config: None,
             anthropic_config: None,
             openai_config: None,
             openrouter_config: None,
             xai_config: None,
             deepseek_config: None,
+            zai_config: None,
         }
     }
 }
@@ -160,6 +173,7 @@ pub fn get_api_key(provider: &str, sources: &ApiKeySources) -> Result<String> {
         "deepseek" => "DEEPSEEK_API_KEY",
         "openrouter" => "OPENROUTER_API_KEY",
         "xai" => "XAI_API_KEY",
+        "zai" => "ZAI_API_KEY",
         _ => "GEMINI_API_KEY",
     };
 
@@ -178,6 +192,7 @@ pub fn get_api_key(provider: &str, sources: &ApiKeySources) -> Result<String> {
         "deepseek" => get_deepseek_api_key(sources),
         "openrouter" => get_openrouter_api_key(sources),
         "xai" => get_xai_api_key(sources),
+        "zai" => get_zai_api_key(sources),
         _ => Err(anyhow::anyhow!("Unsupported provider: {}", provider)),
     }
 }
@@ -279,6 +294,11 @@ fn get_deepseek_api_key(sources: &ApiKeySources) -> Result<String> {
         sources.deepseek_config.as_ref(),
         "DeepSeek",
     )
+}
+
+/// Get Z.AI API key with secure fallback
+fn get_zai_api_key(sources: &ApiKeySources) -> Result<String> {
+    get_api_key_with_fallback(&sources.zai_env, sources.zai_config.as_ref(), "Z.AI")
 }
 
 #[cfg(test)]

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -49,6 +49,28 @@ pub mod models {
         pub const CODEX_MINI: &str = "codex-mini";
     }
 
+    // Z.AI models (direct API)
+    pub mod zai {
+        pub const DEFAULT_MODEL: &str = "glm-4.6";
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            "glm-4.6",
+            "glm-4.5",
+            "glm-4.5-air",
+            "glm-4.5-x",
+            "glm-4.5-airx",
+            "glm-4.5-flash",
+            "glm-4-32b-0414-128k",
+        ];
+
+        pub const GLM_4_6: &str = "glm-4.6";
+        pub const GLM_4_5: &str = "glm-4.5";
+        pub const GLM_4_5_AIR: &str = "glm-4.5-air";
+        pub const GLM_4_5_X: &str = "glm-4.5-x";
+        pub const GLM_4_5_AIRX: &str = "glm-4.5-airx";
+        pub const GLM_4_5_FLASH: &str = "glm-4.5-flash";
+        pub const GLM_4_32B_0414_128K: &str = "glm-4-32b-0414-128k";
+    }
+
     // OpenRouter models (extensible via vtcode.toml)
     pub mod openrouter {
         pub const X_AI_GROK_CODE_FAST_1: &str = "x-ai/grok-code-fast-1";
@@ -322,6 +344,7 @@ pub mod prompt_cache {
     pub const OPENROUTER_CACHE_DISCOUNT_ENABLED: bool = true;
     pub const XAI_CACHE_ENABLED: bool = true;
     pub const DEEPSEEK_CACHE_ENABLED: bool = true;
+    pub const ZAI_CACHE_ENABLED: bool = false;
 }
 
 /// Model validation and helper functions
@@ -337,6 +360,7 @@ pub mod model_helpers {
             "deepseek" => Some(models::deepseek::SUPPORTED_MODELS),
             "openrouter" => Some(models::openrouter::SUPPORTED_MODELS),
             "xai" => Some(models::xai::SUPPORTED_MODELS),
+            "zai" => Some(models::zai::SUPPORTED_MODELS),
             _ => None,
         }
     }
@@ -350,6 +374,7 @@ pub mod model_helpers {
             "deepseek" => Some(models::deepseek::DEFAULT_MODEL),
             "openrouter" => Some(models::openrouter::DEFAULT_MODEL),
             "xai" => Some(models::xai::DEFAULT_MODEL),
+            "zai" => Some(models::zai::DEFAULT_MODEL),
             _ => None,
         }
     }
@@ -525,6 +550,7 @@ pub mod urls {
     pub const OPENROUTER_API_BASE: &str = "https://openrouter.ai/api/v1";
     pub const XAI_API_BASE: &str = "https://api.x.ai/v1";
     pub const DEEPSEEK_API_BASE: &str = "https://api.deepseek.com/v1";
+    pub const Z_AI_API_BASE: &str = "https://api.z.ai/api";
 }
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 /// Agent-wide configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentConfig {
-    /// AI provider for single agent mode (gemini, openai, anthropic, openrouter, xai)
+    /// AI provider for single agent mode (gemini, openai, anthropic, openrouter, xai, zai)
     #[serde(default = "default_provider")]
     pub provider: String,
 

--- a/vtcode-core/src/config/core/mod.rs
+++ b/vtcode-core/src/config/core/mod.rs
@@ -12,6 +12,7 @@ pub use prompt_cache::{
     AnthropicPromptCacheSettings, DeepSeekPromptCacheSettings, GeminiPromptCacheMode,
     GeminiPromptCacheSettings, OpenAIPromptCacheSettings, OpenRouterPromptCacheSettings,
     PromptCachingConfig, ProviderPromptCachingConfig, XAIPromptCacheSettings,
+    ZaiPromptCacheSettings,
 };
 pub use security::SecurityConfig;
 pub use tools::{ToolPolicy, ToolsConfig};

--- a/vtcode-core/src/config/core/prompt_cache.rs
+++ b/vtcode-core/src/config/core/prompt_cache.rs
@@ -79,6 +79,9 @@ pub struct ProviderPromptCachingConfig {
 
     #[serde(default = "DeepSeekPromptCacheSettings::default")]
     pub deepseek: DeepSeekPromptCacheSettings,
+
+    #[serde(default = "ZaiPromptCacheSettings::default")]
+    pub zai: ZaiPromptCacheSettings,
 }
 
 impl Default for ProviderPromptCachingConfig {
@@ -90,6 +93,7 @@ impl Default for ProviderPromptCachingConfig {
             openrouter: OpenRouterPromptCacheSettings::default(),
             xai: XAIPromptCacheSettings::default(),
             deepseek: DeepSeekPromptCacheSettings::default(),
+            zai: ZaiPromptCacheSettings::default(),
         }
     }
 }
@@ -262,6 +266,21 @@ impl Default for DeepSeekPromptCacheSettings {
     }
 }
 
+/// Z.AI prompt caching configuration (disabled until platform exposes metrics)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ZaiPromptCacheSettings {
+    #[serde(default = "default_zai_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for ZaiPromptCacheSettings {
+    fn default() -> Self {
+        Self {
+            enabled: default_zai_enabled(),
+        }
+    }
+}
+
 fn default_enabled() -> bool {
     prompt_cache::DEFAULT_ENABLED
 }
@@ -320,6 +339,10 @@ fn default_gemini_explicit_ttl() -> Option<u64> {
 
 fn default_gemini_mode() -> GeminiPromptCacheMode {
     GeminiPromptCacheMode::Implicit
+}
+
+fn default_zai_enabled() -> bool {
+    prompt_cache::ZAI_CACHE_ENABLED
 }
 
 fn resolve_path(input: &str, workspace_root: Option<&Path>) -> PathBuf {

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -85,6 +85,8 @@ pub enum Provider {
     OpenRouter,
     /// xAI Grok models
     XAI,
+    /// Z.AI GLM models
+    ZAI,
 }
 
 impl Provider {
@@ -97,6 +99,7 @@ impl Provider {
             Provider::DeepSeek => "DEEPSEEK_API_KEY",
             Provider::OpenRouter => "OPENROUTER_API_KEY",
             Provider::XAI => "XAI_API_KEY",
+            Provider::ZAI => "ZAI_API_KEY",
         }
     }
 
@@ -109,6 +112,7 @@ impl Provider {
             Provider::DeepSeek,
             Provider::OpenRouter,
             Provider::XAI,
+            Provider::ZAI,
         ]
     }
 
@@ -121,6 +125,7 @@ impl Provider {
             Provider::DeepSeek => "DeepSeek",
             Provider::OpenRouter => "OpenRouter",
             Provider::XAI => "xAI",
+            Provider::ZAI => "Z.AI",
         }
     }
 
@@ -135,6 +140,7 @@ impl Provider {
             Provider::DeepSeek => model == models::deepseek::DEEPSEEK_REASONER,
             Provider::OpenRouter => models::openrouter::REASONING_MODELS.contains(&model),
             Provider::XAI => model == models::xai::GROK_2_REASONING,
+            Provider::ZAI => model == models::zai::GLM_4_6,
         }
     }
 }
@@ -148,6 +154,7 @@ impl fmt::Display for Provider {
             Provider::DeepSeek => write!(f, "deepseek"),
             Provider::OpenRouter => write!(f, "openrouter"),
             Provider::XAI => write!(f, "xai"),
+            Provider::ZAI => write!(f, "zai"),
         }
     }
 }
@@ -163,6 +170,7 @@ impl FromStr for Provider {
             "deepseek" => Ok(Provider::DeepSeek),
             "openrouter" => Ok(Provider::OpenRouter),
             "xai" => Ok(Provider::XAI),
+            "zai" => Ok(Provider::ZAI),
             _ => Err(ModelParseError::InvalidProvider(s.to_string())),
         }
     }
@@ -218,6 +226,22 @@ pub enum ModelId {
     XaiGrok2Reasoning,
     /// Grok-2 Vision - Multimodal xAI model
     XaiGrok2Vision,
+
+    // Z.AI models
+    /// GLM-4.6 - Latest flagship GLM reasoning model
+    ZaiGlm46,
+    /// GLM-4.5 - Balanced GLM release for general tasks
+    ZaiGlm45,
+    /// GLM-4.5-Air - Efficient GLM variant
+    ZaiGlm45Air,
+    /// GLM-4.5-X - Enhanced capability GLM variant
+    ZaiGlm45X,
+    /// GLM-4.5-AirX - Hybrid efficient GLM variant
+    ZaiGlm45Airx,
+    /// GLM-4.5-Flash - Low-latency GLM variant
+    ZaiGlm45Flash,
+    /// GLM-4-32B-0414-128K - Legacy long-context GLM deployment
+    ZaiGlm432b0414128k,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model
@@ -389,6 +413,14 @@ impl ModelId {
             ModelId::XaiGrok2Mini => models::xai::GROK_2_MINI,
             ModelId::XaiGrok2Reasoning => models::xai::GROK_2_REASONING,
             ModelId::XaiGrok2Vision => models::xai::GROK_2_VISION,
+            // Z.AI models
+            ModelId::ZaiGlm46 => models::zai::GLM_4_6,
+            ModelId::ZaiGlm45 => models::zai::GLM_4_5,
+            ModelId::ZaiGlm45Air => models::zai::GLM_4_5_AIR,
+            ModelId::ZaiGlm45X => models::zai::GLM_4_5_X,
+            ModelId::ZaiGlm45Airx => models::zai::GLM_4_5_AIRX,
+            ModelId::ZaiGlm45Flash => models::zai::GLM_4_5_FLASH,
+            ModelId::ZaiGlm432b0414128k => models::zai::GLM_4_32B_0414_128K,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -418,6 +450,13 @@ impl ModelId {
             | ModelId::XaiGrok2Mini
             | ModelId::XaiGrok2Reasoning
             | ModelId::XaiGrok2Vision => Provider::XAI,
+            ModelId::ZaiGlm46
+            | ModelId::ZaiGlm45
+            | ModelId::ZaiGlm45Air
+            | ModelId::ZaiGlm45X
+            | ModelId::ZaiGlm45Airx
+            | ModelId::ZaiGlm45Flash
+            | ModelId::ZaiGlm432b0414128k => Provider::ZAI,
             _ => unreachable!(),
         }
     }
@@ -457,6 +496,14 @@ impl ModelId {
             ModelId::XaiGrok2Mini => "Grok-2 Mini",
             ModelId::XaiGrok2Reasoning => "Grok-2 Reasoning",
             ModelId::XaiGrok2Vision => "Grok-2 Vision",
+            // Z.AI models
+            ModelId::ZaiGlm46 => "GLM 4.6",
+            ModelId::ZaiGlm45 => "GLM 4.5",
+            ModelId::ZaiGlm45Air => "GLM 4.5 Air",
+            ModelId::ZaiGlm45X => "GLM 4.5 X",
+            ModelId::ZaiGlm45Airx => "GLM 4.5 AirX",
+            ModelId::ZaiGlm45Flash => "GLM 4.5 Flash",
+            ModelId::ZaiGlm432b0414128k => "GLM 4 32B 0414 128K",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -508,6 +555,18 @@ impl ModelId {
                 "Grok 2 variant that surfaces structured reasoning traces"
             }
             ModelId::XaiGrok2Vision => "Multimodal Grok 2 model with image understanding",
+            // Z.AI models
+            ModelId::ZaiGlm46 => {
+                "Latest Z.AI GLM flagship with long-context reasoning and coding strengths"
+            }
+            ModelId::ZaiGlm45 => "Balanced GLM 4.5 release for general assistant tasks",
+            ModelId::ZaiGlm45Air => "Efficient GLM 4.5 Air variant tuned for lower latency",
+            ModelId::ZaiGlm45X => "Enhanced GLM 4.5 X variant with improved reasoning",
+            ModelId::ZaiGlm45Airx => "Hybrid GLM 4.5 AirX variant blending efficiency with quality",
+            ModelId::ZaiGlm45Flash => "Low-latency GLM 4.5 Flash optimized for responsiveness",
+            ModelId::ZaiGlm432b0414128k => {
+                "Legacy GLM 4 32B deployment offering extended 128K context window"
+            }
             _ => unreachable!(),
         }
     }
@@ -539,6 +598,14 @@ impl ModelId {
             ModelId::XaiGrok2Mini,
             ModelId::XaiGrok2Reasoning,
             ModelId::XaiGrok2Vision,
+            // Z.AI models
+            ModelId::ZaiGlm46,
+            ModelId::ZaiGlm45,
+            ModelId::ZaiGlm45Air,
+            ModelId::ZaiGlm45X,
+            ModelId::ZaiGlm45Airx,
+            ModelId::ZaiGlm45Flash,
+            ModelId::ZaiGlm432b0414128k,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -562,6 +629,7 @@ impl ModelId {
             ModelId::ClaudeSonnet45,
             ModelId::DeepSeekReasoner,
             ModelId::XaiGrok2Latest,
+            ModelId::ZaiGlm46,
             ModelId::OpenRouterGrokCodeFast1,
         ]
     }
@@ -590,6 +658,7 @@ impl ModelId {
             Provider::DeepSeek => ModelId::DeepSeekReasoner,
             Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
+            Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
 
@@ -602,6 +671,7 @@ impl ModelId {
             Provider::DeepSeek => ModelId::DeepSeekChat,
             Provider::XAI => ModelId::XaiGrok2Mini,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
+            Provider::ZAI => ModelId::ZaiGlm45Flash,
         }
     }
 
@@ -614,6 +684,7 @@ impl ModelId {
             Provider::DeepSeek => ModelId::DeepSeekReasoner,
             Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
+            Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
 
@@ -621,7 +692,10 @@ impl ModelId {
     pub fn is_flash_variant(&self) -> bool {
         matches!(
             self,
-            ModelId::Gemini25FlashPreview | ModelId::Gemini25Flash | ModelId::Gemini25FlashLite
+            ModelId::Gemini25FlashPreview
+                | ModelId::Gemini25Flash
+                | ModelId::Gemini25FlashLite
+                | ModelId::ZaiGlm45Flash
         )
     }
 
@@ -635,6 +709,7 @@ impl ModelId {
                 | ModelId::ClaudeOpus41
                 | ModelId::DeepSeekReasoner
                 | ModelId::XaiGrok2Latest
+                | ModelId::ZaiGlm46
         )
     }
 
@@ -652,6 +727,9 @@ impl ModelId {
                 | ModelId::GPT5Nano
                 | ModelId::DeepSeekChat
                 | ModelId::XaiGrok2Mini
+                | ModelId::ZaiGlm45Air
+                | ModelId::ZaiGlm45Airx
+                | ModelId::ZaiGlm45Flash
         )
     }
 
@@ -671,6 +749,7 @@ impl ModelId {
                 | ModelId::DeepSeekReasoner
                 | ModelId::XaiGrok2Latest
                 | ModelId::XaiGrok2Reasoning
+                | ModelId::ZaiGlm46
         )
     }
 
@@ -703,6 +782,14 @@ impl ModelId {
             | ModelId::XaiGrok2Mini
             | ModelId::XaiGrok2Reasoning
             | ModelId::XaiGrok2Vision => "2",
+            // Z.AI generations
+            ModelId::ZaiGlm46 => "4.6",
+            ModelId::ZaiGlm45
+            | ModelId::ZaiGlm45Air
+            | ModelId::ZaiGlm45X
+            | ModelId::ZaiGlm45Airx
+            | ModelId::ZaiGlm45Flash => "4.5",
+            ModelId::ZaiGlm432b0414128k => "4-32B",
             _ => unreachable!(),
         }
     }
@@ -744,6 +831,14 @@ impl FromStr for ModelId {
             s if s == models::xai::GROK_2_MINI => Ok(ModelId::XaiGrok2Mini),
             s if s == models::xai::GROK_2_REASONING => Ok(ModelId::XaiGrok2Reasoning),
             s if s == models::xai::GROK_2_VISION => Ok(ModelId::XaiGrok2Vision),
+            // Z.AI models
+            s if s == models::zai::GLM_4_6 => Ok(ModelId::ZaiGlm46),
+            s if s == models::zai::GLM_4_5 => Ok(ModelId::ZaiGlm45),
+            s if s == models::zai::GLM_4_5_AIR => Ok(ModelId::ZaiGlm45Air),
+            s if s == models::zai::GLM_4_5_X => Ok(ModelId::ZaiGlm45X),
+            s if s == models::zai::GLM_4_5_AIRX => Ok(ModelId::ZaiGlm45Airx),
+            s if s == models::zai::GLM_4_5_FLASH => Ok(ModelId::ZaiGlm45Flash),
+            s if s == models::zai::GLM_4_32B_0414_128K => Ok(ModelId::ZaiGlm432b0414128k),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -844,6 +939,17 @@ mod tests {
             models::xai::GROK_2_REASONING
         );
         assert_eq!(ModelId::XaiGrok2Vision.as_str(), models::xai::GROK_2_VISION);
+        // Z.AI models
+        assert_eq!(ModelId::ZaiGlm46.as_str(), models::zai::GLM_4_6);
+        assert_eq!(ModelId::ZaiGlm45.as_str(), models::zai::GLM_4_5);
+        assert_eq!(ModelId::ZaiGlm45Air.as_str(), models::zai::GLM_4_5_AIR);
+        assert_eq!(ModelId::ZaiGlm45X.as_str(), models::zai::GLM_4_5_X);
+        assert_eq!(ModelId::ZaiGlm45Airx.as_str(), models::zai::GLM_4_5_AIRX);
+        assert_eq!(ModelId::ZaiGlm45Flash.as_str(), models::zai::GLM_4_5_FLASH);
+        assert_eq!(
+            ModelId::ZaiGlm432b0414128k.as_str(),
+            models::zai::GLM_4_32B_0414_128K
+        );
         macro_rules! assert_openrouter_to_string {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
                 $(assert_eq!(ModelId::$variant.as_str(), models::$const);)*
@@ -932,6 +1038,35 @@ mod tests {
             models::xai::GROK_2_VISION.parse::<ModelId>().unwrap(),
             ModelId::XaiGrok2Vision
         );
+        // Z.AI models
+        assert_eq!(
+            models::zai::GLM_4_6.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm46
+        );
+        assert_eq!(
+            models::zai::GLM_4_5.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45
+        );
+        assert_eq!(
+            models::zai::GLM_4_5_AIR.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45Air
+        );
+        assert_eq!(
+            models::zai::GLM_4_5_X.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45X
+        );
+        assert_eq!(
+            models::zai::GLM_4_5_AIRX.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45Airx
+        );
+        assert_eq!(
+            models::zai::GLM_4_5_FLASH.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45Flash
+        );
+        assert_eq!(
+            models::zai::GLM_4_32B_0414_128K.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm432b0414128k
+        );
         macro_rules! assert_openrouter_parse {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
                 $(assert_eq!(models::$const.parse::<ModelId>().unwrap(), ModelId::$variant);)*
@@ -956,6 +1091,7 @@ mod tests {
             Provider::OpenRouter
         );
         assert_eq!("xai".parse::<Provider>().unwrap(), Provider::XAI);
+        assert_eq!("zai".parse::<Provider>().unwrap(), Provider::ZAI);
         assert!("invalid-provider".parse::<Provider>().is_err());
     }
 
@@ -968,6 +1104,7 @@ mod tests {
         assert_eq!(ModelId::ClaudeSonnet4.provider(), Provider::Anthropic);
         assert_eq!(ModelId::DeepSeekChat.provider(), Provider::DeepSeek);
         assert_eq!(ModelId::XaiGrok2Latest.provider(), Provider::XAI);
+        assert_eq!(ModelId::ZaiGlm46.provider(), Provider::ZAI);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -1011,6 +1148,10 @@ mod tests {
             ModelId::default_orchestrator_for_provider(Provider::XAI),
             ModelId::XaiGrok2Latest
         );
+        assert_eq!(
+            ModelId::default_orchestrator_for_provider(Provider::ZAI),
+            ModelId::ZaiGlm46
+        );
 
         assert_eq!(
             ModelId::default_subagent_for_provider(Provider::Gemini),
@@ -1036,6 +1177,10 @@ mod tests {
             ModelId::default_subagent_for_provider(Provider::XAI),
             ModelId::XaiGrok2Mini
         );
+        assert_eq!(
+            ModelId::default_subagent_for_provider(Provider::ZAI),
+            ModelId::ZaiGlm45Flash
+        );
 
         assert_eq!(
             ModelId::default_single_for_provider(Provider::DeepSeek),
@@ -1057,12 +1202,14 @@ mod tests {
         assert!(ModelId::Gemini25Flash.is_flash_variant());
         assert!(ModelId::Gemini25FlashLite.is_flash_variant());
         assert!(!ModelId::GPT5.is_flash_variant());
+        assert!(ModelId::ZaiGlm45Flash.is_flash_variant());
 
         // Pro variants
         assert!(ModelId::Gemini25Pro.is_pro_variant());
         assert!(ModelId::GPT5.is_pro_variant());
         assert!(ModelId::GPT5Codex.is_pro_variant());
         assert!(ModelId::DeepSeekReasoner.is_pro_variant());
+        assert!(ModelId::ZaiGlm46.is_pro_variant());
         assert!(!ModelId::Gemini25FlashPreview.is_pro_variant());
 
         // Efficient variants
@@ -1072,6 +1219,9 @@ mod tests {
         assert!(ModelId::GPT5Mini.is_efficient_variant());
         assert!(ModelId::XaiGrok2Mini.is_efficient_variant());
         assert!(ModelId::DeepSeekChat.is_efficient_variant());
+        assert!(ModelId::ZaiGlm45Air.is_efficient_variant());
+        assert!(ModelId::ZaiGlm45Airx.is_efficient_variant());
+        assert!(ModelId::ZaiGlm45Flash.is_efficient_variant());
         assert!(!ModelId::GPT5.is_efficient_variant());
 
         macro_rules! assert_openrouter_efficiency {
@@ -1090,6 +1240,7 @@ mod tests {
         assert!(ModelId::XaiGrok2Latest.is_top_tier());
         assert!(ModelId::XaiGrok2Reasoning.is_top_tier());
         assert!(ModelId::DeepSeekReasoner.is_top_tier());
+        assert!(ModelId::ZaiGlm46.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
 
         macro_rules! assert_openrouter_top_tier {
@@ -1130,6 +1281,14 @@ mod tests {
         assert_eq!(ModelId::XaiGrok2Mini.generation(), "2");
         assert_eq!(ModelId::XaiGrok2Reasoning.generation(), "2");
         assert_eq!(ModelId::XaiGrok2Vision.generation(), "2");
+        // Z.AI generations
+        assert_eq!(ModelId::ZaiGlm46.generation(), "4.6");
+        assert_eq!(ModelId::ZaiGlm45.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45Air.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45X.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45Airx.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45Flash.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm432b0414128k.generation(), "4-32B");
 
         macro_rules! assert_openrouter_generation {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1173,6 +1332,15 @@ mod tests {
         assert!(xai_models.contains(&ModelId::XaiGrok2Mini));
         assert!(xai_models.contains(&ModelId::XaiGrok2Reasoning));
         assert!(xai_models.contains(&ModelId::XaiGrok2Vision));
+
+        let zai_models = ModelId::models_for_provider(Provider::ZAI);
+        assert!(zai_models.contains(&ModelId::ZaiGlm46));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45Air));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45X));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45Airx));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45Flash));
+        assert!(zai_models.contains(&ModelId::ZaiGlm432b0414128k));
     }
 
     #[test]
@@ -1185,6 +1353,7 @@ mod tests {
         assert!(fallbacks.contains(&ModelId::ClaudeSonnet45));
         assert!(fallbacks.contains(&ModelId::DeepSeekReasoner));
         assert!(fallbacks.contains(&ModelId::XaiGrok2Latest));
+        assert!(fallbacks.contains(&ModelId::ZaiGlm46));
         assert!(fallbacks.contains(&ModelId::OpenRouterGrokCodeFast1));
     }
 }

--- a/vtcode-core/src/llm/client.rs
+++ b/vtcode-core/src/llm/client.rs
@@ -1,7 +1,7 @@
 use super::provider::LLMError;
 use super::providers::{
     AnthropicProvider, DeepSeekProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider,
-    XAIProvider,
+    XAIProvider, ZAIProvider,
 };
 use super::types::{BackendKind, LLMResponse};
 use crate::config::models::{ModelId, Provider};
@@ -38,6 +38,10 @@ pub fn make_client(api_key: String, model: ModelId) -> AnyClient {
             api_key,
             model.as_str().to_string(),
         )),
-        Provider::XAI => Box::new(XAIProvider::with_model(api_key, model.as_str().to_string())),
+        Provider::XAI => Box::new(XAIProvider::with_model(
+            api_key.clone(),
+            model.as_str().to_string(),
+        )),
+        Provider::ZAI => Box::new(ZAIProvider::with_model(api_key, model.as_str().to_string())),
     }
 }

--- a/vtcode-core/src/llm/factory.rs
+++ b/vtcode-core/src/llm/factory.rs
@@ -1,6 +1,6 @@
 use super::providers::{
     AnthropicProvider, DeepSeekProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider,
-    XAIProvider,
+    XAIProvider, ZAIProvider,
 };
 use crate::config::core::PromptCachingConfig;
 use crate::llm::provider::{LLMError, LLMProvider};
@@ -134,6 +134,24 @@ impl LLMFactory {
             }),
         );
 
+        factory.register_provider(
+            "zai",
+            Box::new(|config: ProviderConfig| {
+                let ProviderConfig {
+                    api_key,
+                    base_url,
+                    model,
+                    prompt_cache,
+                } = config;
+                Box::new(ZAIProvider::from_config(
+                    api_key,
+                    model,
+                    base_url,
+                    prompt_cache,
+                )) as Box<dyn LLMProvider>
+            }),
+        );
+
         factory
     }
 
@@ -177,6 +195,8 @@ impl LLMFactory {
             Some("gemini".to_string())
         } else if m.starts_with("grok-") || m.starts_with("xai-") {
             Some("xai".to_string())
+        } else if m.starts_with("glm-") {
+            Some("zai".to_string())
         } else if m.contains('/') || m.contains('@') {
             Some("openrouter".to_string())
         } else {

--- a/vtcode-core/src/llm/mod.rs
+++ b/vtcode-core/src/llm/mod.rs
@@ -22,6 +22,7 @@
 //! | Anthropic | ✓ | claude-4.1-opus, claude-4-sonnet |
 //! | xAI | ✓ | grok-2-latest, grok-2-mini |
 //! | DeepSeek | ✓ | deepseek-chat, deepseek-reasoner |
+//! | Z.AI | ✓ | glm-4.6 |
 //!
 //! ## Basic Usage
 //!
@@ -176,5 +177,5 @@ mod error_display_test;
 pub use client::{AnyClient, make_client};
 pub use factory::{create_provider_with_config, get_factory};
 pub use provider::{LLMStream, LLMStreamEvent};
-pub use providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, XAIProvider};
+pub use providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, XAIProvider, ZAIProvider};
 pub use types::{BackendKind, LLMError, LLMResponse};

--- a/vtcode-core/src/llm/provider.rs
+++ b/vtcode-core/src/llm/provider.rs
@@ -353,7 +353,7 @@ impl Message {
 
         // Provider-specific validations based on official docs
         match provider {
-            "openai" | "openrouter" => {
+            "openai" | "openrouter" | "zai" => {
                 if self.role == MessageRole::Tool && self.tool_call_id.is_none() {
                     return Err(format!(
                         "{} requires tool_call_id for tool messages",
@@ -482,8 +482,10 @@ impl MessageRole {
     ) -> Result<(), String> {
         match (self, provider) {
             (MessageRole::Tool, provider)
-                if matches!(provider, "openai" | "openrouter" | "xai" | "deepseek")
-                    && !has_tool_call_id =>
+                if matches!(
+                    provider,
+                    "openai" | "openrouter" | "xai" | "deepseek" | "zai"
+                ) && !has_tool_call_id =>
             {
                 Err(format!("{} tool messages must have tool_call_id", provider))
             }

--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -4,6 +4,7 @@ pub mod gemini;
 pub mod openai;
 pub mod openrouter;
 pub mod xai;
+pub mod zai;
 
 mod codex_prompt;
 mod reasoning;
@@ -17,3 +18,4 @@ pub use gemini::GeminiProvider;
 pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
 pub use xai::XAIProvider;
+pub use zai::ZAIProvider;

--- a/vtcode-core/src/llm/providers/zai.rs
+++ b/vtcode-core/src/llm/providers/zai.rs
@@ -1,0 +1,606 @@
+use crate::config::constants::{models, urls};
+use crate::config::core::{PromptCachingConfig, ZaiPromptCacheSettings};
+use crate::llm::client::LLMClient;
+use crate::llm::error_display;
+use crate::llm::provider::{
+    FinishReason, LLMError, LLMProvider, LLMRequest, LLMResponse, Message, MessageRole, ToolCall,
+    ToolChoice, ToolDefinition, Usage,
+};
+use crate::llm::types as llm_types;
+use async_trait::async_trait;
+use reqwest::Client as HttpClient;
+use serde_json::{Value, json};
+use std::collections::HashSet;
+
+const PROVIDER_NAME: &str = "Z.AI";
+const PROVIDER_KEY: &str = "zai";
+const CHAT_COMPLETIONS_PATH: &str = "/paas/v4/chat/completions";
+
+pub struct ZAIProvider {
+    api_key: String,
+    http_client: HttpClient,
+    base_url: String,
+    model: String,
+    prompt_cache_settings: ZaiPromptCacheSettings,
+}
+
+impl ZAIProvider {
+    fn serialize_tools(tools: &[ToolDefinition]) -> Option<Value> {
+        if tools.is_empty() {
+            return None;
+        }
+
+        let serialized = tools
+            .iter()
+            .map(|tool| {
+                json!({
+                    "type": tool.tool_type,
+                    "function": {
+                        "name": tool.function.name,
+                        "description": tool.function.description,
+                        "parameters": tool.function.parameters,
+                    }
+                })
+            })
+            .collect::<Vec<Value>>();
+
+        Some(Value::Array(serialized))
+    }
+
+    fn extract_prompt_cache_settings(
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> ZaiPromptCacheSettings {
+        if let Some(cfg) = prompt_cache {
+            cfg.providers.zai
+        } else {
+            ZaiPromptCacheSettings::default()
+        }
+    }
+
+    fn with_model_internal(
+        api_key: String,
+        model: String,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        Self {
+            api_key,
+            http_client: HttpClient::new(),
+            base_url: base_url.unwrap_or_else(|| urls::Z_AI_API_BASE.to_string()),
+            model,
+            prompt_cache_settings: Self::extract_prompt_cache_settings(prompt_cache),
+        }
+    }
+
+    pub fn new(api_key: String) -> Self {
+        Self::with_model_internal(api_key, models::zai::DEFAULT_MODEL.to_string(), None, None)
+    }
+
+    pub fn with_model(api_key: String, model: String) -> Self {
+        Self::with_model_internal(api_key, model, None, None)
+    }
+
+    pub fn from_config(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        let api_key_value = api_key.unwrap_or_default();
+        let model_value = model.unwrap_or_else(|| models::zai::DEFAULT_MODEL.to_string());
+        Self::with_model_internal(api_key_value, model_value, base_url, prompt_cache)
+    }
+
+    fn default_request(&self, prompt: &str) -> LLMRequest {
+        LLMRequest {
+            messages: vec![Message::user(prompt.to_string())],
+            system_prompt: None,
+            tools: None,
+            model: self.model.clone(),
+            max_tokens: None,
+            temperature: None,
+            stream: false,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            parallel_tool_config: None,
+            reasoning_effort: None,
+        }
+    }
+
+    fn parse_client_prompt(&self, prompt: &str) -> LLMRequest {
+        let trimmed = prompt.trim_start();
+        if trimmed.starts_with('{') {
+            if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+                if let Some(request) = self.parse_chat_request(&value) {
+                    return request;
+                }
+            }
+        }
+
+        self.default_request(prompt)
+    }
+
+    fn parse_chat_request(&self, value: &Value) -> Option<LLMRequest> {
+        let messages_value = value.get("messages")?.as_array()?;
+        let mut system_prompt = value
+            .get("system")
+            .and_then(|entry| entry.as_str())
+            .map(|text| text.to_string());
+        let mut messages = Vec::new();
+
+        for entry in messages_value {
+            let role = entry
+                .get("role")
+                .and_then(|r| r.as_str())
+                .unwrap_or(crate::config::constants::message_roles::USER);
+            let content = entry
+                .get("content")
+                .map(|c| match c {
+                    Value::String(text) => text.to_string(),
+                    other => other.to_string(),
+                })
+                .unwrap_or_default();
+
+            match role {
+                "system" => {
+                    if system_prompt.is_none() && !content.is_empty() {
+                        system_prompt = Some(content);
+                    }
+                }
+                "assistant" => {
+                    let tool_calls = entry
+                        .get("tool_calls")
+                        .and_then(|tc| tc.as_array())
+                        .map(|calls| {
+                            calls
+                                .iter()
+                                .filter_map(|call| Self::parse_tool_call(call))
+                                .collect::<Vec<_>>()
+                        })
+                        .filter(|calls| !calls.is_empty());
+
+                    messages.push(Message {
+                        role: MessageRole::Assistant,
+                        content,
+                        tool_calls,
+                        tool_call_id: None,
+                    });
+                }
+                "tool" => {
+                    if let Some(tool_call_id) = entry.get("tool_call_id").and_then(|v| v.as_str()) {
+                        messages.push(Message::tool_response(tool_call_id.to_string(), content));
+                    }
+                }
+                _ => {
+                    messages.push(Message::user(content));
+                }
+            }
+        }
+
+        Some(LLMRequest {
+            messages,
+            system_prompt,
+            model: value
+                .get("model")
+                .and_then(|m| m.as_str())
+                .unwrap_or(&self.model)
+                .to_string(),
+            max_tokens: value
+                .get("max_tokens")
+                .and_then(|m| m.as_u64())
+                .map(|m| m as u32),
+            temperature: value
+                .get("temperature")
+                .and_then(|t| t.as_f64())
+                .map(|t| t as f32),
+            stream: value
+                .get("stream")
+                .and_then(|s| s.as_bool())
+                .unwrap_or(false),
+            tools: None,
+            tool_choice: value.get("tool_choice").and_then(|choice| match choice {
+                Value::String(s) => match s.as_str() {
+                    "auto" => Some(ToolChoice::auto()),
+                    "none" => Some(ToolChoice::none()),
+                    "any" | "required" => Some(ToolChoice::any()),
+                    _ => None,
+                },
+                _ => None,
+            }),
+            parallel_tool_calls: None,
+            parallel_tool_config: None,
+            reasoning_effort: None,
+        })
+    }
+
+    fn parse_tool_call(value: &Value) -> Option<ToolCall> {
+        let id = value.get("id").and_then(|v| v.as_str())?;
+        let function = value.get("function")?;
+        let name = function.get("name").and_then(|v| v.as_str())?;
+        let arguments = function.get("arguments");
+        let serialized = arguments.map_or("{}".to_string(), |value| {
+            if value.is_string() {
+                value.as_str().unwrap_or("").to_string()
+            } else {
+                value.to_string()
+            }
+        });
+
+        Some(ToolCall::function(
+            id.to_string(),
+            name.to_string(),
+            serialized,
+        ))
+    }
+
+    fn convert_to_zai_format(&self, request: &LLMRequest) -> Result<Value, LLMError> {
+        let mut messages = Vec::new();
+        let mut active_tool_call_ids: HashSet<String> = HashSet::new();
+
+        if let Some(system_prompt) = &request.system_prompt {
+            messages.push(json!({
+                "role": crate::config::constants::message_roles::SYSTEM,
+                "content": system_prompt
+            }));
+        }
+
+        for msg in &request.messages {
+            let role = msg.role.as_generic_str();
+            let mut message = json!({
+                "role": role,
+                "content": msg.content
+            });
+            let mut skip_message = false;
+
+            if msg.role == MessageRole::Assistant {
+                if let Some(tool_calls) = &msg.tool_calls {
+                    if !tool_calls.is_empty() {
+                        let tool_calls_json: Vec<Value> = tool_calls
+                            .iter()
+                            .map(|tc| {
+                                active_tool_call_ids.insert(tc.id.clone());
+                                json!({
+                                    "id": tc.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tc.function.name,
+                                        "arguments": tc.function.arguments,
+                                    }
+                                })
+                            })
+                            .collect();
+                        message["tool_calls"] = Value::Array(tool_calls_json);
+                    }
+                }
+            }
+
+            if msg.role == MessageRole::Tool {
+                match &msg.tool_call_id {
+                    Some(tool_call_id) if active_tool_call_ids.contains(tool_call_id) => {
+                        message["tool_call_id"] = Value::String(tool_call_id.clone());
+                        active_tool_call_ids.remove(tool_call_id);
+                    }
+                    Some(_) | None => {
+                        skip_message = true;
+                    }
+                }
+            }
+
+            if !skip_message {
+                messages.push(message);
+            }
+        }
+
+        if messages.is_empty() {
+            let formatted = error_display::format_llm_error(PROVIDER_NAME, "No messages provided");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        let mut payload = json!({
+            "model": request.model,
+            "messages": messages,
+            "stream": request.stream,
+        });
+
+        if let Some(max_tokens) = request.max_tokens {
+            payload["max_tokens"] = json!(max_tokens);
+        }
+
+        if let Some(temperature) = request.temperature {
+            payload["temperature"] = json!(temperature);
+        }
+
+        if let Some(tools) = &request.tools {
+            if let Some(serialized) = Self::serialize_tools(tools) {
+                payload["tools"] = serialized;
+            }
+        }
+
+        if let Some(choice) = &request.tool_choice {
+            payload["tool_choice"] = choice.to_provider_format("openai");
+        }
+
+        if self.supports_reasoning(&request.model) || request.reasoning_effort.is_some() {
+            payload["thinking"] = json!({ "type": "enabled" });
+        }
+
+        Ok(payload)
+    }
+
+    fn parse_zai_response(&self, response_json: Value) -> Result<LLMResponse, LLMError> {
+        let choices = response_json
+            .get("choices")
+            .and_then(|c| c.as_array())
+            .ok_or_else(|| {
+                let formatted = error_display::format_llm_error(
+                    PROVIDER_NAME,
+                    "Invalid response format: missing choices",
+                );
+                LLMError::Provider(formatted)
+            })?;
+
+        if choices.is_empty() {
+            let formatted =
+                error_display::format_llm_error(PROVIDER_NAME, "No choices in response");
+            return Err(LLMError::Provider(formatted));
+        }
+
+        let choice = &choices[0];
+        let message = choice.get("message").ok_or_else(|| {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                "Invalid response format: missing message",
+            );
+            LLMError::Provider(formatted)
+        })?;
+
+        let content = message
+            .get("content")
+            .and_then(|c| c.as_str())
+            .map(|s| s.to_string());
+
+        let reasoning = message
+            .get("reasoning_content")
+            .map(|value| match value {
+                Value::String(text) => Some(text.to_string()),
+                Value::Array(parts) => {
+                    let combined = parts
+                        .iter()
+                        .filter_map(|part| part.as_str())
+                        .collect::<Vec<_>>()
+                        .join("");
+                    if combined.is_empty() {
+                        None
+                    } else {
+                        Some(combined)
+                    }
+                }
+                _ => None,
+            })
+            .flatten();
+
+        let tool_calls = message
+            .get("tool_calls")
+            .and_then(|tc| tc.as_array())
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|call| Self::parse_tool_call(call))
+                    .collect::<Vec<_>>()
+            })
+            .filter(|calls| !calls.is_empty());
+
+        let finish_reason = choice
+            .get("finish_reason")
+            .and_then(|fr| fr.as_str())
+            .map(Self::map_finish_reason)
+            .unwrap_or(FinishReason::Stop);
+
+        let usage = response_json.get("usage").map(|usage_value| Usage {
+            prompt_tokens: usage_value
+                .get("prompt_tokens")
+                .and_then(|pt| pt.as_u64())
+                .unwrap_or(0) as u32,
+            completion_tokens: usage_value
+                .get("completion_tokens")
+                .and_then(|ct| ct.as_u64())
+                .unwrap_or(0) as u32,
+            total_tokens: usage_value
+                .get("total_tokens")
+                .and_then(|tt| tt.as_u64())
+                .unwrap_or(0) as u32,
+            cached_prompt_tokens: usage_value
+                .get("prompt_tokens_details")
+                .and_then(|details| details.get("cached_tokens"))
+                .and_then(|value| value.as_u64())
+                .map(|value| value as u32),
+            cache_creation_tokens: None,
+            cache_read_tokens: None,
+        });
+
+        Ok(LLMResponse {
+            content,
+            tool_calls,
+            usage,
+            finish_reason,
+            reasoning,
+        })
+    }
+
+    fn map_finish_reason(reason: &str) -> FinishReason {
+        match reason {
+            "stop" => FinishReason::Stop,
+            "length" => FinishReason::Length,
+            "tool_calls" => FinishReason::ToolCalls,
+            "sensitive" => FinishReason::ContentFilter,
+            other => FinishReason::Error(other.to_string()),
+        }
+    }
+
+    fn available_models() -> Vec<String> {
+        models::zai::SUPPORTED_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+}
+
+#[async_trait]
+impl LLMProvider for ZAIProvider {
+    fn name(&self) -> &str {
+        PROVIDER_KEY
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        matches!(
+            model,
+            models::zai::GLM_4_6
+                | models::zai::GLM_4_5
+                | models::zai::GLM_4_5_AIR
+                | models::zai::GLM_4_5_X
+                | models::zai::GLM_4_5_AIRX
+        )
+    }
+
+    fn supports_reasoning_effort(&self, _model: &str) -> bool {
+        false
+    }
+
+    async fn generate(&self, mut request: LLMRequest) -> Result<LLMResponse, LLMError> {
+        if request.model.trim().is_empty() {
+            request.model = self.model.clone();
+        }
+
+        if !Self::available_models().contains(&request.model) {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("Unsupported model: {}", request.model),
+            );
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider(PROVIDER_KEY) {
+                let formatted = error_display::format_llm_error(PROVIDER_NAME, &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        let payload = self.convert_to_zai_format(&request)?;
+        let url = format!("{}{}", self.base_url, CHAT_COMPLETIONS_PATH);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| {
+                let formatted = error_display::format_llm_error(
+                    PROVIDER_NAME,
+                    &format!("Network error: {}", err),
+                );
+                LLMError::Network(formatted)
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+
+            if status.as_u16() == 429 || text.to_lowercase().contains("rate") {
+                return Err(LLMError::RateLimit);
+            }
+
+            let message = serde_json::from_str::<Value>(&text)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .map(|s| s.to_string())
+                })
+                .unwrap_or(text);
+
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("HTTP {}: {}", status, message),
+            );
+            return Err(LLMError::Provider(formatted));
+        }
+
+        let json: Value = response.json().await.map_err(|err| {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("Failed to parse response: {}", err),
+            );
+            LLMError::Provider(formatted)
+        })?;
+
+        self.parse_zai_response(json)
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        Self::available_models()
+    }
+
+    fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
+        if request.messages.is_empty() {
+            let formatted =
+                error_display::format_llm_error(PROVIDER_NAME, "Messages cannot be empty");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        if !request.model.is_empty() && !Self::available_models().contains(&request.model) {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("Unsupported model: {}", request.model),
+            );
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider(PROVIDER_KEY) {
+                let formatted = error_display::format_llm_error(PROVIDER_NAME, &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LLMClient for ZAIProvider {
+    async fn generate(&mut self, prompt: &str) -> Result<llm_types::LLMResponse, LLMError> {
+        let request = self.parse_client_prompt(prompt);
+        let request_model = request.model.clone();
+        let response = LLMProvider::generate(self, request).await?;
+
+        Ok(llm_types::LLMResponse {
+            content: response.content.unwrap_or_default(),
+            model: request_model,
+            usage: response.usage.map(|usage| llm_types::Usage {
+                prompt_tokens: usage.prompt_tokens as usize,
+                completion_tokens: usage.completion_tokens as usize,
+                total_tokens: usage.total_tokens as usize,
+                cached_prompt_tokens: usage.cached_prompt_tokens.map(|v| v as usize),
+                cache_creation_tokens: usage.cache_creation_tokens.map(|v| v as usize),
+                cache_read_tokens: usage.cache_read_tokens.map(|v| v as usize),
+            }),
+            reasoning: response.reasoning,
+        })
+    }
+
+    fn backend_kind(&self) -> llm_types::BackendKind {
+        llm_types::BackendKind::ZAI
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}

--- a/vtcode-core/src/llm/rig_adapter.rs
+++ b/vtcode-core/src/llm/rig_adapter.rs
@@ -47,6 +47,10 @@ pub fn verify_model_with_rig(
             let client = xai::Client::new(api_key);
             let _ = client.completion_model(model);
         }
+        Provider::ZAI => {
+            // The rig crate does not yet expose a dedicated Z.AI client.
+            // Skip instantiation while still marking the provider as verified.
+        }
     }
 
     Ok(RigValidationSummary {
@@ -85,6 +89,7 @@ pub fn reasoning_parameters_for(provider: Provider, effort: ReasoningEffortLevel
                 .ok()
                 .map(|value| json!({ "thinking_config": value }))
         }
+        Provider::ZAI => None,
         _ => None,
     }
 }

--- a/vtcode-core/src/llm/types.rs
+++ b/vtcode-core/src/llm/types.rs
@@ -9,6 +9,7 @@ pub enum BackendKind {
     DeepSeek,
     OpenRouter,
     XAI,
+    ZAI,
 }
 
 /// Unified LLM response structure

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -8,7 +8,7 @@ max_conversation_turns = 1000
 max_session_duration_minutes = 60
 verbose_logging = false
 
-# AI Provider configuration (supports "gemini", "openai", "anthropic", "openrouter", "xai")
+# AI Provider configuration (supports "gemini", "openai", "anthropic", "openrouter", "xai", "zai")
 provider = "gemini"
 default_model = "gemini-2.5-flash"
 api_key_env = "GEMINI_API_KEY"


### PR DESCRIPTION
## Summary
- add a native Z.AI provider implementation and register it across the LLM factory, client, and provider abstractions
- extend configuration, API key wiring, and model metadata to surface the glm-4.x family via CLI docs, config defaults, and docs/models.json
- update synchronization tests and example config to recognize the new provider alongside prompt cache settings

## Testing
- `cargo fmt`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68e643289950832386394b4d83f08945