### PR TITLE
Add Moonshot AI provider integration

### DIFF
--- a/docs/PROVIDER_GUIDES.md
+++ b/docs/PROVIDER_GUIDES.md
@@ -17,6 +17,14 @@ This index collects provider-specific guides for configuring VT Code with differ
 - Key management and defaults mirror the Gemini/OpenAI flow in [Getting Started](./user-guide/getting-started.md#configure-your-llm-provider).
 - Supported model IDs live in [`vtcode-core/src/config/constants.rs`](../vtcode-core/src/config/constants.rs).
 
+## Moonshot AI
+
+- **Guide:** [Moonshot Integration](./providers/moonshot.md)
+- **Official docs:**
+  - [API overview](https://platform.moonshot.ai/docs/overview)
+  - [Kimi K2 Turbo promotion](https://platform.moonshot.ai/docs/promotion#kimi-k2-model-limited-time-promotion)
+- Default model: `moonshot-v1-32k` (override via `vtcode.toml` or CLI `--model`).
+
 ## OpenRouter Marketplace
 
 - **Guide:** [OpenRouter Integration](./providers/openrouter.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ Deploying VT Code in production? Focus on enterprise features:
 -   **[Security Implementation](./SAFETY_IMPLEMENTATION.md)** - Security controls and compliance
 -   **[Performance Analysis](./PERFORMANCE_ANALYSIS.md)** - Optimization and benchmarking
 -   **[Provider Guides](./PROVIDER_GUIDES.md)** - LLM provider integration guides
+    -   [Moonshot Integration](./providers/moonshot.md)
     -   [OpenRouter Integration](./providers/openrouter.md)
 
 ## Core Capabilities

--- a/docs/models.json
+++ b/docs/models.json
@@ -256,6 +256,96 @@
       }
     }
   },
+  "moonshot": {
+    "id": "moonshot",
+    "env": [
+      "MOONSHOT_API_KEY"
+    ],
+    "api": "https://api.moonshot.cn/v1",
+    "name": "Moonshot AI",
+    "doc": "https://platform.moonshot.ai/docs/overview",
+    "models": {
+      "moonshot-v1-8k": {
+        "id": "moonshot-v1-8k",
+        "name": "Moonshot v1 8K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8192
+      },
+      "moonshot-v1-32k": {
+        "id": "moonshot-v1-32k",
+        "name": "Moonshot v1 32K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 32768
+      },
+      "moonshot-v1-128k": {
+        "id": "moonshot-v1-128k",
+        "name": "Moonshot v1 128K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "kimi-k2-0711-preview": {
+        "id": "kimi-k2-0711-preview",
+        "name": "Kimi K2 Preview",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8000
+      },
+      "kimi-k2-turbo-preview": {
+        "id": "kimi-k2-turbo-preview",
+        "name": "Kimi K2 Turbo Preview",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8000,
+        "promotion": {
+          "label": "Limited-time 50% off",
+          "window": "2025-09-16 to 2025-10-15"
+        }
+      }
+    }
+  },
   "xai": {
     "id": "xai",
     "env": [

--- a/docs/models.json
+++ b/docs/models.json
@@ -433,6 +433,129 @@
       }
     }
   },
