### PR TITLE
Align xAI reasoning detection with Grok 4 constants

### DIFF
--- a/vtcode-core/src/llm/providers/xai.rs
+++ b/vtcode-core/src/llm/providers/xai.rs
@@ -84,7 +84,10 @@ impl LLMProvider for XAIProvider {
         } else {
             model
         };
-        requested.contains("reasoning")
+
+        requested == models::xai::GROK_4
+            || requested == models::xai::GROK_4_CODE
+            || requested == models::xai::GROK_4_CODE_LATEST
     }
 
     fn supports_reasoning_effort(&self, _model: &str) -> bool {


### PR DESCRIPTION
## Summary
- update the xAI provider reasoning detection to look for the Grok 4 model constants instead of a substring match

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6923863648323b5090df10daa2cfc