### PR TITLE
Add Moonshot provider and refresh model catalog

### DIFF
--- a/docs/models.json
+++ b/docs/models.json
@@ -265,9 +265,9 @@
     "name": "xAI",
     "doc": "https://docs.x.ai/docs/models",
     "models": {
-      "grok-2-latest": {
-        "id": "grok-2-latest",
-        "name": "Grok 2 Latest",
+      "grok-4": {
+        "id": "grok-4",
+        "name": "Grok 4",
         "reasoning": true,
         "tool_call": true,
         "modalities": {
@@ -280,24 +280,9 @@
         },
         "context": 131072
       },
-      "grok-2": {
-        "id": "grok-2",
-        "name": "Grok 2",
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "context": 131072
-      },
-      "grok-2-mini": {
-        "id": "grok-2-mini",
-        "name": "Grok 2 Mini",
+      "grok-4-mini": {
+        "id": "grok-4-mini",
+        "name": "Grok 4 Mini",
         "reasoning": false,
         "tool_call": true,
         "modalities": {
@@ -310,9 +295,9 @@
         },
         "context": 65536
       },
-      "grok-2-reasoning": {
-        "id": "grok-2-reasoning",
-        "name": "Grok 2 Reasoning",
+      "grok-4-code": {
+        "id": "grok-4-code",
+        "name": "Grok 4 Code",
         "reasoning": true,
         "tool_call": true,
         "modalities": {
@@ -325,9 +310,24 @@
         },
         "context": 131072
       },
-      "grok-2-vision": {
-        "id": "grok-2-vision",
-        "name": "Grok 2 Vision",
+      "grok-4-code-latest": {
+        "id": "grok-4-code-latest",
+        "name": "Grok 4 Code Latest",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "grok-4-vision": {
+        "id": "grok-4-vision",
+        "name": "Grok 4 Vision",
         "reasoning": true,
         "tool_call": true,
         "modalities": {
@@ -877,48 +877,6 @@
           "output": 0.0
         }
       },
-      "qwen/qwen3-vl-235b-a22b-instruct": {
-        "id": "qwen/qwen3-vl-235b-a22b-instruct",
-        "name": "Qwen: Qwen3 VL 235B A22B Instruct",
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "context": 131072,
-        "max_output_tokens": null,
-        "cost": {
-          "input": 3e-07,
-          "output": 1.2e-06
-        }
-      },
-      "qwen/qwen3-vl-235b-a22b-thinking": {
-        "id": "qwen/qwen3-vl-235b-a22b-thinking",
-        "name": "Qwen: Qwen3 VL 235B A22B Thinking",
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "context": 65536,
-        "max_output_tokens": 65536,
-        "cost": {
-          "input": 5e-07,
-          "output": 3.5e-06
-        }
-      },
       "qwen/qwen3-next-80b-a3b-instruct": {
         "id": "qwen/qwen3-next-80b-a3b-instruct",
         "name": "Qwen: Qwen3 Next 80B A3B Instruct",
@@ -1348,6 +1306,65 @@
           "input": 1.5e-05,
           "output": 7.5e-05
         }
+      }
+    }
+  },
+  "moonshot": {
+    "id": "moonshot",
+    "env": [
+      "MOONSHOT_API_KEY"
+    ],
+    "api": "https://api.moonshot.cn/v1",
+    "name": "Moonshot AI",
+    "doc": "https://platform.moonshot.ai/docs/overview",
+    "models": {
+      "moonshot-v1-8k": {
+        "id": "moonshot-v1-8k",
+        "name": "Moonshot v1 8K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8192,
+        "max_output_tokens": 8192
+      },
+      "moonshot-v1-32k": {
+        "id": "moonshot-v1-32k",
+        "name": "Moonshot v1 32K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 32768,
+        "max_output_tokens": 32768
+      },
+      "moonshot-v1-128k": {
+        "id": "moonshot-v1-128k",
+        "name": "Moonshot v1 128K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072,
+        "max_output_tokens": 131072
       }
     }
   }

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -765,3 +765,47 @@ fn title_case(value: &str) -> String {
     result.push_str(&chars.as_str().to_ascii_lowercase());
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn has_model(options: &[ModelOption], model: ModelId) -> bool {
+        let id = model.as_str();
+        let provider = model.provider();
+        options
+            .iter()
+            .any(|option| option.id == id && option.provider == provider)
+    }
+
+    #[test]
+    fn model_picker_lists_new_moonshot_models() {
+        let options = MODEL_OPTIONS.as_slice();
+        assert!(has_model(options, ModelId::MoonshotV18k));
+        assert!(has_model(options, ModelId::MoonshotV132k));
+        assert!(has_model(options, ModelId::MoonshotV1128k));
+        assert!(has_model(options, ModelId::OpenRouterMoonshotaiKimiK20905));
+    }
+
+    #[test]
+    fn model_picker_lists_new_xai_models() {
+        let options = MODEL_OPTIONS.as_slice();
+        assert!(has_model(options, ModelId::XaiGrok4));
+        assert!(has_model(options, ModelId::XaiGrok4Mini));
+        assert!(has_model(options, ModelId::XaiGrok4Code));
+        assert!(has_model(options, ModelId::XaiGrok4CodeLatest));
+        assert!(has_model(options, ModelId::XaiGrok4Vision));
+    }
+
+    #[test]
+    fn model_picker_lists_new_zai_models() {
+        let options = MODEL_OPTIONS.as_slice();
+        assert!(has_model(options, ModelId::ZaiGlm46));
+        assert!(has_model(options, ModelId::ZaiGlm45));
+        assert!(has_model(options, ModelId::ZaiGlm45Air));
+        assert!(has_model(options, ModelId::ZaiGlm45X));
+        assert!(has_model(options, ModelId::ZaiGlm45Airx));
+        assert!(has_model(options, ModelId::ZaiGlm45Flash));
+        assert!(has_model(options, ModelId::ZaiGlm432b0414128k));
+    }
+}

--- a/tests/llm_focused_test.rs
+++ b/tests/llm_focused_test.rs
@@ -5,7 +5,8 @@ use vtcode_core::llm::{
     factory::{LLMFactory, create_provider_for_model},
     provider::{LLMProvider, LLMRequest, Message, MessageRole},
     providers::{
-        AnthropicProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider, XAIProvider,
+        AnthropicProvider, GeminiProvider, MoonshotProvider, OpenAIProvider, OpenRouterProvider,
+        XAIProvider,
     },
 };
 
@@ -18,9 +19,11 @@ fn test_provider_factory_basic() {
     assert!(providers.contains(&"openai".to_string()));
     assert!(providers.contains(&"anthropic".to_string()));
     assert!(providers.contains(&"openrouter".to_string()));
+    assert!(providers.contains(&"moonshot".to_string()));
     assert!(providers.contains(&"xai".to_string()));
     assert!(providers.contains(&"deepseek".to_string()));
-    assert_eq!(providers.len(), 6);
+    assert!(providers.contains(&"zai".to_string()));
+    assert_eq!(providers.len(), 8);
 }
 
 #[test]
@@ -48,8 +51,12 @@ fn test_provider_auto_detection() {
         Some("openrouter".to_string())
     );
     assert_eq!(
-        factory.provider_from_model(models::xai::GROK_2_LATEST),
+        factory.provider_from_model(models::xai::GROK_4),
         Some("xai".to_string())
+    );
+    assert_eq!(
+        factory.provider_from_model(models::MOONSHOT_V1_32K),
+        Some("moonshot".to_string())
     );
     assert_eq!(factory.provider_from_model("unknown-model"), None);
 }
@@ -78,8 +85,11 @@ fn test_unified_client_creation() {
     );
     assert!(openrouter.is_ok());
 
-    let xai = create_provider_for_model(models::xai::GROK_2_LATEST, "test_key".to_string(), None);
+    let xai = create_provider_for_model(models::xai::GROK_4, "test_key".to_string(), None);
     assert!(xai.is_ok());
+
+    let moonshot = create_provider_for_model(models::MOONSHOT_V1_32K, "test_key".to_string(), None);
+    assert!(moonshot.is_ok());
 }
 
 #[test]
@@ -109,6 +119,9 @@ fn test_provider_names() {
 
     let xai = XAIProvider::new("test_key".to_string());
     assert_eq!(xai.name(), "xai");
+
+    let moonshot = MoonshotProvider::new("test_key".to_string());
+    assert_eq!(moonshot.name(), "moonshot");
 }
 
 #[test]

--- a/tests/models_sync.rs
+++ b/tests/models_sync.rs
@@ -47,6 +47,22 @@ fn constants_cover_models_json() {
                 validated_providers.insert("google");
                 Some(models::google::SUPPORTED_MODELS)
             }
+            "openrouter" => {
+                validated_providers.insert("openrouter");
+                Some(models::openrouter::SUPPORTED_MODELS)
+            }
+            "deepseek" => {
+                validated_providers.insert("deepseek");
+                Some(models::deepseek::SUPPORTED_MODELS)
+            }
+            "xai" => {
+                validated_providers.insert("xai");
+                Some(models::xai::SUPPORTED_MODELS)
+            }
+            "moonshot" => {
+                validated_providers.insert("moonshot");
+                Some(models::moonshot::SUPPORTED_MODELS)
+            }
             "zai" => {
                 validated_providers.insert("zai");
                 Some(models::zai::SUPPORTED_MODELS)
@@ -124,7 +140,16 @@ fn constants_cover_models_json() {
     }
 
     // Ensure we validated the expected providers
-    let expected_providers = ["openai", "anthropic", "google", "openrouter", "zai"];
+    let expected_providers = [
+        "openai",
+        "anthropic",
+        "google",
+        "openrouter",
+        "deepseek",
+        "xai",
+        "moonshot",
+        "zai",
+    ];
     for expected in &expected_providers {
         assert!(
             validated_providers.contains(expected),
@@ -168,6 +193,11 @@ fn model_helpers_validation_edge_cases() {
     assert!(model_helpers::is_valid(
         "openrouter",
         models::openrouter::DEFAULT_MODEL
+    ));
+    assert!(model_helpers::is_valid("xai", models::xai::DEFAULT_MODEL));
+    assert!(model_helpers::is_valid(
+        "moonshot",
+        models::moonshot::DEFAULT_MODEL
     ));
     assert!(model_helpers::is_valid("zai", models::zai::DEFAULT_MODEL));
 }

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -71,6 +71,17 @@ pub mod models {
         pub const GLM_4_32B_0414_128K: &str = "glm-4-32b-0414-128k";
     }
 
+    // Moonshot.ai models (direct API)
+    pub mod moonshot {
+        pub const DEFAULT_MODEL: &str = "moonshot-v1-32k";
+        pub const SUPPORTED_MODELS: &[&str] =
+            &["moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k"];
+
+        pub const MOONSHOT_V1_8K: &str = "moonshot-v1-8k";
+        pub const MOONSHOT_V1_32K: &str = "moonshot-v1-32k";
+        pub const MOONSHOT_V1_128K: &str = "moonshot-v1-128k";
+    }
+
     // OpenRouter models (extensible via vtcode.toml)
     pub mod openrouter {
         pub const X_AI_GROK_CODE_FAST_1: &str = "x-ai/grok-code-fast-1";
@@ -94,8 +105,6 @@ pub mod models {
         pub const QWEN3_8B: &str = "qwen/qwen3-8b";
         pub const QWEN3_8B_FREE: &str = "qwen/qwen3-8b:free";
         pub const QWEN3_4B_FREE: &str = "qwen/qwen3-4b:free";
-        pub const QWEN3_VL_235B_A22B_INSTRUCT: &str = "qwen/qwen3-vl-235b-a22b-instruct";
-        pub const QWEN3_VL_235B_A22B_THINKING: &str = "qwen/qwen3-vl-235b-a22b-thinking";
         pub const QWEN3_NEXT_80B_A3B_INSTRUCT: &str = "qwen/qwen3-next-80b-a3b-instruct";
         pub const QWEN3_NEXT_80B_A3B_THINKING: &str = "qwen/qwen3-next-80b-a3b-thinking";
         pub const QWEN3_CODER: &str = "qwen/qwen3-coder";
@@ -137,8 +146,6 @@ pub mod models {
             QWEN3_30B_A3B_INSTRUCT_2507,
             QWEN3_30B_A3B_THINKING_2507,
             QWEN3_14B,
-            QWEN3_VL_235B_A22B_INSTRUCT,
-            QWEN3_VL_235B_A22B_THINKING,
             QWEN3_NEXT_80B_A3B_INSTRUCT,
             QWEN3_NEXT_80B_A3B_THINKING,
             QWEN3_CODER,
@@ -172,8 +179,6 @@ pub mod models {
             QWEN3_30B_A3B_THINKING_2507,
             QWEN3_14B,
             QWEN3_4B_FREE,
-            QWEN3_VL_235B_A22B_INSTRUCT,
-            QWEN3_VL_235B_A22B_THINKING,
             QWEN3_NEXT_80B_A3B_THINKING,
             DEEPSEEK_DEEPSEEK_V3_2_EXP,
             DEEPSEEK_DEEPSEEK_CHAT_V3_1,
@@ -228,20 +233,20 @@ pub mod models {
 
     // xAI models
     pub mod xai {
-        pub const DEFAULT_MODEL: &str = "grok-2-latest";
+        pub const DEFAULT_MODEL: &str = "grok-4";
         pub const SUPPORTED_MODELS: &[&str] = &[
-            "grok-2-latest",
-            "grok-2",
-            "grok-2-mini",
-            "grok-2-reasoning",
-            "grok-2-vision",
+            "grok-4",
+            "grok-4-mini",
+            "grok-4-code",
+            "grok-4-code-latest",
+            "grok-4-vision",
         ];
 
-        pub const GROK_2_LATEST: &str = "grok-2-latest";
-        pub const GROK_2: &str = "grok-2";
-        pub const GROK_2_MINI: &str = "grok-2-mini";
-        pub const GROK_2_REASONING: &str = "grok-2-reasoning";
-        pub const GROK_2_VISION: &str = "grok-2-vision";
+        pub const GROK_4: &str = "grok-4";
+        pub const GROK_4_MINI: &str = "grok-4-mini";
+        pub const GROK_4_CODE: &str = "grok-4-code";
+        pub const GROK_4_CODE_LATEST: &str = "grok-4-code-latest";
+        pub const GROK_4_VISION: &str = "grok-4-vision";
     }
 
     // Backwards compatibility - keep old constants working
@@ -282,10 +287,6 @@ pub mod models {
     pub const OPENROUTER_QWEN3_8B: &str = openrouter::QWEN3_8B;
     pub const OPENROUTER_QWEN3_8B_FREE: &str = openrouter::QWEN3_8B_FREE;
     pub const OPENROUTER_QWEN3_4B_FREE: &str = openrouter::QWEN3_4B_FREE;
-    pub const OPENROUTER_QWEN3_VL_235B_A22B_INSTRUCT: &str =
-        openrouter::QWEN3_VL_235B_A22B_INSTRUCT;
-    pub const OPENROUTER_QWEN3_VL_235B_A22B_THINKING: &str =
-        openrouter::QWEN3_VL_235B_A22B_THINKING;
     pub const OPENROUTER_QWEN3_NEXT_80B_A3B_INSTRUCT: &str =
         openrouter::QWEN3_NEXT_80B_A3B_INSTRUCT;
     pub const OPENROUTER_QWEN3_NEXT_80B_A3B_THINKING: &str =
@@ -313,11 +314,14 @@ pub mod models {
     pub const OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5: &str =
         openrouter::ANTHROPIC_CLAUDE_SONNET_4_5;
     pub const OPENROUTER_ANTHROPIC_CLAUDE_OPUS_4_1: &str = openrouter::ANTHROPIC_CLAUDE_OPUS_4_1;
-    pub const XAI_GROK_2_LATEST: &str = xai::GROK_2_LATEST;
-    pub const XAI_GROK_2: &str = xai::GROK_2;
-    pub const XAI_GROK_2_MINI: &str = xai::GROK_2_MINI;
-    pub const XAI_GROK_2_REASONING: &str = xai::GROK_2_REASONING;
-    pub const XAI_GROK_2_VISION: &str = xai::GROK_2_VISION;
+    pub const MOONSHOT_V1_8K: &str = moonshot::MOONSHOT_V1_8K;
+    pub const MOONSHOT_V1_32K: &str = moonshot::MOONSHOT_V1_32K;
+    pub const MOONSHOT_V1_128K: &str = moonshot::MOONSHOT_V1_128K;
+    pub const XAI_GROK_4: &str = xai::GROK_4;
+    pub const XAI_GROK_4_MINI: &str = xai::GROK_4_MINI;
+    pub const XAI_GROK_4_CODE: &str = xai::GROK_4_CODE;
+    pub const XAI_GROK_4_CODE_LATEST: &str = xai::GROK_4_CODE_LATEST;
+    pub const XAI_GROK_4_VISION: &str = xai::GROK_4_VISION;
     pub const DEEPSEEK_CHAT: &str = deepseek::DEEPSEEK_CHAT;
     pub const DEEPSEEK_REASONER: &str = deepseek::DEEPSEEK_REASONER;
 }
@@ -345,6 +349,7 @@ pub mod prompt_cache {
     pub const XAI_CACHE_ENABLED: bool = true;
     pub const DEEPSEEK_CACHE_ENABLED: bool = true;
     pub const ZAI_CACHE_ENABLED: bool = false;
+    pub const MOONSHOT_CACHE_ENABLED: bool = true;
 }
 
 /// Model validation and helper functions
@@ -359,6 +364,7 @@ pub mod model_helpers {
             "anthropic" => Some(models::anthropic::SUPPORTED_MODELS),
             "deepseek" => Some(models::deepseek::SUPPORTED_MODELS),
             "openrouter" => Some(models::openrouter::SUPPORTED_MODELS),
+            "moonshot" => Some(models::moonshot::SUPPORTED_MODELS),
             "xai" => Some(models::xai::SUPPORTED_MODELS),
             "zai" => Some(models::zai::SUPPORTED_MODELS),
             _ => None,
@@ -373,6 +379,7 @@ pub mod model_helpers {
             "anthropic" => Some(models::anthropic::DEFAULT_MODEL),
             "deepseek" => Some(models::deepseek::DEFAULT_MODEL),
             "openrouter" => Some(models::openrouter::DEFAULT_MODEL),
+            "moonshot" => Some(models::moonshot::DEFAULT_MODEL),
             "xai" => Some(models::xai::DEFAULT_MODEL),
             "zai" => Some(models::zai::DEFAULT_MODEL),
             _ => None,
@@ -551,6 +558,7 @@ pub mod urls {
     pub const XAI_API_BASE: &str = "https://api.x.ai/v1";
     pub const DEEPSEEK_API_BASE: &str = "https://api.deepseek.com/v1";
     pub const Z_AI_API_BASE: &str = "https://api.z.ai/api";
+    pub const MOONSHOT_API_BASE: &str = "https://api.moonshot.cn/v1";
 }
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase

--- a/vtcode-core/src/config/core/mod.rs
+++ b/vtcode-core/src/config/core/mod.rs
@@ -10,9 +10,9 @@ pub use automation::{AutomationConfig, FullAutoConfig};
 pub use commands::CommandsConfig;
 pub use prompt_cache::{
     AnthropicPromptCacheSettings, DeepSeekPromptCacheSettings, GeminiPromptCacheMode,
-    GeminiPromptCacheSettings, OpenAIPromptCacheSettings, OpenRouterPromptCacheSettings,
-    PromptCachingConfig, ProviderPromptCachingConfig, XAIPromptCacheSettings,
-    ZaiPromptCacheSettings,
+    GeminiPromptCacheSettings, MoonshotPromptCacheSettings, OpenAIPromptCacheSettings,
+    OpenRouterPromptCacheSettings, PromptCachingConfig, ProviderPromptCachingConfig,
+    XAIPromptCacheSettings, ZaiPromptCacheSettings,
 };
 pub use security::SecurityConfig;
 pub use tools::{ToolPolicy, ToolsConfig};

--- a/vtcode-core/src/config/core/prompt_cache.rs
+++ b/vtcode-core/src/config/core/prompt_cache.rs
@@ -74,6 +74,9 @@ pub struct ProviderPromptCachingConfig {
     #[serde(default = "OpenRouterPromptCacheSettings::default")]
     pub openrouter: OpenRouterPromptCacheSettings,
 
+    #[serde(default = "MoonshotPromptCacheSettings::default")]
+    pub moonshot: MoonshotPromptCacheSettings,
+
     #[serde(default = "XAIPromptCacheSettings::default")]
     pub xai: XAIPromptCacheSettings,
 
@@ -91,6 +94,7 @@ impl Default for ProviderPromptCachingConfig {
             anthropic: AnthropicPromptCacheSettings::default(),
             gemini: GeminiPromptCacheSettings::default(),
             openrouter: OpenRouterPromptCacheSettings::default(),
+            moonshot: MoonshotPromptCacheSettings::default(),
             xai: XAIPromptCacheSettings::default(),
             deepseek: DeepSeekPromptCacheSettings::default(),
             zai: ZaiPromptCacheSettings::default(),
@@ -231,6 +235,21 @@ impl Default for OpenRouterPromptCacheSettings {
     }
 }
 
+/// Moonshot prompt caching configuration (leverages server-side reuse)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MoonshotPromptCacheSettings {
+    #[serde(default = "default_moonshot_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for MoonshotPromptCacheSettings {
+    fn default() -> Self {
+        Self {
+            enabled: default_moonshot_enabled(),
+        }
+    }
+}
+
 /// xAI prompt caching configuration (automatic platform-level cache)
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct XAIPromptCacheSettings {
@@ -345,6 +364,10 @@ fn default_zai_enabled() -> bool {
     prompt_cache::ZAI_CACHE_ENABLED
 }
 
+fn default_moonshot_enabled() -> bool {
+    prompt_cache::MOONSHOT_CACHE_ENABLED
+}
+
 fn resolve_path(input: &str, workspace_root: Option<&Path>) -> PathBuf {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -405,6 +428,7 @@ mod tests {
             Some(prompt_cache::ANTHROPIC_EXTENDED_TTL_SECONDS)
         );
         assert_eq!(cfg.providers.gemini.mode, GeminiPromptCacheMode::Implicit);
+        assert!(cfg.providers.moonshot.enabled);
     }
 
     #[test]

--- a/vtcode-core/src/llm/client.rs
+++ b/vtcode-core/src/llm/client.rs
@@ -1,7 +1,7 @@
 use super::provider::LLMError;
 use super::providers::{
-    AnthropicProvider, DeepSeekProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider,
-    XAIProvider, ZAIProvider,
+    AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OpenAIProvider,
+    OpenRouterProvider, XAIProvider, ZAIProvider,
 };
 use super::types::{BackendKind, LLMResponse};
 use crate::config::models::{ModelId, Provider};
@@ -35,6 +35,10 @@ pub fn make_client(api_key: String, model: ModelId) -> AnyClient {
             model.as_str().to_string(),
         )),
         Provider::OpenRouter => Box::new(OpenRouterProvider::with_model(
+            api_key,
+            model.as_str().to_string(),
+        )),
+        Provider::Moonshot => Box::new(MoonshotProvider::with_model(
             api_key,
             model.as_str().to_string(),
         )),

--- a/vtcode-core/src/llm/factory.rs
+++ b/vtcode-core/src/llm/factory.rs
@@ -1,6 +1,6 @@
 use super::providers::{
-    AnthropicProvider, DeepSeekProvider, GeminiProvider, OpenAIProvider, OpenRouterProvider,
-    XAIProvider, ZAIProvider,
+    AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OpenAIProvider,
+    OpenRouterProvider, XAIProvider, ZAIProvider,
 };
 use crate::config::core::PromptCachingConfig;
 use crate::llm::provider::{LLMError, LLMProvider};
@@ -117,6 +117,24 @@ impl LLMFactory {
         );
 
         factory.register_provider(
+            "moonshot",
+            Box::new(|config: ProviderConfig| {
+                let ProviderConfig {
+                    api_key,
+                    base_url,
+                    model,
+                    prompt_cache,
+                } = config;
+                Box::new(MoonshotProvider::from_config(
+                    api_key,
+                    model,
+                    base_url,
+                    prompt_cache,
+                )) as Box<dyn LLMProvider>
+            }),
+        );
+
+        factory.register_provider(
             "xai",
             Box::new(|config: ProviderConfig| {
                 let ProviderConfig {
@@ -197,6 +215,8 @@ impl LLMFactory {
             Some("xai".to_string())
         } else if m.starts_with("glm-") {
             Some("zai".to_string())
+        } else if m.starts_with("moonshot-") {
+            Some("moonshot".to_string())
         } else if m.contains('/') || m.contains('@') {
             Some("openrouter".to_string())
         } else {

--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic;
 pub mod deepseek;
 pub mod gemini;
+pub mod moonshot;
 pub mod openai;
 pub mod openrouter;
 pub mod xai;
@@ -15,6 +16,7 @@ pub(crate) use reasoning::extract_reasoning_trace;
 pub use anthropic::AnthropicProvider;
 pub use deepseek::DeepSeekProvider;
 pub use gemini::GeminiProvider;
+pub use moonshot::MoonshotProvider;
 pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
 pub use xai::XAIProvider;

--- a/vtcode-core/src/llm/providers/moonshot.rs
+++ b/vtcode-core/src/llm/providers/moonshot.rs
@@ -1,0 +1,136 @@
+use crate::config::constants::{models, urls};
+use crate::config::core::PromptCachingConfig;
+use crate::llm::client::LLMClient;
+use crate::llm::error_display;
+use crate::llm::provider::{LLMError, LLMProvider, LLMRequest, LLMResponse};
+use crate::llm::providers::openai::OpenAIProvider;
+use crate::llm::types as llm_types;
+use async_trait::async_trait;
+
+/// Moonshot.ai provider implemented as an OpenAI-compatible wrapper.
+pub struct MoonshotProvider {
+    inner: OpenAIProvider,
+    model: String,
+}
+
+impl MoonshotProvider {
+    pub fn new(api_key: String) -> Self {
+        Self::with_model_internal(api_key, models::moonshot::DEFAULT_MODEL.to_string(), None)
+    }
+
+    pub fn with_model(api_key: String, model: String) -> Self {
+        Self::with_model_internal(api_key, model, None)
+    }
+
+    pub fn from_config(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        let resolved_model = model.unwrap_or_else(|| models::moonshot::DEFAULT_MODEL.to_string());
+        let resolved_base_url = base_url.unwrap_or_else(|| urls::MOONSHOT_API_BASE.to_string());
+        let prompt_cache_forward = Self::extract_prompt_cache_settings(prompt_cache);
+
+        let inner = OpenAIProvider::from_config(
+            api_key,
+            Some(resolved_model.clone()),
+            Some(resolved_base_url),
+            prompt_cache_forward,
+        );
+
+        Self {
+            inner,
+            model: resolved_model,
+        }
+    }
+
+    fn with_model_internal(
+        api_key: String,
+        model: String,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        Self::from_config(Some(api_key), Some(model), None, prompt_cache)
+    }
+
+    fn extract_prompt_cache_settings(
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Option<PromptCachingConfig> {
+        prompt_cache.and_then(|cfg| {
+            if cfg.enabled && cfg.providers.moonshot.enabled {
+                Some(cfg)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[async_trait]
+impl LLMProvider for MoonshotProvider {
+    fn name(&self) -> &str {
+        "moonshot"
+    }
+
+    fn supports_reasoning(&self, _model: &str) -> bool {
+        false
+    }
+
+    fn supports_reasoning_effort(&self, _model: &str) -> bool {
+        false
+    }
+
+    async fn generate(&self, mut request: LLMRequest) -> Result<LLMResponse, LLMError> {
+        if request.model.trim().is_empty() {
+            request.model = self.model.clone();
+        }
+
+        self.inner.generate(request).await
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        models::moonshot::SUPPORTED_MODELS
+            .iter()
+            .map(|model| (*model).to_string())
+            .collect()
+    }
+
+    fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
+        if request.messages.is_empty() {
+            let formatted = error_display::format_llm_error("Moonshot", "Messages cannot be empty");
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        if !request.model.trim().is_empty() && !self.supported_models().contains(&request.model) {
+            let formatted = error_display::format_llm_error(
+                "Moonshot",
+                &format!("Unsupported model: {}", request.model),
+            );
+            return Err(LLMError::InvalidRequest(formatted));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider("openai") {
+                let formatted = error_display::format_llm_error("Moonshot", &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LLMClient for MoonshotProvider {
+    async fn generate(&mut self, prompt: &str) -> Result<llm_types::LLMResponse, LLMError> {
+        <OpenAIProvider as LLMClient>::generate(&mut self.inner, prompt).await
+    }
+
+    fn backend_kind(&self) -> llm_types::BackendKind {
+        llm_types::BackendKind::Moonshot
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}

--- a/vtcode-core/src/llm/providers/xai.rs
+++ b/vtcode-core/src/llm/providers/xai.rs
@@ -84,7 +84,10 @@ impl LLMProvider for XAIProvider {
         } else {
             model
         };
-        requested.contains("reasoning")
+
+        requested == models::xai::GROK_4
+            || requested == models::xai::GROK_4_CODE
+            || requested == models::xai::GROK_4_CODE_LATEST
     }
 
     fn supports_reasoning_effort(&self, _model: &str) -> bool {

--- a/vtcode-core/src/llm/rig_adapter.rs
+++ b/vtcode-core/src/llm/rig_adapter.rs
@@ -47,6 +47,9 @@ pub fn verify_model_with_rig(
             let client = xai::Client::new(api_key);
             let _ = client.completion_model(model);
         }
+        Provider::Moonshot => {
+            // Moonshot does not have a rig client integration yet.
+        }
         Provider::ZAI => {
             // The rig crate does not yet expose a dedicated Z.AI client.
             // Skip instantiation while still marking the provider as verified.

--- a/vtcode-core/src/llm/types.rs
+++ b/vtcode-core/src/llm/types.rs
@@ -10,6 +10,7 @@ pub enum BackendKind {
     OpenRouter,
     XAI,
     ZAI,
+    Moonshot,
 }
 
 /// Unified LLM response structure


### PR DESCRIPTION
## Summary
- add a Moonshot.ai provider that reuses the OpenAI client surface and wire it through the factory, client, rig adapter, and backend types
- extend model constants, prompt cache configuration, and Provider/ModelId metadata to include Moonshot models while updating xAI listings to the Grok 4 family
- refresh docs/models.json and provider tests to cover the new Moonshot entries and the updated xAI/Grok coverage

## Testing
- cargo fmt
- cargo clippy
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e68612b1748323a6b5d2ff850284bc