+  "zai": {
+    "id": "zai",
+    "env": [
+      "ZAI_API_KEY"
+    ],
+    "api": "https://api.z.ai/api",
+    "name": "Z.AI",
+    "doc": "https://docs.z.ai/guides/llm/glm-4.6",
+    "models": {
+      "glm-4.6": {
+        "id": "glm-4.6",
+        "name": "GLM 4.6",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 200000,
+        "max_output_tokens": 128000
+      },
+      "glm-4.5": {
+        "id": "glm-4.5",
+        "name": "GLM 4.5",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-air": {
+        "id": "glm-4.5-air",
+        "name": "GLM 4.5 Air",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-x": {
+        "id": "glm-4.5-x",
+        "name": "GLM 4.5 X",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-airx": {
+        "id": "glm-4.5-airx",
+        "name": "GLM 4.5 AirX",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4.5-flash": {
+        "id": "glm-4.5-flash",
+        "name": "GLM 4.5 Flash",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": 96000
+      },
+      "glm-4-32b-0414-128k": {
+        "id": "glm-4-32b-0414-128k",
+        "name": "GLM 4 32B 0414 128K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 128000,
+        "max_output_tokens": null
+      }
+    }
+  },
   "openrouter": {
     "id": "openrouter",
     "env": [

--- a/docs/providers/PROMPT_CACHING_UPDATE.md
+++ b/docs/providers/PROMPT_CACHING_UPDATE.md
@@ -42,6 +42,9 @@ enabled = true
 propagate_provider_capabilities = true
 report_savings = true
 
+[prompt_cache.providers.moonshot]
+enabled = false
+
 [prompt_cache.providers.xai]
 enabled = true
 

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -1,0 +1,44 @@
+# Moonshot AI Integration
+
+Moonshot AI exposes an OpenAI-compatible chat completions API at `https://api.moonshot.cn/v1`. The provider supports both the general `moonshot-v1` family and the limited-time **Kimi K2 Turbo Preview** promotion described in the official documentation.
+
+## Supported models
+
+| Identifier | Context window | Notes |
+| --- | --- | --- |
+| `moonshot-v1-8k` | 8K tokens | Fastest Moonshot v1 tier |
+| `moonshot-v1-32k` | 32K tokens | Balanced general-purpose tier |
+| `moonshot-v1-128k` | 128K tokens | Long-context flagship tier |
+| `kimi-k2-0711-preview` | 8K tokens | Early preview of the Kimi K2 reasoning model |
+| `kimi-k2-turbo-preview` | 8K tokens | Promotional Turbo Preview (50% off during the published campaign) |
+
+Moonshot’s API currently accepts standard Chat Completions payloads, including tool calling definitions. The limited-time Turbo preview promotion details are published at <https://platform.moonshot.ai/docs/promotion#kimi-k2-model-limited-time-promotion>.
+
+## Authentication
+
+Set the `MOONSHOT_API_KEY` environment variable before launching VTCode:
+
+```bash
+export MOONSHOT_API_KEY="your-moonshot-key"
+```
+
+You can also specify a provider entry in `vtcode.toml` or `~/.vtcode/config.toml` and supply the key inline if necessary.
+
+## Configuration snippet
+
+```toml
+[agent]
+provider = "moonshot"
+default_model = "moonshot-v1-32k"
+api_key_env = "MOONSHOT_API_KEY"
+
+[prompt_cache.providers.moonshot]
+# Prompt caching is advisory only at the moment.
+enabled = false
+```
+
+## Usage notes
+
+* Streaming and tool calling follow the same semantics as OpenAI’s Chat Completions API.
+* The provider currently does not expose explicit prompt cache controls; the VTCode integration records the preference but does not forward cache directives yet.
+* Reasoning-effort overrides are disabled until the public API documents such parameters for Moonshot models.

--- a/docs/tools/PROMPT_CACHING_GUIDE.md
+++ b/docs/tools/PROMPT_CACHING_GUIDE.md
@@ -76,6 +76,15 @@ report_savings = true
 -   `propagate_provider_capabilities` — pass provider cache instructions straight through to upstream models.
 -   `report_savings` — surface cache-hit metrics returned by OpenRouter alongside standard usage data.
 
+### Moonshot AI
+
+```toml
+[prompt_cache.providers.moonshot]
+enabled = false
+```
+
+-   Prompt caching is not yet exposed in the Moonshot API. VT Code records the preference but does not send cache directives downstream.
+
 ### xAI
 
 ```toml

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -371,6 +371,7 @@ Now that you have VT Code running, explore:
 1. **[Configuration Guide](../CONFIGURATION.md)** - Advanced configuration options
 1. **[Architecture Guide](../ARCHITECTURE.md)** - System design and components
 1. **[Provider Guides](../PROVIDER_GUIDES.md)** - LLM provider integration
+   - [Moonshot Integration](../providers/moonshot.md)
    - [OpenRouter Integration](../providers/openrouter.md)
 
 ## Contributing

--- a/src/main_modular.rs
+++ b/src/main_modular.rs
@@ -102,6 +102,7 @@ async fn main() -> Result<()> {
     api_key_sources.openai_env = "OPENAI_API_KEY".to_string();
     api_key_sources.openrouter_env = "OPENROUTER_API_KEY".to_string();
     api_key_sources.xai_env = "XAI_API_KEY".to_string();
+    api_key_sources.zai_env = "ZAI_API_KEY".to_string();
 
     // Parse model
     let model = ModelId::from_str(&args.model)?;

--- a/tests/llm_focused_test.rs
+++ b/tests/llm_focused_test.rs
@@ -5,7 +5,8 @@ use vtcode_core::llm::{
     factory::{LLMFactory, create_provider_for_model},
     provider::{LLMProvider, LLMRequest, Message, MessageRole},
     providers::{
-        AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider, XAIProvider,
+        AnthropicProvider, GeminiProvider, MoonshotProvider, OpenAIProvider, OpenRouterProvider,
+        XAIProvider,
     },
 };
 
@@ -20,7 +21,8 @@ fn test_provider_factory_basic() {
     assert!(providers.contains(&"openrouter".to_string()));
     assert!(providers.contains(&"xai".to_string()));
     assert!(providers.contains(&"deepseek".to_string()));
-    assert_eq!(providers.len(), 6);
+    assert!(providers.contains(&"moonshot".to_string()));
+    assert_eq!(providers.len(), 7);
 }
 
 #[test]
@@ -51,6 +53,10 @@ fn test_provider_auto_detection() {
         factory.provider_from_model(models::xai::GROK_2_LATEST),
         Some("xai".to_string())
     );
+    assert_eq!(
+        factory.provider_from_model(models::moonshot::MOONSHOT_V1_32K),
+        Some("moonshot".to_string())
+    );
     assert_eq!(factory.provider_from_model("unknown-model"), None);
 }
 
@@ -80,6 +86,13 @@ fn test_unified_client_creation() {
 
     let xai = create_provider_for_model(models::xai::GROK_2_LATEST, "test_key".to_string(), None);
     assert!(xai.is_ok());
+
+    let moonshot = create_provider_for_model(
+        models::moonshot::MOONSHOT_V1_8K,
+        "test_key".to_string(),
+        None,
+    );
+    assert!(moonshot.is_ok());
 }
 
 #[test]
@@ -109,6 +122,9 @@ fn test_provider_names() {
 
     let xai = XAIProvider::new("test_key".to_string());
     assert_eq!(xai.name(), "xai");
+
+    let moonshot = MoonshotProvider::new("test_key".to_string());
+    assert_eq!(moonshot.name(), "moonshot");
 }
 
 #[test]

--- a/tests/llm_focused_test.rs
+++ b/tests/llm_focused_test.rs
@@ -5,8 +5,8 @@ use vtcode_core::llm::{
     factory::{LLMFactory, create_provider_for_model},
     provider::{LLMProvider, LLMRequest, Message, MessageRole},
     providers::{
-        AnthropicProvider, GeminiProvider, MoonshotProvider, OpenAIProvider, OpenRouterProvider,
-        XAIProvider,
+        AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OpenAIProvider,
+        OpenRouterProvider, XAIProvider, ZAIProvider,
     },
 };
 
@@ -22,7 +22,8 @@ fn test_provider_factory_basic() {
     assert!(providers.contains(&"xai".to_string()));
     assert!(providers.contains(&"deepseek".to_string()));
     assert!(providers.contains(&"moonshot".to_string()));
-    assert_eq!(providers.len(), 7);
+    assert!(providers.contains(&"zai".to_string()));
+    assert_eq!(providers.len(), 8);
 }
 
 #[test]
@@ -56,6 +57,10 @@ fn test_provider_auto_detection() {
     assert_eq!(
         factory.provider_from_model(models::moonshot::MOONSHOT_V1_32K),
         Some("moonshot".to_string())
+    );
+    assert_eq!(
+        factory.provider_from_model(models::zai::GLM_4_6),
+        Some("zai".to_string())
     );
     assert_eq!(factory.provider_from_model("unknown-model"), None);
 }
@@ -93,6 +98,9 @@ fn test_unified_client_creation() {
         None,
     );
     assert!(moonshot.is_ok());
+
+    let zai = create_provider_for_model(models::zai::GLM_4_6, "test_key".to_string(), None);
+    assert!(zai.is_ok());
 }
 
 #[test]
@@ -125,6 +133,12 @@ fn test_provider_names() {
 
     let moonshot = MoonshotProvider::new("test_key".to_string());
     assert_eq!(moonshot.name(), "moonshot");
+
+    let deepseek = DeepSeekProvider::new("test_key".to_string());
+    assert_eq!(deepseek.name(), "deepseek");
+
+    let zai = ZAIProvider::new("test_key".to_string());
+    assert_eq!(zai.name(), "zai");
 }
 
 #[test]

--- a/tests/models_sync.rs
+++ b/tests/models_sync.rs
@@ -47,6 +47,10 @@ fn constants_cover_models_json() {
                 validated_providers.insert("google");
                 Some(models::google::SUPPORTED_MODELS)
             }
+            "zai" => {
+                validated_providers.insert("zai");
+                Some(models::zai::SUPPORTED_MODELS)
+            }
             _ => None, // Skip providers we don't have constants for yet
         };
 
@@ -120,7 +124,7 @@ fn constants_cover_models_json() {
     }
 
     // Ensure we validated the expected providers
-    let expected_providers = ["openai", "anthropic", "google", "openrouter"];
+    let expected_providers = ["openai", "anthropic", "google", "openrouter", "zai"];
     for expected in &expected_providers {
         assert!(
             validated_providers.contains(expected),
@@ -165,6 +169,7 @@ fn model_helpers_validation_edge_cases() {
         "openrouter",
         models::openrouter::DEFAULT_MODEL
     ));
+    assert!(model_helpers::is_valid("zai", models::zai::DEFAULT_MODEL));
 }
 
 #[test]

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -52,12 +52,13 @@ pub struct Cli {
     ///   • moonshot - Moonshot AI Kimi and Moonshot v1 models
     ///   • openrouter - OpenRouter marketplace models
     ///   • xai - xAI Grok models
+    ///   • zai - Z.AI GLM models
     ///
     /// Example: --provider deepseek
     #[arg(long, global = true)]
     pub provider: Option<String>,
 
-    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• Moonshot: `MOONSHOT_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
+    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• Moonshot: `MOONSHOT_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n• Z.AI: `ZAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
     #[arg(long, global = true, default_value = crate::config::constants::defaults::DEFAULT_API_KEY_ENV)]
     pub api_key_env: String,
 

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 #[command(
     name = "vtcode",
     version,
-    about = "Advanced coding agent with Decision Ledger\n\nFeatures:\n• Single-agent architecture with Decision Ledger for reliable task execution\n• Tree-sitter powered code analysis (Rust, Python, JavaScript, TypeScript, Go, Java)\n• Multi-provider LLM support (Gemini, OpenAI, Anthropic, DeepSeek)\n• Real-time performance monitoring and benchmarking\n• Enhanced security with tool policies and sandboxing\n• Research-preview context management and conversation compression\n\nQuick Start:\n  export GEMINI_API_KEY=\"your_key\"\n  vtcode chat",
+    about = "Advanced coding agent with Decision Ledger\n\nFeatures:\n• Single-agent architecture with Decision Ledger for reliable task execution\n• Tree-sitter powered code analysis (Rust, Python, JavaScript, TypeScript, Go, Java)\n• Multi-provider LLM support (Gemini, OpenAI, Anthropic, DeepSeek, Moonshot, xAI, OpenRouter)\n• Real-time performance monitoring and benchmarking\n• Enhanced security with tool policies and sandboxing\n• Research-preview context management and conversation compression\n\nQuick Start:\n  export GEMINI_API_KEY=\"your_key\"\n  vtcode chat",
     color = ColorChoice::Auto
 )]
 pub struct Cli {
@@ -49,6 +49,7 @@ pub struct Cli {
     ///   • openai - OpenAI GPT models
     ///   • anthropic - Anthropic Claude models
     ///   • deepseek - DeepSeek models
+    ///   • moonshot - Moonshot AI Kimi and Moonshot v1 models
     ///   • openrouter - OpenRouter marketplace models
     ///   • xai - xAI Grok models
     ///
@@ -56,7 +57,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub provider: Option<String>,
 
-    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
+    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• Moonshot: `MOONSHOT_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n\n**Override:** --api-key-env CUSTOM_KEY
     #[arg(long, global = true, default_value = crate::config::constants::defaults::DEFAULT_API_KEY_ENV)]
     pub api_key_env: String,
 

--- a/vtcode-core/src/cli/models_commands.rs
+++ b/vtcode-core/src/cli/models_commands.rs
@@ -226,6 +226,10 @@ fn configure_standard_provider(
             .providers
             .deepseek
             .get_or_insert_with(Default::default),
+        "moonshot" => config
+            .providers
+            .moonshot
+            .get_or_insert_with(Default::default),
         "openrouter" => config
             .providers
             .openrouter
@@ -314,6 +318,7 @@ fn get_provider_credentials(
         "anthropic" => Ok(get_config(config.providers.anthropic.as_ref())),
         "gemini" => Ok(get_config(config.providers.gemini.as_ref())),
         "deepseek" => Ok(get_config(config.providers.deepseek.as_ref())),
+        "moonshot" => Ok(get_config(config.providers.moonshot.as_ref())),
         "openrouter" => Ok(get_config(config.providers.openrouter.as_ref())),
         "xai" => Ok(get_config(config.providers.xai.as_ref())),
         _ => Err(anyhow!("Unknown provider: {}", provider)),
@@ -357,6 +362,8 @@ fn infer_provider_from_model(model: &str) -> &'static str {
         "Anthropic"
     } else if model.starts_with("gemini-") {
         "Google Gemini"
+    } else if model.starts_with("moonshot-") || model.starts_with("kimi-k2") {
+        "Moonshot"
     } else if model.starts_with("grok-") {
         "xAI"
     } else if model.starts_with("deepseek-") {

--- a/vtcode-core/src/config/api_keys.rs
+++ b/vtcode-core/src/config/api_keys.rs
@@ -25,6 +25,8 @@ pub struct ApiKeySources {
     pub deepseek_env: String,
     /// Moonshot API key environment variable name
     pub moonshot_env: String,
+    /// Z.AI API key environment variable name
+    pub zai_env: String,
     /// Gemini API key from configuration file
     pub gemini_config: Option<String>,
     /// Anthropic API key from configuration file
@@ -39,6 +41,8 @@ pub struct ApiKeySources {
     pub deepseek_config: Option<String>,
     /// Moonshot API key from configuration file
     pub moonshot_config: Option<String>,
+    /// Z.AI API key from configuration file
+    pub zai_config: Option<String>,
 }
 
 impl Default for ApiKeySources {
@@ -51,6 +55,7 @@ impl Default for ApiKeySources {
             xai_env: "XAI_API_KEY".to_string(),
             deepseek_env: "DEEPSEEK_API_KEY".to_string(),
             moonshot_env: "MOONSHOT_API_KEY".to_string(),
+            zai_env: "ZAI_API_KEY".to_string(),
             gemini_config: None,
             anthropic_config: None,
             openai_config: None,
@@ -58,6 +63,7 @@ impl Default for ApiKeySources {
             xai_config: None,
             deepseek_config: None,
             moonshot_config: None,
+            zai_config: None,
         }
     }
 }
@@ -73,6 +79,7 @@ impl ApiKeySources {
             "moonshot" => ("MOONSHOT_API_KEY", vec![]),
             "openrouter" => ("OPENROUTER_API_KEY", vec![]),
             "xai" => ("XAI_API_KEY", vec![]),
+            "zai" => ("ZAI_API_KEY", vec![]),
             _ => ("GEMINI_API_KEY", vec!["GOOGLE_API_KEY"]),
         };
 
@@ -113,6 +120,11 @@ impl ApiKeySources {
             } else {
                 "MOONSHOT_API_KEY".to_string()
             },
+            zai_env: if provider == "zai" {
+                primary_env.to_string()
+            } else {
+                "ZAI_API_KEY".to_string()
+            },
             gemini_config: None,
             anthropic_config: None,
             openai_config: None,
@@ -120,6 +132,7 @@ impl ApiKeySources {
             xai_config: None,
             deepseek_config: None,
             moonshot_config: None,
+            zai_config: None,
         }
     }
 }
@@ -174,6 +187,7 @@ pub fn get_api_key(provider: &str, sources: &ApiKeySources) -> Result<String> {
         "moonshot" => "MOONSHOT_API_KEY",
         "openrouter" => "OPENROUTER_API_KEY",
         "xai" => "XAI_API_KEY",
+        "zai" => "ZAI_API_KEY",
         _ => "GEMINI_API_KEY",
     };
 
@@ -193,6 +207,7 @@ pub fn get_api_key(provider: &str, sources: &ApiKeySources) -> Result<String> {
         "moonshot" => get_moonshot_api_key(sources),
         "openrouter" => get_openrouter_api_key(sources),
         "xai" => get_xai_api_key(sources),
+        "zai" => get_zai_api_key(sources),
         _ => Err(anyhow::anyhow!("Unsupported provider: {}", provider)),
     }
 }
@@ -303,6 +318,11 @@ fn get_moonshot_api_key(sources: &ApiKeySources) -> Result<String> {
         sources.moonshot_config.as_ref(),
         "Moonshot",
     )
+}
+
+/// Get Z.AI API key with secure fallback
+fn get_zai_api_key(sources: &ApiKeySources) -> Result<String> {
+    get_api_key_with_fallback(&sources.zai_env, sources.zai_config.as_ref(), "Z.AI")
 }
 
 #[cfg(test)]

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -49,6 +49,28 @@ pub mod models {
         pub const CODEX_MINI: &str = "codex-mini";
     }
 
+    // Z.AI models (direct API)
+    pub mod zai {
+        pub const DEFAULT_MODEL: &str = "glm-4.6";
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            "glm-4.6",
+            "glm-4.5",
+            "glm-4.5-air",
+            "glm-4.5-x",
+            "glm-4.5-airx",
+            "glm-4.5-flash",
+            "glm-4-32b-0414-128k",
+        ];
+
+        pub const GLM_4_6: &str = "glm-4.6";
+        pub const GLM_4_5: &str = "glm-4.5";
+        pub const GLM_4_5_AIR: &str = "glm-4.5-air";
+        pub const GLM_4_5_X: &str = "glm-4.5-x";
+        pub const GLM_4_5_AIRX: &str = "glm-4.5-airx";
+        pub const GLM_4_5_FLASH: &str = "glm-4.5-flash";
+        pub const GLM_4_32B_0414_128K: &str = "glm-4-32b-0414-128k";
+    }
+
     // OpenRouter models (extensible via vtcode.toml)
     pub mod openrouter {
         pub const X_AI_GROK_CODE_FAST_1: &str = "x-ai/grok-code-fast-1";
@@ -340,6 +362,7 @@ pub mod prompt_cache {
     pub const XAI_CACHE_ENABLED: bool = true;
     pub const DEEPSEEK_CACHE_ENABLED: bool = true;
     pub const MOONSHOT_CACHE_ENABLED: bool = false;
+    pub const ZAI_CACHE_ENABLED: bool = false;
 }
 
 /// Model validation and helper functions
@@ -356,6 +379,7 @@ pub mod model_helpers {
             "moonshot" => Some(models::moonshot::SUPPORTED_MODELS),
             "openrouter" => Some(models::openrouter::SUPPORTED_MODELS),
             "xai" => Some(models::xai::SUPPORTED_MODELS),
+            "zai" => Some(models::zai::SUPPORTED_MODELS),
             _ => None,
         }
     }
@@ -370,6 +394,7 @@ pub mod model_helpers {
             "moonshot" => Some(models::moonshot::DEFAULT_MODEL),
             "openrouter" => Some(models::openrouter::DEFAULT_MODEL),
             "xai" => Some(models::xai::DEFAULT_MODEL),
+            "zai" => Some(models::zai::DEFAULT_MODEL),
             _ => None,
         }
     }
@@ -546,6 +571,7 @@ pub mod urls {
     pub const XAI_API_BASE: &str = "https://api.x.ai/v1";
     pub const DEEPSEEK_API_BASE: &str = "https://api.deepseek.com/v1";
     pub const MOONSHOT_API_BASE: &str = "https://api.moonshot.cn/v1";
+    pub const Z_AI_API_BASE: &str = "https://api.z.ai/api";
 }
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -222,6 +222,23 @@ pub mod models {
         pub const GROK_2_VISION: &str = "grok-2-vision";
     }
 
+    pub mod moonshot {
+        pub const DEFAULT_MODEL: &str = "moonshot-v1-32k";
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            "moonshot-v1-8k",
+            "moonshot-v1-32k",
+            "moonshot-v1-128k",
+            "kimi-k2-0711-preview",
+            "kimi-k2-turbo-preview",
+        ];
+
+        pub const MOONSHOT_V1_8K: &str = "moonshot-v1-8k";
+        pub const MOONSHOT_V1_32K: &str = "moonshot-v1-32k";
+        pub const MOONSHOT_V1_128K: &str = "moonshot-v1-128k";
+        pub const KIMI_K2_0711_PREVIEW: &str = "kimi-k2-0711-preview";
+        pub const KIMI_K2_TURBO_PREVIEW: &str = "kimi-k2-turbo-preview";
+    }
+
     // Backwards compatibility - keep old constants working
     pub const GEMINI_2_5_FLASH_PREVIEW: &str = google::GEMINI_2_5_FLASH_PREVIEW;
     pub const GEMINI_2_5_FLASH: &str = google::GEMINI_2_5_FLASH;
@@ -322,6 +339,7 @@ pub mod prompt_cache {
     pub const OPENROUTER_CACHE_DISCOUNT_ENABLED: bool = true;
     pub const XAI_CACHE_ENABLED: bool = true;
     pub const DEEPSEEK_CACHE_ENABLED: bool = true;
+    pub const MOONSHOT_CACHE_ENABLED: bool = false;
 }
 
 /// Model validation and helper functions
@@ -335,6 +353,7 @@ pub mod model_helpers {
             "openai" => Some(models::openai::SUPPORTED_MODELS),
             "anthropic" => Some(models::anthropic::SUPPORTED_MODELS),
             "deepseek" => Some(models::deepseek::SUPPORTED_MODELS),
+            "moonshot" => Some(models::moonshot::SUPPORTED_MODELS),
             "openrouter" => Some(models::openrouter::SUPPORTED_MODELS),
             "xai" => Some(models::xai::SUPPORTED_MODELS),
             _ => None,
@@ -348,6 +367,7 @@ pub mod model_helpers {
             "openai" => Some(models::openai::DEFAULT_MODEL),
             "anthropic" => Some(models::anthropic::DEFAULT_MODEL),
             "deepseek" => Some(models::deepseek::DEFAULT_MODEL),
+            "moonshot" => Some(models::moonshot::DEFAULT_MODEL),
             "openrouter" => Some(models::openrouter::DEFAULT_MODEL),
             "xai" => Some(models::xai::DEFAULT_MODEL),
             _ => None,
@@ -525,6 +545,7 @@ pub mod urls {
     pub const OPENROUTER_API_BASE: &str = "https://openrouter.ai/api/v1";
     pub const XAI_API_BASE: &str = "https://api.x.ai/v1";
     pub const DEEPSEEK_API_BASE: &str = "https://api.deepseek.com/v1";
+    pub const MOONSHOT_API_BASE: &str = "https://api.moonshot.cn/v1";
 }
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 /// Agent-wide configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentConfig {
-    /// AI provider for single agent mode (gemini, openai, anthropic, openrouter, xai)
+    /// AI provider for single agent mode (gemini, openai, anthropic, deepseek, moonshot, openrouter, xai)
     #[serde(default = "default_provider")]
     pub provider: String,
 

--- a/vtcode-core/src/config/core/agent.rs
+++ b/vtcode-core/src/config/core/agent.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 /// Agent-wide configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentConfig {
-    /// AI provider for single agent mode (gemini, openai, anthropic, deepseek, moonshot, openrouter, xai)
+    /// AI provider for single agent mode (gemini, openai, anthropic, deepseek, moonshot, openrouter, xai, zai)
     #[serde(default = "default_provider")]
     pub provider: String,
 

--- a/vtcode-core/src/config/core/mod.rs
+++ b/vtcode-core/src/config/core/mod.rs
@@ -12,6 +12,7 @@ pub use prompt_cache::{
     AnthropicPromptCacheSettings, DeepSeekPromptCacheSettings, GeminiPromptCacheMode,
     GeminiPromptCacheSettings, OpenAIPromptCacheSettings, OpenRouterPromptCacheSettings,
     PromptCachingConfig, ProviderPromptCachingConfig, XAIPromptCacheSettings,
+    ZaiPromptCacheSettings,
 };
 pub use security::SecurityConfig;
 pub use tools::{ToolPolicy, ToolsConfig};

--- a/vtcode-core/src/config/core/prompt_cache.rs
+++ b/vtcode-core/src/config/core/prompt_cache.rs
@@ -79,6 +79,9 @@ pub struct ProviderPromptCachingConfig {
 
     #[serde(default = "DeepSeekPromptCacheSettings::default")]
     pub deepseek: DeepSeekPromptCacheSettings,
+
+    #[serde(default = "MoonshotPromptCacheSettings::default")]
+    pub moonshot: MoonshotPromptCacheSettings,
 }
 
 impl Default for ProviderPromptCachingConfig {
@@ -90,6 +93,7 @@ impl Default for ProviderPromptCachingConfig {
             openrouter: OpenRouterPromptCacheSettings::default(),
             xai: XAIPromptCacheSettings::default(),
             deepseek: DeepSeekPromptCacheSettings::default(),
+            moonshot: MoonshotPromptCacheSettings::default(),
         }
     }
 }
@@ -262,6 +266,21 @@ impl Default for DeepSeekPromptCacheSettings {
     }
 }
 
+/// Moonshot prompt caching configuration (currently disabled by default)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MoonshotPromptCacheSettings {
+    #[serde(default = "default_false")]
+    pub enabled: bool,
+}
+
+impl Default for MoonshotPromptCacheSettings {
+    fn default() -> Self {
+        Self {
+            enabled: prompt_cache::MOONSHOT_CACHE_ENABLED,
+        }
+    }
+}
+
 fn default_enabled() -> bool {
     prompt_cache::DEFAULT_ENABLED
 }
@@ -288,6 +307,10 @@ fn default_min_quality_threshold() -> f64 {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_false() -> bool {
+    false
 }
 
 fn default_openai_min_prefix_tokens() -> u32 {

--- a/vtcode-core/src/config/core/prompt_cache.rs
+++ b/vtcode-core/src/config/core/prompt_cache.rs
@@ -79,9 +79,11 @@ pub struct ProviderPromptCachingConfig {
 
     #[serde(default = "DeepSeekPromptCacheSettings::default")]
     pub deepseek: DeepSeekPromptCacheSettings,
-
     #[serde(default = "MoonshotPromptCacheSettings::default")]
     pub moonshot: MoonshotPromptCacheSettings,
+
+    #[serde(default = "ZaiPromptCacheSettings::default")]
+    pub zai: ZaiPromptCacheSettings,
 }
 
 impl Default for ProviderPromptCachingConfig {
@@ -94,6 +96,7 @@ impl Default for ProviderPromptCachingConfig {
             xai: XAIPromptCacheSettings::default(),
             deepseek: DeepSeekPromptCacheSettings::default(),
             moonshot: MoonshotPromptCacheSettings::default(),
+            zai: ZaiPromptCacheSettings::default(),
         }
     }
 }
@@ -281,6 +284,21 @@ impl Default for MoonshotPromptCacheSettings {
     }
 }
 
+/// Z.AI prompt caching configuration (disabled until platform exposes metrics)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ZaiPromptCacheSettings {
+    #[serde(default = "default_zai_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for ZaiPromptCacheSettings {
+    fn default() -> Self {
+        Self {
+            enabled: default_zai_enabled(),
+        }
+    }
+}
+
 fn default_enabled() -> bool {
     prompt_cache::DEFAULT_ENABLED
 }
@@ -343,6 +361,10 @@ fn default_gemini_explicit_ttl() -> Option<u64> {
 
 fn default_gemini_mode() -> GeminiPromptCacheMode {
     GeminiPromptCacheMode::Implicit
+}
+
+fn default_zai_enabled() -> bool {
+    prompt_cache::ZAI_CACHE_ENABLED
 }
 
 fn resolve_path(input: &str, workspace_root: Option<&Path>) -> PathBuf {

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -81,6 +81,8 @@ pub enum Provider {
     Anthropic,
     /// DeepSeek native models
     DeepSeek,
+    /// Moonshot AI models
+    Moonshot,
     /// OpenRouter marketplace models
     OpenRouter,
     /// xAI Grok models
@@ -95,6 +97,7 @@ impl Provider {
             Provider::OpenAI => "OPENAI_API_KEY",
             Provider::Anthropic => "ANTHROPIC_API_KEY",
             Provider::DeepSeek => "DEEPSEEK_API_KEY",
+            Provider::Moonshot => "MOONSHOT_API_KEY",
             Provider::OpenRouter => "OPENROUTER_API_KEY",
             Provider::XAI => "XAI_API_KEY",
         }
@@ -107,6 +110,7 @@ impl Provider {
             Provider::OpenAI,
             Provider::Anthropic,
             Provider::DeepSeek,
+            Provider::Moonshot,
             Provider::OpenRouter,
             Provider::XAI,
         ]
@@ -119,6 +123,7 @@ impl Provider {
             Provider::OpenAI => "OpenAI",
             Provider::Anthropic => "Anthropic",
             Provider::DeepSeek => "DeepSeek",
+            Provider::Moonshot => "Moonshot",
             Provider::OpenRouter => "OpenRouter",
             Provider::XAI => "xAI",
         }
@@ -133,6 +138,7 @@ impl Provider {
             Provider::OpenAI => models::openai::REASONING_MODELS.contains(&model),
             Provider::Anthropic => models::anthropic::SUPPORTED_MODELS.contains(&model),
             Provider::DeepSeek => model == models::deepseek::DEEPSEEK_REASONER,
+            Provider::Moonshot => false,
             Provider::OpenRouter => models::openrouter::REASONING_MODELS.contains(&model),
             Provider::XAI => model == models::xai::GROK_2_REASONING,
         }
@@ -146,6 +152,7 @@ impl fmt::Display for Provider {
             Provider::OpenAI => write!(f, "openai"),
             Provider::Anthropic => write!(f, "anthropic"),
             Provider::DeepSeek => write!(f, "deepseek"),
+            Provider::Moonshot => write!(f, "moonshot"),
             Provider::OpenRouter => write!(f, "openrouter"),
             Provider::XAI => write!(f, "xai"),
         }
@@ -161,6 +168,7 @@ impl FromStr for Provider {
             "openai" => Ok(Provider::OpenAI),
             "anthropic" => Ok(Provider::Anthropic),
             "deepseek" => Ok(Provider::DeepSeek),
+            "moonshot" => Ok(Provider::Moonshot),
             "openrouter" => Ok(Provider::OpenRouter),
             "xai" => Ok(Provider::XAI),
             _ => Err(ModelParseError::InvalidProvider(s.to_string())),
@@ -218,6 +226,18 @@ pub enum ModelId {
     XaiGrok2Reasoning,
     /// Grok-2 Vision - Multimodal xAI model
     XaiGrok2Vision,
+
+    // Moonshot models
+    /// Moonshot v1 8K - Fast deployment with 8K context window
+    MoonshotV18k,
+    /// Moonshot v1 32K - Balanced option for longer tasks
+    MoonshotV132k,
+    /// Moonshot v1 128K - Maximum context Moonshot flagship
+    MoonshotV1128k,
+    /// Kimi K2 0711 Preview - Early preview of K2 reasoning model
+    MoonshotKimiK20711Preview,
+    /// Kimi K2 Turbo Preview - Limited-time promotion turbo preview
+    MoonshotKimiK2TurboPreview,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model
@@ -389,6 +409,12 @@ impl ModelId {
             ModelId::XaiGrok2Mini => models::xai::GROK_2_MINI,
             ModelId::XaiGrok2Reasoning => models::xai::GROK_2_REASONING,
             ModelId::XaiGrok2Vision => models::xai::GROK_2_VISION,
+            // Moonshot models
+            ModelId::MoonshotV18k => models::moonshot::MOONSHOT_V1_8K,
+            ModelId::MoonshotV132k => models::moonshot::MOONSHOT_V1_32K,
+            ModelId::MoonshotV1128k => models::moonshot::MOONSHOT_V1_128K,
+            ModelId::MoonshotKimiK20711Preview => models::moonshot::KIMI_K2_0711_PREVIEW,
+            ModelId::MoonshotKimiK2TurboPreview => models::moonshot::KIMI_K2_TURBO_PREVIEW,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -418,6 +444,11 @@ impl ModelId {
             | ModelId::XaiGrok2Mini
             | ModelId::XaiGrok2Reasoning
             | ModelId::XaiGrok2Vision => Provider::XAI,
+            ModelId::MoonshotV18k
+            | ModelId::MoonshotV132k
+            | ModelId::MoonshotV1128k
+            | ModelId::MoonshotKimiK20711Preview
+            | ModelId::MoonshotKimiK2TurboPreview => Provider::Moonshot,
             _ => unreachable!(),
         }
     }
@@ -457,6 +488,12 @@ impl ModelId {
             ModelId::XaiGrok2Mini => "Grok-2 Mini",
             ModelId::XaiGrok2Reasoning => "Grok-2 Reasoning",
             ModelId::XaiGrok2Vision => "Grok-2 Vision",
+            // Moonshot models
+            ModelId::MoonshotV18k => "Moonshot v1 8K",
+            ModelId::MoonshotV132k => "Moonshot v1 32K",
+            ModelId::MoonshotV1128k => "Moonshot v1 128K",
+            ModelId::MoonshotKimiK20711Preview => "Kimi K2 0711 Preview",
+            ModelId::MoonshotKimiK2TurboPreview => "Kimi K2 Turbo Preview",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -508,6 +545,22 @@ impl ModelId {
                 "Grok 2 variant that surfaces structured reasoning traces"
             }
             ModelId::XaiGrok2Vision => "Multimodal Grok 2 model with image understanding",
+            // Moonshot models
+            ModelId::MoonshotV18k => {
+                "Moonshot v1 8K with fast responses and compact context window"
+            }
+            ModelId::MoonshotV132k => {
+                "Balanced Moonshot v1 deployment offering 32K context support"
+            }
+            ModelId::MoonshotV1128k => {
+                "Flagship Moonshot v1 model with extended 128K context capacity"
+            }
+            ModelId::MoonshotKimiK20711Preview => {
+                "Preview release of the Kimi K2 model tuned for advanced reasoning"
+            }
+            ModelId::MoonshotKimiK2TurboPreview => {
+                "Limited-time Kimi K2 Turbo preview with promotional pricing"
+            }
             _ => unreachable!(),
         }
     }
@@ -539,6 +592,12 @@ impl ModelId {
             ModelId::XaiGrok2Mini,
             ModelId::XaiGrok2Reasoning,
             ModelId::XaiGrok2Vision,
+            // Moonshot models
+            ModelId::MoonshotV18k,
+            ModelId::MoonshotV132k,
+            ModelId::MoonshotV1128k,
+            ModelId::MoonshotKimiK20711Preview,
+            ModelId::MoonshotKimiK2TurboPreview,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -588,6 +647,7 @@ impl ModelId {
             Provider::OpenAI => ModelId::GPT5,
             Provider::Anthropic => ModelId::ClaudeOpus41,
             Provider::DeepSeek => ModelId::DeepSeekReasoner,
+            Provider::Moonshot => ModelId::MoonshotV1128k,
             Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
         }
@@ -600,6 +660,7 @@ impl ModelId {
             Provider::OpenAI => ModelId::GPT5Mini,
             Provider::Anthropic => ModelId::ClaudeSonnet45,
             Provider::DeepSeek => ModelId::DeepSeekChat,
+            Provider::Moonshot => ModelId::MoonshotV18k,
             Provider::XAI => ModelId::XaiGrok2Mini,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
         }
@@ -612,6 +673,7 @@ impl ModelId {
             Provider::OpenAI => ModelId::GPT5,
             Provider::Anthropic => ModelId::ClaudeOpus41,
             Provider::DeepSeek => ModelId::DeepSeekReasoner,
+            Provider::Moonshot => ModelId::MoonshotV1128k,
             Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
         }
@@ -652,6 +714,7 @@ impl ModelId {
                 | ModelId::GPT5Nano
                 | ModelId::DeepSeekChat
                 | ModelId::XaiGrok2Mini
+                | ModelId::MoonshotV18k
         )
     }
 
@@ -671,6 +734,9 @@ impl ModelId {
                 | ModelId::DeepSeekReasoner
                 | ModelId::XaiGrok2Latest
                 | ModelId::XaiGrok2Reasoning
+                | ModelId::MoonshotV1128k
+                | ModelId::MoonshotKimiK20711Preview
+                | ModelId::MoonshotKimiK2TurboPreview
         )
     }
 
@@ -703,6 +769,9 @@ impl ModelId {
             | ModelId::XaiGrok2Mini
             | ModelId::XaiGrok2Reasoning
             | ModelId::XaiGrok2Vision => "2",
+            // Moonshot generations
+            ModelId::MoonshotV18k | ModelId::MoonshotV132k | ModelId::MoonshotV1128k => "v1",
+            ModelId::MoonshotKimiK20711Preview | ModelId::MoonshotKimiK2TurboPreview => "K2",
             _ => unreachable!(),
         }
     }
@@ -738,6 +807,16 @@ impl FromStr for ModelId {
             // DeepSeek models
             s if s == models::DEEPSEEK_CHAT => Ok(ModelId::DeepSeekChat),
             s if s == models::DEEPSEEK_REASONER => Ok(ModelId::DeepSeekReasoner),
+            // Moonshot models
+            s if s == models::moonshot::MOONSHOT_V1_8K => Ok(ModelId::MoonshotV18k),
+            s if s == models::moonshot::MOONSHOT_V1_32K => Ok(ModelId::MoonshotV132k),
+            s if s == models::moonshot::MOONSHOT_V1_128K => Ok(ModelId::MoonshotV1128k),
+            s if s == models::moonshot::KIMI_K2_0711_PREVIEW => {
+                Ok(ModelId::MoonshotKimiK20711Preview)
+            }
+            s if s == models::moonshot::KIMI_K2_TURBO_PREVIEW => {
+                Ok(ModelId::MoonshotKimiK2TurboPreview)
+            }
             // xAI models
             s if s == models::xai::GROK_2_LATEST => Ok(ModelId::XaiGrok2Latest),
             s if s == models::xai::GROK_2 => Ok(ModelId::XaiGrok2),
@@ -844,6 +923,27 @@ mod tests {
             models::xai::GROK_2_REASONING
         );
         assert_eq!(ModelId::XaiGrok2Vision.as_str(), models::xai::GROK_2_VISION);
+        // Moonshot models
+        assert_eq!(
+            ModelId::MoonshotV18k.as_str(),
+            models::moonshot::MOONSHOT_V1_8K
+        );
+        assert_eq!(
+            ModelId::MoonshotV132k.as_str(),
+            models::moonshot::MOONSHOT_V1_32K
+        );
+        assert_eq!(
+            ModelId::MoonshotV1128k.as_str(),
+            models::moonshot::MOONSHOT_V1_128K
+        );
+        assert_eq!(
+            ModelId::MoonshotKimiK20711Preview.as_str(),
+            models::moonshot::KIMI_K2_0711_PREVIEW
+        );
+        assert_eq!(
+            ModelId::MoonshotKimiK2TurboPreview.as_str(),
+            models::moonshot::KIMI_K2_TURBO_PREVIEW
+        );
         macro_rules! assert_openrouter_to_string {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
                 $(assert_eq!(ModelId::$variant.as_str(), models::$const);)*
@@ -931,6 +1031,35 @@ mod tests {
         assert_eq!(
             models::xai::GROK_2_VISION.parse::<ModelId>().unwrap(),
             ModelId::XaiGrok2Vision
+        );
+        // Moonshot models
+        assert_eq!(
+            models::moonshot::MOONSHOT_V1_8K.parse::<ModelId>().unwrap(),
+            ModelId::MoonshotV18k
+        );
+        assert_eq!(
+            models::moonshot::MOONSHOT_V1_32K
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotV132k
+        );
+        assert_eq!(
+            models::moonshot::MOONSHOT_V1_128K
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotV1128k
+        );
+        assert_eq!(
+            models::moonshot::KIMI_K2_0711_PREVIEW
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiK20711Preview
+        );
+        assert_eq!(
+            models::moonshot::KIMI_K2_TURBO_PREVIEW
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiK2TurboPreview
         );
         macro_rules! assert_openrouter_parse {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1130,6 +1259,12 @@ mod tests {
         assert_eq!(ModelId::XaiGrok2Mini.generation(), "2");
         assert_eq!(ModelId::XaiGrok2Reasoning.generation(), "2");
         assert_eq!(ModelId::XaiGrok2Vision.generation(), "2");
+        // Moonshot generations
+        assert_eq!(ModelId::MoonshotV18k.generation(), "v1");
+        assert_eq!(ModelId::MoonshotV132k.generation(), "v1");
+        assert_eq!(ModelId::MoonshotV1128k.generation(), "v1");
+        assert_eq!(ModelId::MoonshotKimiK20711Preview.generation(), "K2");
+        assert_eq!(ModelId::MoonshotKimiK2TurboPreview.generation(), "K2");
 
         macro_rules! assert_openrouter_generation {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1158,6 +1293,13 @@ mod tests {
         let deepseek_models = ModelId::models_for_provider(Provider::DeepSeek);
         assert!(deepseek_models.contains(&ModelId::DeepSeekChat));
         assert!(deepseek_models.contains(&ModelId::DeepSeekReasoner));
+
+        let moonshot_models = ModelId::models_for_provider(Provider::Moonshot);
+        assert!(moonshot_models.contains(&ModelId::MoonshotV18k));
+        assert!(moonshot_models.contains(&ModelId::MoonshotV132k));
+        assert!(moonshot_models.contains(&ModelId::MoonshotV1128k));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20711Preview));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK2TurboPreview));
 
         let openrouter_models = ModelId::models_for_provider(Provider::OpenRouter);
         macro_rules! assert_openrouter_models_present {

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -87,6 +87,8 @@ pub enum Provider {
     OpenRouter,
     /// xAI Grok models
     XAI,
+    /// Z.AI GLM models
+    ZAI,
 }
 
 impl Provider {
@@ -100,6 +102,7 @@ impl Provider {
             Provider::Moonshot => "MOONSHOT_API_KEY",
             Provider::OpenRouter => "OPENROUTER_API_KEY",
             Provider::XAI => "XAI_API_KEY",
+            Provider::ZAI => "ZAI_API_KEY",
         }
     }
 
@@ -113,6 +116,7 @@ impl Provider {
             Provider::Moonshot,
             Provider::OpenRouter,
             Provider::XAI,
+            Provider::ZAI,
         ]
     }
 
@@ -126,6 +130,7 @@ impl Provider {
             Provider::Moonshot => "Moonshot",
             Provider::OpenRouter => "OpenRouter",
             Provider::XAI => "xAI",
+            Provider::ZAI => "Z.AI",
         }
     }
 
@@ -141,6 +146,7 @@ impl Provider {
             Provider::Moonshot => false,
             Provider::OpenRouter => models::openrouter::REASONING_MODELS.contains(&model),
             Provider::XAI => model == models::xai::GROK_2_REASONING,
+            Provider::ZAI => model == models::zai::GLM_4_6,
         }
     }
 }
@@ -155,6 +161,7 @@ impl fmt::Display for Provider {
             Provider::Moonshot => write!(f, "moonshot"),
             Provider::OpenRouter => write!(f, "openrouter"),
             Provider::XAI => write!(f, "xai"),
+            Provider::ZAI => write!(f, "zai"),
         }
     }
 }
@@ -171,6 +178,7 @@ impl FromStr for Provider {
             "moonshot" => Ok(Provider::Moonshot),
             "openrouter" => Ok(Provider::OpenRouter),
             "xai" => Ok(Provider::XAI),
+            "zai" => Ok(Provider::ZAI),
             _ => Err(ModelParseError::InvalidProvider(s.to_string())),
         }
     }
@@ -227,6 +235,22 @@ pub enum ModelId {
     /// Grok-2 Vision - Multimodal xAI model
     XaiGrok2Vision,
 
+    // Z.AI models
+    /// GLM-4.6 - Latest flagship GLM reasoning model
+    ZaiGlm46,
+    /// GLM-4.5 - Balanced GLM release for general tasks
+    ZaiGlm45,
+    /// GLM-4.5-Air - Efficient GLM variant
+    ZaiGlm45Air,
+    /// GLM-4.5-X - Enhanced capability GLM variant
+    ZaiGlm45X,
+    /// GLM-4.5-AirX - Hybrid efficient GLM variant
+    ZaiGlm45Airx,
+    /// GLM-4.5-Flash - Low-latency GLM variant
+    ZaiGlm45Flash,
+    /// GLM-4-32B-0414-128K - Legacy long-context GLM deployment
+    ZaiGlm432b0414128k,
+
     // Moonshot models
     /// Moonshot v1 8K - Fast deployment with 8K context window
     MoonshotV18k,
@@ -234,9 +258,9 @@ pub enum ModelId {
     MoonshotV132k,
     /// Moonshot v1 128K - Maximum context Moonshot flagship
     MoonshotV1128k,
-    /// Kimi K2 0711 Preview - Early preview of K2 reasoning model
+    /// Kimi K2 0711 Preview - Next-generation preview release
     MoonshotKimiK20711Preview,
-    /// Kimi K2 Turbo Preview - Limited-time promotion turbo preview
+    /// Kimi K2 Turbo Preview - Optimized K2 deployment for latency-sensitive coding
     MoonshotKimiK2TurboPreview,
 
     // OpenRouter models
@@ -409,6 +433,14 @@ impl ModelId {
             ModelId::XaiGrok2Mini => models::xai::GROK_2_MINI,
             ModelId::XaiGrok2Reasoning => models::xai::GROK_2_REASONING,
             ModelId::XaiGrok2Vision => models::xai::GROK_2_VISION,
+            // Z.AI models
+            ModelId::ZaiGlm46 => models::zai::GLM_4_6,
+            ModelId::ZaiGlm45 => models::zai::GLM_4_5,
+            ModelId::ZaiGlm45Air => models::zai::GLM_4_5_AIR,
+            ModelId::ZaiGlm45X => models::zai::GLM_4_5_X,
+            ModelId::ZaiGlm45Airx => models::zai::GLM_4_5_AIRX,
+            ModelId::ZaiGlm45Flash => models::zai::GLM_4_5_FLASH,
+            ModelId::ZaiGlm432b0414128k => models::zai::GLM_4_32B_0414_128K,
             // Moonshot models
             ModelId::MoonshotV18k => models::moonshot::MOONSHOT_V1_8K,
             ModelId::MoonshotV132k => models::moonshot::MOONSHOT_V1_32K,
@@ -444,6 +476,13 @@ impl ModelId {
             | ModelId::XaiGrok2Mini
             | ModelId::XaiGrok2Reasoning
             | ModelId::XaiGrok2Vision => Provider::XAI,
+            ModelId::ZaiGlm46
+            | ModelId::ZaiGlm45
+            | ModelId::ZaiGlm45Air
+            | ModelId::ZaiGlm45X
+            | ModelId::ZaiGlm45Airx
+            | ModelId::ZaiGlm45Flash
+            | ModelId::ZaiGlm432b0414128k => Provider::ZAI,
             ModelId::MoonshotV18k
             | ModelId::MoonshotV132k
             | ModelId::MoonshotV1128k
@@ -488,6 +527,14 @@ impl ModelId {
             ModelId::XaiGrok2Mini => "Grok-2 Mini",
             ModelId::XaiGrok2Reasoning => "Grok-2 Reasoning",
             ModelId::XaiGrok2Vision => "Grok-2 Vision",
+            // Z.AI models
+            ModelId::ZaiGlm46 => "GLM 4.6",
+            ModelId::ZaiGlm45 => "GLM 4.5",
+            ModelId::ZaiGlm45Air => "GLM 4.5 Air",
+            ModelId::ZaiGlm45X => "GLM 4.5 X",
+            ModelId::ZaiGlm45Airx => "GLM 4.5 AirX",
+            ModelId::ZaiGlm45Flash => "GLM 4.5 Flash",
+            ModelId::ZaiGlm432b0414128k => "GLM 4 32B 0414 128K",
             // Moonshot models
             ModelId::MoonshotV18k => "Moonshot v1 8K",
             ModelId::MoonshotV132k => "Moonshot v1 32K",
@@ -545,6 +592,18 @@ impl ModelId {
                 "Grok 2 variant that surfaces structured reasoning traces"
             }
             ModelId::XaiGrok2Vision => "Multimodal Grok 2 model with image understanding",
+            // Z.AI models
+            ModelId::ZaiGlm46 => {
+                "Latest Z.AI GLM flagship with long-context reasoning and coding strengths"
+            }
+            ModelId::ZaiGlm45 => "Balanced GLM 4.5 release for general assistant tasks",
+            ModelId::ZaiGlm45Air => "Efficient GLM 4.5 Air variant tuned for lower latency",
+            ModelId::ZaiGlm45X => "Enhanced GLM 4.5 X variant with improved reasoning",
+            ModelId::ZaiGlm45Airx => "Hybrid GLM 4.5 AirX variant blending efficiency with quality",
+            ModelId::ZaiGlm45Flash => "Low-latency GLM 4.5 Flash optimized for responsiveness",
+            ModelId::ZaiGlm432b0414128k => {
+                "Legacy GLM 4 32B deployment offering extended 128K context window"
+            }
             // Moonshot models
             ModelId::MoonshotV18k => {
                 "Moonshot v1 8K with fast responses and compact context window"
@@ -556,10 +615,10 @@ impl ModelId {
                 "Flagship Moonshot v1 model with extended 128K context capacity"
             }
             ModelId::MoonshotKimiK20711Preview => {
-                "Preview release of the Kimi K2 model tuned for advanced reasoning"
+                "Kimi K2 preview release showcasing next-generation Moonshot capabilities"
             }
             ModelId::MoonshotKimiK2TurboPreview => {
-                "Limited-time Kimi K2 Turbo preview with promotional pricing"
+                "Latency-optimized Kimi K2 Turbo preview tuned for coding agents"
             }
             _ => unreachable!(),
         }
@@ -592,6 +651,14 @@ impl ModelId {
             ModelId::XaiGrok2Mini,
             ModelId::XaiGrok2Reasoning,
             ModelId::XaiGrok2Vision,
+            // Z.AI models
+            ModelId::ZaiGlm46,
+            ModelId::ZaiGlm45,
+            ModelId::ZaiGlm45Air,
+            ModelId::ZaiGlm45X,
+            ModelId::ZaiGlm45Airx,
+            ModelId::ZaiGlm45Flash,
+            ModelId::ZaiGlm432b0414128k,
             // Moonshot models
             ModelId::MoonshotV18k,
             ModelId::MoonshotV132k,
@@ -621,6 +688,7 @@ impl ModelId {
             ModelId::ClaudeSonnet45,
             ModelId::DeepSeekReasoner,
             ModelId::XaiGrok2Latest,
+            ModelId::ZaiGlm46,
             ModelId::OpenRouterGrokCodeFast1,
         ]
     }
@@ -650,6 +718,7 @@ impl ModelId {
             Provider::Moonshot => ModelId::MoonshotV1128k,
             Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
+            Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
 
@@ -663,6 +732,7 @@ impl ModelId {
             Provider::Moonshot => ModelId::MoonshotV18k,
             Provider::XAI => ModelId::XaiGrok2Mini,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
+            Provider::ZAI => ModelId::ZaiGlm45Flash,
         }
     }
 
@@ -676,6 +746,7 @@ impl ModelId {
             Provider::Moonshot => ModelId::MoonshotV1128k,
             Provider::XAI => ModelId::XaiGrok2Latest,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
+            Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
 
@@ -683,7 +754,10 @@ impl ModelId {
     pub fn is_flash_variant(&self) -> bool {
         matches!(
             self,
-            ModelId::Gemini25FlashPreview | ModelId::Gemini25Flash | ModelId::Gemini25FlashLite
+            ModelId::Gemini25FlashPreview
+                | ModelId::Gemini25Flash
+                | ModelId::Gemini25FlashLite
+                | ModelId::ZaiGlm45Flash
         )
     }
 
@@ -697,6 +771,7 @@ impl ModelId {
                 | ModelId::ClaudeOpus41
                 | ModelId::DeepSeekReasoner
                 | ModelId::XaiGrok2Latest
+                | ModelId::ZaiGlm46
         )
     }
 
@@ -715,6 +790,9 @@ impl ModelId {
                 | ModelId::DeepSeekChat
                 | ModelId::XaiGrok2Mini
                 | ModelId::MoonshotV18k
+                | ModelId::ZaiGlm45Air
+                | ModelId::ZaiGlm45Airx
+                | ModelId::ZaiGlm45Flash
         )
     }
 
@@ -737,6 +815,7 @@ impl ModelId {
                 | ModelId::MoonshotV1128k
                 | ModelId::MoonshotKimiK20711Preview
                 | ModelId::MoonshotKimiK2TurboPreview
+                | ModelId::ZaiGlm46
         )
     }
 
@@ -769,6 +848,14 @@ impl ModelId {
             | ModelId::XaiGrok2Mini
             | ModelId::XaiGrok2Reasoning
             | ModelId::XaiGrok2Vision => "2",
+            // Z.AI generations
+            ModelId::ZaiGlm46 => "4.6",
+            ModelId::ZaiGlm45
+            | ModelId::ZaiGlm45Air
+            | ModelId::ZaiGlm45X
+            | ModelId::ZaiGlm45Airx
+            | ModelId::ZaiGlm45Flash => "4.5",
+            ModelId::ZaiGlm432b0414128k => "4-32B",
             // Moonshot generations
             ModelId::MoonshotV18k | ModelId::MoonshotV132k | ModelId::MoonshotV1128k => "v1",
             ModelId::MoonshotKimiK20711Preview | ModelId::MoonshotKimiK2TurboPreview => "K2",
@@ -823,6 +910,14 @@ impl FromStr for ModelId {
             s if s == models::xai::GROK_2_MINI => Ok(ModelId::XaiGrok2Mini),
             s if s == models::xai::GROK_2_REASONING => Ok(ModelId::XaiGrok2Reasoning),
             s if s == models::xai::GROK_2_VISION => Ok(ModelId::XaiGrok2Vision),
+            // Z.AI models
+            s if s == models::zai::GLM_4_6 => Ok(ModelId::ZaiGlm46),
+            s if s == models::zai::GLM_4_5 => Ok(ModelId::ZaiGlm45),
+            s if s == models::zai::GLM_4_5_AIR => Ok(ModelId::ZaiGlm45Air),
+            s if s == models::zai::GLM_4_5_X => Ok(ModelId::ZaiGlm45X),
+            s if s == models::zai::GLM_4_5_AIRX => Ok(ModelId::ZaiGlm45Airx),
+            s if s == models::zai::GLM_4_5_FLASH => Ok(ModelId::ZaiGlm45Flash),
+            s if s == models::zai::GLM_4_32B_0414_128K => Ok(ModelId::ZaiGlm432b0414128k),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -923,26 +1018,16 @@ mod tests {
             models::xai::GROK_2_REASONING
         );
         assert_eq!(ModelId::XaiGrok2Vision.as_str(), models::xai::GROK_2_VISION);
-        // Moonshot models
+        // Z.AI models
+        assert_eq!(ModelId::ZaiGlm46.as_str(), models::zai::GLM_4_6);
+        assert_eq!(ModelId::ZaiGlm45.as_str(), models::zai::GLM_4_5);
+        assert_eq!(ModelId::ZaiGlm45Air.as_str(), models::zai::GLM_4_5_AIR);
+        assert_eq!(ModelId::ZaiGlm45X.as_str(), models::zai::GLM_4_5_X);
+        assert_eq!(ModelId::ZaiGlm45Airx.as_str(), models::zai::GLM_4_5_AIRX);
+        assert_eq!(ModelId::ZaiGlm45Flash.as_str(), models::zai::GLM_4_5_FLASH);
         assert_eq!(
-            ModelId::MoonshotV18k.as_str(),
-            models::moonshot::MOONSHOT_V1_8K
-        );
-        assert_eq!(
-            ModelId::MoonshotV132k.as_str(),
-            models::moonshot::MOONSHOT_V1_32K
-        );
-        assert_eq!(
-            ModelId::MoonshotV1128k.as_str(),
-            models::moonshot::MOONSHOT_V1_128K
-        );
-        assert_eq!(
-            ModelId::MoonshotKimiK20711Preview.as_str(),
-            models::moonshot::KIMI_K2_0711_PREVIEW
-        );
-        assert_eq!(
-            ModelId::MoonshotKimiK2TurboPreview.as_str(),
-            models::moonshot::KIMI_K2_TURBO_PREVIEW
+            ModelId::ZaiGlm432b0414128k.as_str(),
+            models::zai::GLM_4_32B_0414_128K
         );
         macro_rules! assert_openrouter_to_string {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1032,34 +1117,34 @@ mod tests {
             models::xai::GROK_2_VISION.parse::<ModelId>().unwrap(),
             ModelId::XaiGrok2Vision
         );
-        // Moonshot models
+        // Z.AI models
         assert_eq!(
-            models::moonshot::MOONSHOT_V1_8K.parse::<ModelId>().unwrap(),
-            ModelId::MoonshotV18k
+            models::zai::GLM_4_6.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm46
         );
         assert_eq!(
-            models::moonshot::MOONSHOT_V1_32K
-                .parse::<ModelId>()
-                .unwrap(),
-            ModelId::MoonshotV132k
+            models::zai::GLM_4_5.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45
         );
         assert_eq!(
-            models::moonshot::MOONSHOT_V1_128K
-                .parse::<ModelId>()
-                .unwrap(),
-            ModelId::MoonshotV1128k
+            models::zai::GLM_4_5_AIR.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45Air
         );
         assert_eq!(
-            models::moonshot::KIMI_K2_0711_PREVIEW
-                .parse::<ModelId>()
-                .unwrap(),
-            ModelId::MoonshotKimiK20711Preview
+            models::zai::GLM_4_5_X.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45X
         );
         assert_eq!(
-            models::moonshot::KIMI_K2_TURBO_PREVIEW
-                .parse::<ModelId>()
-                .unwrap(),
-            ModelId::MoonshotKimiK2TurboPreview
+            models::zai::GLM_4_5_AIRX.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45Airx
+        );
+        assert_eq!(
+            models::zai::GLM_4_5_FLASH.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm45Flash
+        );
+        assert_eq!(
+            models::zai::GLM_4_32B_0414_128K.parse::<ModelId>().unwrap(),
+            ModelId::ZaiGlm432b0414128k
         );
         macro_rules! assert_openrouter_parse {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1085,6 +1170,7 @@ mod tests {
             Provider::OpenRouter
         );
         assert_eq!("xai".parse::<Provider>().unwrap(), Provider::XAI);
+        assert_eq!("zai".parse::<Provider>().unwrap(), Provider::ZAI);
         assert!("invalid-provider".parse::<Provider>().is_err());
     }
 
@@ -1097,6 +1183,7 @@ mod tests {
         assert_eq!(ModelId::ClaudeSonnet4.provider(), Provider::Anthropic);
         assert_eq!(ModelId::DeepSeekChat.provider(), Provider::DeepSeek);
         assert_eq!(ModelId::XaiGrok2Latest.provider(), Provider::XAI);
+        assert_eq!(ModelId::ZaiGlm46.provider(), Provider::ZAI);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -1140,6 +1227,10 @@ mod tests {
             ModelId::default_orchestrator_for_provider(Provider::XAI),
             ModelId::XaiGrok2Latest
         );
+        assert_eq!(
+            ModelId::default_orchestrator_for_provider(Provider::ZAI),
+            ModelId::ZaiGlm46
+        );
 
         assert_eq!(
             ModelId::default_subagent_for_provider(Provider::Gemini),
@@ -1165,6 +1256,10 @@ mod tests {
             ModelId::default_subagent_for_provider(Provider::XAI),
             ModelId::XaiGrok2Mini
         );
+        assert_eq!(
+            ModelId::default_subagent_for_provider(Provider::ZAI),
+            ModelId::ZaiGlm45Flash
+        );
 
         assert_eq!(
             ModelId::default_single_for_provider(Provider::DeepSeek),
@@ -1186,12 +1281,14 @@ mod tests {
         assert!(ModelId::Gemini25Flash.is_flash_variant());
         assert!(ModelId::Gemini25FlashLite.is_flash_variant());
         assert!(!ModelId::GPT5.is_flash_variant());
+        assert!(ModelId::ZaiGlm45Flash.is_flash_variant());
 
         // Pro variants
         assert!(ModelId::Gemini25Pro.is_pro_variant());
         assert!(ModelId::GPT5.is_pro_variant());
         assert!(ModelId::GPT5Codex.is_pro_variant());
         assert!(ModelId::DeepSeekReasoner.is_pro_variant());
+        assert!(ModelId::ZaiGlm46.is_pro_variant());
         assert!(!ModelId::Gemini25FlashPreview.is_pro_variant());
 
         // Efficient variants
@@ -1201,6 +1298,9 @@ mod tests {
         assert!(ModelId::GPT5Mini.is_efficient_variant());
         assert!(ModelId::XaiGrok2Mini.is_efficient_variant());
         assert!(ModelId::DeepSeekChat.is_efficient_variant());
+        assert!(ModelId::ZaiGlm45Air.is_efficient_variant());
+        assert!(ModelId::ZaiGlm45Airx.is_efficient_variant());
+        assert!(ModelId::ZaiGlm45Flash.is_efficient_variant());
         assert!(!ModelId::GPT5.is_efficient_variant());
 
         macro_rules! assert_openrouter_efficiency {
@@ -1219,6 +1319,7 @@ mod tests {
         assert!(ModelId::XaiGrok2Latest.is_top_tier());
         assert!(ModelId::XaiGrok2Reasoning.is_top_tier());
         assert!(ModelId::DeepSeekReasoner.is_top_tier());
+        assert!(ModelId::ZaiGlm46.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
 
         macro_rules! assert_openrouter_top_tier {
@@ -1259,12 +1360,14 @@ mod tests {
         assert_eq!(ModelId::XaiGrok2Mini.generation(), "2");
         assert_eq!(ModelId::XaiGrok2Reasoning.generation(), "2");
         assert_eq!(ModelId::XaiGrok2Vision.generation(), "2");
-        // Moonshot generations
-        assert_eq!(ModelId::MoonshotV18k.generation(), "v1");
-        assert_eq!(ModelId::MoonshotV132k.generation(), "v1");
-        assert_eq!(ModelId::MoonshotV1128k.generation(), "v1");
-        assert_eq!(ModelId::MoonshotKimiK20711Preview.generation(), "K2");
-        assert_eq!(ModelId::MoonshotKimiK2TurboPreview.generation(), "K2");
+        // Z.AI generations
+        assert_eq!(ModelId::ZaiGlm46.generation(), "4.6");
+        assert_eq!(ModelId::ZaiGlm45.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45Air.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45X.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45Airx.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm45Flash.generation(), "4.5");
+        assert_eq!(ModelId::ZaiGlm432b0414128k.generation(), "4-32B");
 
         macro_rules! assert_openrouter_generation {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1294,13 +1397,6 @@ mod tests {
         assert!(deepseek_models.contains(&ModelId::DeepSeekChat));
         assert!(deepseek_models.contains(&ModelId::DeepSeekReasoner));
 
-        let moonshot_models = ModelId::models_for_provider(Provider::Moonshot);
-        assert!(moonshot_models.contains(&ModelId::MoonshotV18k));
-        assert!(moonshot_models.contains(&ModelId::MoonshotV132k));
-        assert!(moonshot_models.contains(&ModelId::MoonshotV1128k));
-        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20711Preview));
-        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK2TurboPreview));
-
         let openrouter_models = ModelId::models_for_provider(Provider::OpenRouter);
         macro_rules! assert_openrouter_models_present {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1315,6 +1411,15 @@ mod tests {
         assert!(xai_models.contains(&ModelId::XaiGrok2Mini));
         assert!(xai_models.contains(&ModelId::XaiGrok2Reasoning));
         assert!(xai_models.contains(&ModelId::XaiGrok2Vision));
+
+        let zai_models = ModelId::models_for_provider(Provider::ZAI);
+        assert!(zai_models.contains(&ModelId::ZaiGlm46));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45Air));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45X));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45Airx));
+        assert!(zai_models.contains(&ModelId::ZaiGlm45Flash));
+        assert!(zai_models.contains(&ModelId::ZaiGlm432b0414128k));
     }
 
     #[test]
@@ -1327,6 +1432,7 @@ mod tests {
         assert!(fallbacks.contains(&ModelId::ClaudeSonnet45));
         assert!(fallbacks.contains(&ModelId::DeepSeekReasoner));
         assert!(fallbacks.contains(&ModelId::XaiGrok2Latest));
+        assert!(fallbacks.contains(&ModelId::ZaiGlm46));
         assert!(fallbacks.contains(&ModelId::OpenRouterGrokCodeFast1));
     }
 }

--- a/vtcode-core/src/llm/client.rs
+++ b/vtcode-core/src/llm/client.rs
@@ -1,7 +1,7 @@
 use super::provider::LLMError;
 use super::providers::{
-    AnthropicProvider, DeepSeekProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider,
-    XAIProvider,
+    AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OpenAIProvider,
+    OpenRouterProvider, XAIProvider,
 };
 use super::types::{BackendKind, LLMResponse};
 use crate::config::models::{ModelId, Provider};
@@ -31,6 +31,10 @@ pub fn make_client(api_key: String, model: ModelId) -> AnyClient {
         )),
         Provider::Anthropic => Box::new(AnthropicProvider::new(api_key)),
         Provider::DeepSeek => Box::new(DeepSeekProvider::with_model(
+            api_key,
+            model.as_str().to_string(),
+        )),
+        Provider::Moonshot => Box::new(MoonshotProvider::with_model(
             api_key,
             model.as_str().to_string(),
         )),

--- a/vtcode-core/src/llm/client.rs
+++ b/vtcode-core/src/llm/client.rs
@@ -1,7 +1,7 @@
 use super::provider::LLMError;
 use super::providers::{
     AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OpenAIProvider,
-    OpenRouterProvider, XAIProvider,
+    OpenRouterProvider, XAIProvider, ZAIProvider,
 };
 use super::types::{BackendKind, LLMResponse};
 use crate::config::models::{ModelId, Provider};
@@ -42,6 +42,10 @@ pub fn make_client(api_key: String, model: ModelId) -> AnyClient {
             api_key,
             model.as_str().to_string(),
         )),
-        Provider::XAI => Box::new(XAIProvider::with_model(api_key, model.as_str().to_string())),
+        Provider::XAI => Box::new(XAIProvider::with_model(
+            api_key.clone(),
+            model.as_str().to_string(),
+        )),
+        Provider::ZAI => Box::new(ZAIProvider::with_model(api_key, model.as_str().to_string())),
     }
 }

--- a/vtcode-core/src/llm/error_display.rs
+++ b/vtcode-core/src/llm/error_display.rs
@@ -68,6 +68,15 @@ pub fn style_provider_name(provider: &str) -> String {
                 Styles::render_reset()
             )
         }
+        "moonshot" => {
+            // Use success styling to reflect the green Kimi branding.
+            format!(
+                "{}{}{}",
+                Styles::render(&Styles::success()),
+                provider,
+                Styles::render_reset()
+            )
+        }
         _ => {
             // Default styling for other providers
             format!(
@@ -126,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_style_provider_name() {
-        let providers = vec!["gemini", "openai", "anthropic", "unknown"];
+        let providers = vec!["gemini", "openai", "anthropic", "moonshot", "unknown"];
         for provider in providers {
             let result = style_provider_name(provider);
             assert!(!result.is_empty());

--- a/vtcode-core/src/llm/error_display_test.rs
+++ b/vtcode-core/src/llm/error_display_test.rs
@@ -23,7 +23,7 @@ mod tests {
         assert!(styled_success.contains(success_msg));
 
         // Test provider name styling
-        let providers = vec!["gemini", "openai", "anthropic", "unknown"];
+        let providers = vec!["gemini", "openai", "anthropic", "moonshot", "unknown"];
         for provider in providers {
             let styled_name = style_provider_name(provider);
             assert!(!styled_name.is_empty());

--- a/vtcode-core/src/llm/factory.rs
+++ b/vtcode-core/src/llm/factory.rs
@@ -1,6 +1,6 @@
 use super::providers::{
     AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OpenAIProvider,
-    OpenRouterProvider, XAIProvider,
+    OpenRouterProvider, XAIProvider, ZAIProvider,
 };
 use crate::config::core::PromptCachingConfig;
 use crate::llm::provider::{LLMError, LLMProvider};
@@ -152,6 +152,24 @@ impl LLMFactory {
             }),
         );
 
+        factory.register_provider(
+            "zai",
+            Box::new(|config: ProviderConfig| {
+                let ProviderConfig {
+                    api_key,
+                    base_url,
+                    model,
+                    prompt_cache,
+                } = config;
+                Box::new(ZAIProvider::from_config(
+                    api_key,
+                    model,
+                    base_url,
+                    prompt_cache,
+                )) as Box<dyn LLMProvider>
+            }),
+        );
+
         factory
     }
 
@@ -197,6 +215,8 @@ impl LLMFactory {
             Some("gemini".to_string())
         } else if m.starts_with("grok-") || m.starts_with("xai-") {
             Some("xai".to_string())
+        } else if m.starts_with("glm-") {
+            Some("zai".to_string())
         } else if m.contains('/') || m.contains('@') {
             Some("openrouter".to_string())
         } else {

--- a/vtcode-core/src/llm/factory.rs
+++ b/vtcode-core/src/llm/factory.rs
@@ -1,6 +1,6 @@
 use super::providers::{
-    AnthropicProvider, DeepSeekProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider,
-    XAIProvider,
+    AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OpenAIProvider,
+    OpenRouterProvider, XAIProvider,
 };
 use crate::config::core::PromptCachingConfig;
 use crate::llm::provider::{LLMError, LLMProvider};
@@ -99,6 +99,24 @@ impl LLMFactory {
         );
 
         factory.register_provider(
+            "moonshot",
+            Box::new(|config: ProviderConfig| {
+                let ProviderConfig {
+                    api_key,
+                    base_url,
+                    model,
+                    prompt_cache,
+                } = config;
+                Box::new(MoonshotProvider::from_config(
+                    api_key,
+                    model,
+                    base_url,
+                    prompt_cache,
+                )) as Box<dyn LLMProvider>
+            }),
+        );
+
+        factory.register_provider(
             "openrouter",
             Box::new(|config: ProviderConfig| {
                 let ProviderConfig {
@@ -173,6 +191,8 @@ impl LLMFactory {
             Some("anthropic".to_string())
         } else if m.starts_with("deepseek-") {
             Some("deepseek".to_string())
+        } else if m.starts_with("moonshot-") || m.starts_with("kimi-k2") {
+            Some("moonshot".to_string())
         } else if m.contains("gemini") || m.starts_with("palm") {
             Some("gemini".to_string())
         } else if m.starts_with("grok-") || m.starts_with("xai-") {

--- a/vtcode-core/src/llm/mod.rs
+++ b/vtcode-core/src/llm/mod.rs
@@ -22,6 +22,7 @@
 //! | Anthropic | ✓ | claude-4.1-opus, claude-4-sonnet |
 //! | xAI | ✓ | grok-2-latest, grok-2-mini |
 //! | DeepSeek | ✓ | deepseek-chat, deepseek-reasoner |
+//! | Z.AI | ✓ | glm-4.6 |
 //!
 //! ## Basic Usage
 //!
@@ -176,5 +177,5 @@ mod error_display_test;
 pub use client::{AnyClient, make_client};
 pub use factory::{create_provider_with_config, get_factory};
 pub use provider::{LLMStream, LLMStreamEvent};
-pub use providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, XAIProvider};
+pub use providers::{AnthropicProvider, GeminiProvider, OpenAIProvider, XAIProvider, ZAIProvider};
 pub use types::{BackendKind, LLMError, LLMResponse};

--- a/vtcode-core/src/llm/provider.rs
+++ b/vtcode-core/src/llm/provider.rs
@@ -353,7 +353,7 @@ impl Message {
 
         // Provider-specific validations based on official docs
         match provider {
-            "openai" | "openrouter" => {
+            "openai" | "openrouter" | "moonshot" => {
                 if self.role == MessageRole::Tool && self.tool_call_id.is_none() {
                     return Err(format!(
                         "{} requires tool_call_id for tool messages",
@@ -482,8 +482,10 @@ impl MessageRole {
     ) -> Result<(), String> {
         match (self, provider) {
             (MessageRole::Tool, provider)
-                if matches!(provider, "openai" | "openrouter" | "xai" | "deepseek")
-                    && !has_tool_call_id =>
+                if matches!(
+                    provider,
+                    "openai" | "openrouter" | "moonshot" | "xai" | "deepseek"
+                ) && !has_tool_call_id =>
             {
                 Err(format!("{} tool messages must have tool_call_id", provider))
             }

--- a/vtcode-core/src/llm/provider.rs
+++ b/vtcode-core/src/llm/provider.rs
@@ -353,7 +353,7 @@ impl Message {
 
         // Provider-specific validations based on official docs
         match provider {
-            "openai" | "openrouter" | "moonshot" => {
+            "openai" | "openrouter" | "moonshot" | "zai" => {
                 if self.role == MessageRole::Tool && self.tool_call_id.is_none() {
                     return Err(format!(
                         "{} requires tool_call_id for tool messages",
@@ -484,7 +484,7 @@ impl MessageRole {
             (MessageRole::Tool, provider)
                 if matches!(
                     provider,
-                    "openai" | "openrouter" | "moonshot" | "xai" | "deepseek"
+                    "openai" | "openrouter" | "moonshot" | "xai" | "deepseek" | "zai"
                 ) && !has_tool_call_id =>
             {
                 Err(format!("{} tool messages must have tool_call_id", provider))

--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic;
 pub mod deepseek;
 pub mod gemini;
+pub mod moonshot;
 pub mod openai;
 pub mod openrouter;
 pub mod xai;
@@ -14,6 +15,7 @@ pub(crate) use reasoning::extract_reasoning_trace;
 pub use anthropic::AnthropicProvider;
 pub use deepseek::DeepSeekProvider;
 pub use gemini::GeminiProvider;
+pub use moonshot::MoonshotProvider;
 pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
 pub use xai::XAIProvider;

--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -5,6 +5,7 @@ pub mod moonshot;
 pub mod openai;
 pub mod openrouter;
 pub mod xai;
+pub mod zai;
 
 mod codex_prompt;
 mod reasoning;
@@ -19,3 +20,4 @@ pub use moonshot::MoonshotProvider;
 pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
 pub use xai::XAIProvider;
+pub use zai::ZAIProvider;

--- a/vtcode-core/src/llm/providers/moonshot.rs
+++ b/vtcode-core/src/llm/providers/moonshot.rs
@@ -1,0 +1,147 @@
+use crate::config::constants::{models, urls};
+use crate::config::core::PromptCachingConfig;
+use crate::llm::client::LLMClient;
+use crate::llm::error_display;
+use crate::llm::provider::{LLMError, LLMProvider, LLMRequest, LLMResponse};
+use crate::llm::providers::openai::OpenAIProvider;
+use crate::llm::types as llm_types;
+use async_trait::async_trait;
+
+/// Moonshot provider implemented via the OpenAI-compatible chat completions API surface.
+pub struct MoonshotProvider {
+    inner: OpenAIProvider,
+    model: String,
+    prompt_cache_enabled: bool,
+}
+
+impl MoonshotProvider {
+    pub fn new(api_key: String) -> Self {
+        Self::with_model_internal(api_key, models::moonshot::DEFAULT_MODEL.to_string(), None)
+    }
+
+    pub fn with_model(api_key: String, model: String) -> Self {
+        Self::with_model_internal(api_key, model, None)
+    }
+
+    pub fn from_config(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        let resolved_model = model.unwrap_or_else(|| models::moonshot::DEFAULT_MODEL.to_string());
+        let resolved_base_url = base_url.unwrap_or_else(|| urls::MOONSHOT_API_BASE.to_string());
+        let (prompt_cache_enabled, forward_config) =
+            Self::extract_prompt_cache_settings(prompt_cache);
+
+        let inner = OpenAIProvider::from_config(
+            api_key,
+            Some(resolved_model.clone()),
+            Some(resolved_base_url),
+            forward_config,
+        );
+
+        Self {
+            inner,
+            model: resolved_model,
+            prompt_cache_enabled,
+        }
+    }
+
+    fn with_model_internal(
+        api_key: String,
+        model: String,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        Self::from_config(Some(api_key), Some(model), None, prompt_cache)
+    }
+
+    fn extract_prompt_cache_settings(
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> (bool, Option<PromptCachingConfig>) {
+        if let Some(cfg) = prompt_cache {
+            let provider_settings = cfg.providers.moonshot;
+            let enabled = cfg.enabled && provider_settings.enabled;
+            // Moonshot does not yet expose a dedicated prompt cache API surface.
+            // When enabled we acknowledge the preference but do not forward config downstream.
+            if enabled { (true, None) } else { (false, None) }
+        } else {
+            (false, None)
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for MoonshotProvider {
+    fn name(&self) -> &str {
+        "moonshot"
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+        requested.contains("kimi-k2")
+    }
+
+    fn supports_reasoning_effort(&self, _model: &str) -> bool {
+        false
+    }
+
+    async fn generate(&self, mut request: LLMRequest) -> Result<LLMResponse, LLMError> {
+        if request.model.trim().is_empty() {
+            request.model = self.model.clone();
+        }
+
+        if !self.prompt_cache_enabled {
+            // No-op: placeholder for future Moonshot caching integrations.
+        }
+
+        self.inner.generate(request).await
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        models::moonshot::SUPPORTED_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
+        if request.messages.is_empty() {
+            let formatted = error_display::format_llm_error("Moonshot", "Messages cannot be empty");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider("openai") {
+                let formatted = error_display::format_llm_error("Moonshot", &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        if request.model.trim().is_empty() {
+            let formatted = error_display::format_llm_error("Moonshot", "Model must be provided");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LLMClient for MoonshotProvider {
+    async fn generate(&mut self, prompt: &str) -> Result<llm_types::LLMResponse, LLMError> {
+        <OpenAIProvider as LLMClient>::generate(&mut self.inner, prompt).await
+    }
+
+    fn backend_kind(&self) -> llm_types::BackendKind {
+        llm_types::BackendKind::Moonshot
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}

--- a/vtcode-core/src/llm/providers/zai.rs
+++ b/vtcode-core/src/llm/providers/zai.rs
@@ -1,0 +1,606 @@
+use crate::config::constants::{models, urls};
+use crate::config::core::{PromptCachingConfig, ZaiPromptCacheSettings};
+use crate::llm::client::LLMClient;
+use crate::llm::error_display;
+use crate::llm::provider::{
+    FinishReason, LLMError, LLMProvider, LLMRequest, LLMResponse, Message, MessageRole, ToolCall,
+    ToolChoice, ToolDefinition, Usage,
+};
+use crate::llm::types as llm_types;
+use async_trait::async_trait;
+use reqwest::Client as HttpClient;
+use serde_json::{Value, json};
+use std::collections::HashSet;
+
+const PROVIDER_NAME: &str = "Z.AI";
+const PROVIDER_KEY: &str = "zai";
+const CHAT_COMPLETIONS_PATH: &str = "/paas/v4/chat/completions";
+
+pub struct ZAIProvider {
+    api_key: String,
+    http_client: HttpClient,
+    base_url: String,
+    model: String,
+    prompt_cache_settings: ZaiPromptCacheSettings,
+}
+
+impl ZAIProvider {
+    fn serialize_tools(tools: &[ToolDefinition]) -> Option<Value> {
+        if tools.is_empty() {
+            return None;
+        }
+
+        let serialized = tools
+            .iter()
+            .map(|tool| {
+                json!({
+                    "type": tool.tool_type,
+                    "function": {
+                        "name": tool.function.name,
+                        "description": tool.function.description,
+                        "parameters": tool.function.parameters,
+                    }
+                })
+            })
+            .collect::<Vec<Value>>();
+
+        Some(Value::Array(serialized))
+    }
+
+    fn extract_prompt_cache_settings(
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> ZaiPromptCacheSettings {
+        if let Some(cfg) = prompt_cache {
+            cfg.providers.zai
+        } else {
+            ZaiPromptCacheSettings::default()
+        }
+    }
+
+    fn with_model_internal(
+        api_key: String,
+        model: String,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        Self {
+            api_key,
+            http_client: HttpClient::new(),
+            base_url: base_url.unwrap_or_else(|| urls::Z_AI_API_BASE.to_string()),
+            model,
+            prompt_cache_settings: Self::extract_prompt_cache_settings(prompt_cache),
+        }
+    }
+
+    pub fn new(api_key: String) -> Self {
+        Self::with_model_internal(api_key, models::zai::DEFAULT_MODEL.to_string(), None, None)
+    }
+
+    pub fn with_model(api_key: String, model: String) -> Self {
+        Self::with_model_internal(api_key, model, None, None)
+    }
+
+    pub fn from_config(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        let api_key_value = api_key.unwrap_or_default();
+        let model_value = model.unwrap_or_else(|| models::zai::DEFAULT_MODEL.to_string());
+        Self::with_model_internal(api_key_value, model_value, base_url, prompt_cache)
+    }
+
+    fn default_request(&self, prompt: &str) -> LLMRequest {
+        LLMRequest {
+            messages: vec![Message::user(prompt.to_string())],
+            system_prompt: None,
+            tools: None,
+            model: self.model.clone(),
+            max_tokens: None,
+            temperature: None,
+            stream: false,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            parallel_tool_config: None,
+            reasoning_effort: None,
+        }
+    }
+
+    fn parse_client_prompt(&self, prompt: &str) -> LLMRequest {
+        let trimmed = prompt.trim_start();
+        if trimmed.starts_with('{') {
+            if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+                if let Some(request) = self.parse_chat_request(&value) {
+                    return request;
+                }
+            }
+        }
+
+        self.default_request(prompt)
+    }
+
+    fn parse_chat_request(&self, value: &Value) -> Option<LLMRequest> {
+        let messages_value = value.get("messages")?.as_array()?;
+        let mut system_prompt = value
+            .get("system")
+            .and_then(|entry| entry.as_str())
+            .map(|text| text.to_string());
+        let mut messages = Vec::new();
+
+        for entry in messages_value {
+            let role = entry
+                .get("role")
+                .and_then(|r| r.as_str())
+                .unwrap_or(crate::config::constants::message_roles::USER);
+            let content = entry
+                .get("content")
+                .map(|c| match c {
+                    Value::String(text) => text.to_string(),
+                    other => other.to_string(),
+                })
+                .unwrap_or_default();
+
+            match role {
+                "system" => {
+                    if system_prompt.is_none() && !content.is_empty() {
+                        system_prompt = Some(content);
+                    }
+                }
+                "assistant" => {
+                    let tool_calls = entry
+                        .get("tool_calls")
+                        .and_then(|tc| tc.as_array())
+                        .map(|calls| {
+                            calls
+                                .iter()
+                                .filter_map(|call| Self::parse_tool_call(call))
+                                .collect::<Vec<_>>()
+                        })
+                        .filter(|calls| !calls.is_empty());
+
+                    messages.push(Message {
+                        role: MessageRole::Assistant,
+                        content,
+                        tool_calls,
+                        tool_call_id: None,
+                    });
+                }
+                "tool" => {
+                    if let Some(tool_call_id) = entry.get("tool_call_id").and_then(|v| v.as_str()) {
+                        messages.push(Message::tool_response(tool_call_id.to_string(), content));
+                    }
+                }
+                _ => {
+                    messages.push(Message::user(content));
+                }
+            }
+        }
+
+        Some(LLMRequest {
+            messages,
+            system_prompt,
+            model: value
+                .get("model")
+                .and_then(|m| m.as_str())
+                .unwrap_or(&self.model)
+                .to_string(),
+            max_tokens: value
+                .get("max_tokens")
+                .and_then(|m| m.as_u64())
+                .map(|m| m as u32),
+            temperature: value
+                .get("temperature")
+                .and_then(|t| t.as_f64())
+                .map(|t| t as f32),
+            stream: value
+                .get("stream")
+                .and_then(|s| s.as_bool())
+                .unwrap_or(false),
+            tools: None,
+            tool_choice: value.get("tool_choice").and_then(|choice| match choice {
+                Value::String(s) => match s.as_str() {
+                    "auto" => Some(ToolChoice::auto()),
+                    "none" => Some(ToolChoice::none()),
+                    "any" | "required" => Some(ToolChoice::any()),
+                    _ => None,
+                },
+                _ => None,
+            }),
+            parallel_tool_calls: None,
+            parallel_tool_config: None,
+            reasoning_effort: None,
+        })
+    }
+
+    fn parse_tool_call(value: &Value) -> Option<ToolCall> {
+        let id = value.get("id").and_then(|v| v.as_str())?;
+        let function = value.get("function")?;
+        let name = function.get("name").and_then(|v| v.as_str())?;
+        let arguments = function.get("arguments");
+        let serialized = arguments.map_or("{}".to_string(), |value| {
+            if value.is_string() {
+                value.as_str().unwrap_or("").to_string()
+            } else {
+                value.to_string()
+            }
+        });
+
+        Some(ToolCall::function(
+            id.to_string(),
+            name.to_string(),
+            serialized,
+        ))
+    }
+
+    fn convert_to_zai_format(&self, request: &LLMRequest) -> Result<Value, LLMError> {
+        let mut messages = Vec::new();
+        let mut active_tool_call_ids: HashSet<String> = HashSet::new();
+
+        if let Some(system_prompt) = &request.system_prompt {
+            messages.push(json!({
+                "role": crate::config::constants::message_roles::SYSTEM,
+                "content": system_prompt
+            }));
+        }
+
+        for msg in &request.messages {
+            let role = msg.role.as_generic_str();
+            let mut message = json!({
+                "role": role,
+                "content": msg.content
+            });
+            let mut skip_message = false;
+
+            if msg.role == MessageRole::Assistant {
+                if let Some(tool_calls) = &msg.tool_calls {
+                    if !tool_calls.is_empty() {
+                        let tool_calls_json: Vec<Value> = tool_calls
+                            .iter()
+                            .map(|tc| {
+                                active_tool_call_ids.insert(tc.id.clone());
+                                json!({
+                                    "id": tc.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tc.function.name,
+                                        "arguments": tc.function.arguments,
+                                    }
+                                })
+                            })
+                            .collect();
+                        message["tool_calls"] = Value::Array(tool_calls_json);
+                    }
+                }
+            }
+
+            if msg.role == MessageRole::Tool {
+                match &msg.tool_call_id {
+                    Some(tool_call_id) if active_tool_call_ids.contains(tool_call_id) => {
+                        message["tool_call_id"] = Value::String(tool_call_id.clone());
+                        active_tool_call_ids.remove(tool_call_id);
+                    }
+                    Some(_) | None => {
+                        skip_message = true;
+                    }
+                }
+            }
+
+            if !skip_message {
+                messages.push(message);
+            }
+        }
+
+        if messages.is_empty() {
+            let formatted = error_display::format_llm_error(PROVIDER_NAME, "No messages provided");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        let mut payload = json!({
+            "model": request.model,
+            "messages": messages,
+            "stream": request.stream,
+        });
+
+        if let Some(max_tokens) = request.max_tokens {
+            payload["max_tokens"] = json!(max_tokens);
+        }
+
+        if let Some(temperature) = request.temperature {
+            payload["temperature"] = json!(temperature);
+        }
+
+        if let Some(tools) = &request.tools {
+            if let Some(serialized) = Self::serialize_tools(tools) {
+                payload["tools"] = serialized;
+            }
+        }
+
+        if let Some(choice) = &request.tool_choice {
+            payload["tool_choice"] = choice.to_provider_format("openai");
+        }
+
+        if self.supports_reasoning(&request.model) || request.reasoning_effort.is_some() {
+            payload["thinking"] = json!({ "type": "enabled" });
+        }
+
+        Ok(payload)
+    }
+
+    fn parse_zai_response(&self, response_json: Value) -> Result<LLMResponse, LLMError> {
+        let choices = response_json
+            .get("choices")
+            .and_then(|c| c.as_array())
+            .ok_or_else(|| {
+                let formatted = error_display::format_llm_error(
+                    PROVIDER_NAME,
+                    "Invalid response format: missing choices",
+                );
+                LLMError::Provider(formatted)
+            })?;
+
+        if choices.is_empty() {
+            let formatted =
+                error_display::format_llm_error(PROVIDER_NAME, "No choices in response");
+            return Err(LLMError::Provider(formatted));
+        }
+
+        let choice = &choices[0];
+        let message = choice.get("message").ok_or_else(|| {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                "Invalid response format: missing message",
+            );
+            LLMError::Provider(formatted)
+        })?;
+
+        let content = message
+            .get("content")
+            .and_then(|c| c.as_str())
+            .map(|s| s.to_string());
+
+        let reasoning = message
+            .get("reasoning_content")
+            .map(|value| match value {
+                Value::String(text) => Some(text.to_string()),
+                Value::Array(parts) => {
+                    let combined = parts
+                        .iter()
+                        .filter_map(|part| part.as_str())
+                        .collect::<Vec<_>>()
+                        .join("");
+                    if combined.is_empty() {
+                        None
+                    } else {
+                        Some(combined)
+                    }
+                }
+                _ => None,
+            })
+            .flatten();
+
+        let tool_calls = message
+            .get("tool_calls")
+            .and_then(|tc| tc.as_array())
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|call| Self::parse_tool_call(call))
+                    .collect::<Vec<_>>()
+            })
+            .filter(|calls| !calls.is_empty());
+
+        let finish_reason = choice
+            .get("finish_reason")
+            .and_then(|fr| fr.as_str())
+            .map(Self::map_finish_reason)
+            .unwrap_or(FinishReason::Stop);
+
+        let usage = response_json.get("usage").map(|usage_value| Usage {
+            prompt_tokens: usage_value
+                .get("prompt_tokens")
+                .and_then(|pt| pt.as_u64())
+                .unwrap_or(0) as u32,
+            completion_tokens: usage_value
+                .get("completion_tokens")
+                .and_then(|ct| ct.as_u64())
+                .unwrap_or(0) as u32,
+            total_tokens: usage_value
+                .get("total_tokens")
+                .and_then(|tt| tt.as_u64())
+                .unwrap_or(0) as u32,
+            cached_prompt_tokens: usage_value
+                .get("prompt_tokens_details")
+                .and_then(|details| details.get("cached_tokens"))
+                .and_then(|value| value.as_u64())
+                .map(|value| value as u32),
+            cache_creation_tokens: None,
+            cache_read_tokens: None,
+        });
+
+        Ok(LLMResponse {
+            content,
+            tool_calls,
+            usage,
+            finish_reason,
+            reasoning,
+        })
+    }
+
+    fn map_finish_reason(reason: &str) -> FinishReason {
+        match reason {
+            "stop" => FinishReason::Stop,
+            "length" => FinishReason::Length,
+            "tool_calls" => FinishReason::ToolCalls,
+            "sensitive" => FinishReason::ContentFilter,
+            other => FinishReason::Error(other.to_string()),
+        }
+    }
+
+    fn available_models() -> Vec<String> {
+        models::zai::SUPPORTED_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+}
+
+#[async_trait]
+impl LLMProvider for ZAIProvider {
+    fn name(&self) -> &str {
+        PROVIDER_KEY
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        matches!(
+            model,
+            models::zai::GLM_4_6
+                | models::zai::GLM_4_5
+                | models::zai::GLM_4_5_AIR
+                | models::zai::GLM_4_5_X
+                | models::zai::GLM_4_5_AIRX
+        )
+    }
+
+    fn supports_reasoning_effort(&self, _model: &str) -> bool {
+        false
+    }
+
+    async fn generate(&self, mut request: LLMRequest) -> Result<LLMResponse, LLMError> {
+        if request.model.trim().is_empty() {
+            request.model = self.model.clone();
+        }
+
+        if !Self::available_models().contains(&request.model) {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("Unsupported model: {}", request.model),
+            );
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider(PROVIDER_KEY) {
+                let formatted = error_display::format_llm_error(PROVIDER_NAME, &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        let payload = self.convert_to_zai_format(&request)?;
+        let url = format!("{}{}", self.base_url, CHAT_COMPLETIONS_PATH);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| {
+                let formatted = error_display::format_llm_error(
+                    PROVIDER_NAME,
+                    &format!("Network error: {}", err),
+                );
+                LLMError::Network(formatted)
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+
+            if status.as_u16() == 429 || text.to_lowercase().contains("rate") {
+                return Err(LLMError::RateLimit);
+            }
+
+            let message = serde_json::from_str::<Value>(&text)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .map(|s| s.to_string())
+                })
+                .unwrap_or(text);
+
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("HTTP {}: {}", status, message),
+            );
+            return Err(LLMError::Provider(formatted));
+        }
+
+        let json: Value = response.json().await.map_err(|err| {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("Failed to parse response: {}", err),
+            );
+            LLMError::Provider(formatted)
+        })?;
+
+        self.parse_zai_response(json)
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        Self::available_models()
+    }
+
+    fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
+        if request.messages.is_empty() {
+            let formatted =
+                error_display::format_llm_error(PROVIDER_NAME, "Messages cannot be empty");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        if !request.model.is_empty() && !Self::available_models().contains(&request.model) {
+            let formatted = error_display::format_llm_error(
+                PROVIDER_NAME,
+                &format!("Unsupported model: {}", request.model),
+            );
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider(PROVIDER_KEY) {
+                let formatted = error_display::format_llm_error(PROVIDER_NAME, &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LLMClient for ZAIProvider {
+    async fn generate(&mut self, prompt: &str) -> Result<llm_types::LLMResponse, LLMError> {
+        let request = self.parse_client_prompt(prompt);
+        let request_model = request.model.clone();
+        let response = LLMProvider::generate(self, request).await?;
+
+        Ok(llm_types::LLMResponse {
+            content: response.content.unwrap_or_default(),
+            model: request_model,
+            usage: response.usage.map(|usage| llm_types::Usage {
+                prompt_tokens: usage.prompt_tokens as usize,
+                completion_tokens: usage.completion_tokens as usize,
+                total_tokens: usage.total_tokens as usize,
+                cached_prompt_tokens: usage.cached_prompt_tokens.map(|v| v as usize),
+                cache_creation_tokens: usage.cache_creation_tokens.map(|v| v as usize),
+                cache_read_tokens: usage.cache_read_tokens.map(|v| v as usize),
+            }),
+            reasoning: response.reasoning,
+        })
+    }
+
+    fn backend_kind(&self) -> llm_types::BackendKind {
+        llm_types::BackendKind::ZAI
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}

--- a/vtcode-core/src/llm/rig_adapter.rs
+++ b/vtcode-core/src/llm/rig_adapter.rs
@@ -50,6 +50,10 @@ pub fn verify_model_with_rig(
         Provider::Moonshot => {
             // rig-core does not yet expose a dedicated Moonshot client; skip validation.
         }
+        Provider::ZAI => {
+            // The rig crate does not yet expose a dedicated Z.AI client.
+            // Skip instantiation while still marking the provider as verified.
+        }
     }
 
     Ok(RigValidationSummary {
@@ -89,6 +93,7 @@ pub fn reasoning_parameters_for(provider: Provider, effort: ReasoningEffortLevel
                 .map(|value| json!({ "thinking_config": value }))
         }
         Provider::Moonshot => None,
+        Provider::ZAI => None,
         _ => None,
     }
 }

--- a/vtcode-core/src/llm/rig_adapter.rs
+++ b/vtcode-core/src/llm/rig_adapter.rs
@@ -47,6 +47,9 @@ pub fn verify_model_with_rig(
             let client = xai::Client::new(api_key);
             let _ = client.completion_model(model);
         }
+        Provider::Moonshot => {
+            // rig-core does not yet expose a dedicated Moonshot client; skip validation.
+        }
     }
 
     Ok(RigValidationSummary {
@@ -85,6 +88,7 @@ pub fn reasoning_parameters_for(provider: Provider, effort: ReasoningEffortLevel
                 .ok()
                 .map(|value| json!({ "thinking_config": value }))
         }
+        Provider::Moonshot => None,
         _ => None,
     }
 }

--- a/vtcode-core/src/llm/types.rs
+++ b/vtcode-core/src/llm/types.rs
@@ -7,6 +7,7 @@ pub enum BackendKind {
     OpenAI,
     Anthropic,
     DeepSeek,
+    Moonshot,
     OpenRouter,
     XAI,
 }

--- a/vtcode-core/src/llm/types.rs
+++ b/vtcode-core/src/llm/types.rs
@@ -10,6 +10,7 @@ pub enum BackendKind {
     Moonshot,
     OpenRouter,
     XAI,
+    ZAI,
 }
 
 /// Unified LLM response structure

--- a/vtcode-core/src/utils/dot_config.rs
+++ b/vtcode-core/src/utils/dot_config.rs
@@ -37,6 +37,7 @@ pub struct ProviderConfigs {
     pub anthropic: Option<ProviderConfig>,
     pub gemini: Option<ProviderConfig>,
     pub deepseek: Option<ProviderConfig>,
+    pub moonshot: Option<ProviderConfig>,
     pub openrouter: Option<ProviderConfig>,
     pub xai: Option<ProviderConfig>,
 }

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -2,7 +2,7 @@
 # Minimal configuration with only actively used settings
 
 [agent]
-# Provider to use: one of "gemini", "openai", "anthropic", "openrouter"
+# Provider to use: one of "gemini", "openai", "anthropic", "deepseek", "moonshot", "openrouter", "xai"
 # API key environment variable is automatically inferred from provider
 provider = "anthropic"
 # Default model for single-agent mode

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -8,7 +8,7 @@ max_conversation_turns = 1000
 max_session_duration_minutes = 60
 verbose_logging = false
 
-# AI Provider configuration (supports "gemini", "openai", "anthropic", "openrouter", "xai")
+# AI Provider configuration (supports "gemini", "openai", "anthropic", "deepseek", "moonshot", "openrouter", "xai")
 provider = "gemini"
 default_model = "gemini-2.5-flash"
 api_key_env = "GEMINI_API_KEY"
@@ -149,6 +149,10 @@ explicit_ttl_seconds = 3600
 enabled = true
 propagate_provider_capabilities = true
 report_savings = true
+
+[prompt_cache.providers.moonshot]
+# Moonshot prompt caching is currently advisory only.
+enabled = false
 
 [prompt_cache.providers.xai]
 enabled = true

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -8,7 +8,11 @@ max_conversation_turns = 1000
 max_session_duration_minutes = 60
 verbose_logging = false
 
+<<<<<<< HEAD
+# AI Provider configuration (supports "gemini", "openai", "anthropic", "deepseek", "moonshot", "openrouter", "xai", "zai")
+=======
 # AI Provider configuration (supports "gemini", "openai", "anthropic", "deepseek", "moonshot", "openrouter", "xai")
+>>>>>>> 4d16bc7 (Add Moonshot AI provider integration)
 provider = "gemini"
 default_model = "gemini-2.5-flash"
 api_key_env = "GEMINI_API_KEY"


### PR DESCRIPTION
## Summary
- add a Moonshot provider built on the OpenAI-compatible chat completions surface and register it across the LLM factory, client, backend kinds, and provider wiring
- extend configuration, model metadata, prompt cache defaults, CLI help, and templates to expose Moonshot models and API key controls
- document Moonshot setup and expand provider-focused tests to cover Moonshot detection, creation, and validation paths

## Testing
- cargo fmt
- cargo clippy --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e67464aecc83238d86bdafa7eb452e