### PR TITLE
Update Moonshot models and model picker layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_setters"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5c625eda104c228c06ecaf988d1c60e542176bd7a490e60eeda3493244c0c9"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,6 +2444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fef540f80dbe8a0773266fa6077788ceb65ef624cdbf36e131aaf90b4a52df4"
+dependencies = [
+ "ratatui",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,6 +3728,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-popup"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ee3d08800c83ba0a2efaec44d225bcc3f885f30e2b520a17e2cd962b7da6ab"
+dependencies = [
+ "derive-getters",
+ "derive_setters",
+ "document-features",
+ "ratatui",
+]
+
+[[package]]
+name = "tui-prompts"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6e0d8a972545cc209b933a1c06dab8932674b54ae19947834ec854fec2364f"
+dependencies = [
+ "itertools 0.13.0",
+ "ratatui",
+ "ratatui-macros",
+ "rstest",
+]
+
+[[package]]
 name = "tui-scrollview"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,6 +4031,8 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+ "tui-popup",
+ "tui-prompts",
  "tui-scrollview",
  "unicode-segmentation",
  "unicode-width 0.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,6 +3882,7 @@ dependencies = [
  "console 0.16.1",
  "criterion",
  "dialoguer 0.9.0",
+ "dotenvy",
  "futures",
  "indexmap",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 indicatif = { version = "0.18", default-features = false }
 is-terminal = "0.4.16"
 async-trait = "0.1.89"
+# Environment helpers
+dotenvy = "0.15"
 # ANSI styling
 anstyle = "1.0"
 sysinfo = "0.37.0"

--- a/docs/models.json
+++ b/docs/models.json
@@ -1316,11 +1316,11 @@
     ],
     "api": "https://api.moonshot.cn/v1",
     "name": "Moonshot AI",
-    "doc": "https://platform.moonshot.ai/docs/overview",
+    "doc": "https://platform.moonshot.ai/docs/api/tool-use",
     "models": {
-      "moonshot-v1-8k": {
-        "id": "moonshot-v1-8k",
-        "name": "Moonshot v1 8K",
+      "kimi-k2-turbo-preview": {
+        "id": "kimi-k2-turbo-preview",
+        "name": "Kimi K2 Turbo Preview",
         "reasoning": false,
         "tool_call": true,
         "modalities": {
@@ -1331,12 +1331,17 @@
             "text"
           ]
         },
-        "context": 8192,
-        "max_output_tokens": 8192
+        "context": 262144,
+        "max_output_tokens": null,
+        "cost": {
+          "input_cache_hit": 6e-7,
+          "input": 2.4e-6,
+          "output": 1e-5
+        }
       },
-      "moonshot-v1-32k": {
-        "id": "moonshot-v1-32k",
-        "name": "Moonshot v1 32K",
+      "kimi-k2-0905-preview": {
+        "id": "kimi-k2-0905-preview",
+        "name": "Kimi K2 0905 Preview",
         "reasoning": false,
         "tool_call": true,
         "modalities": {
@@ -1347,12 +1352,17 @@
             "text"
           ]
         },
-        "context": 32768,
-        "max_output_tokens": 32768
+        "context": 262144,
+        "max_output_tokens": null,
+        "cost": {
+          "input_cache_hit": 1.5e-7,
+          "input": 6e-7,
+          "output": 2.5e-6
+        }
       },
-      "moonshot-v1-128k": {
-        "id": "moonshot-v1-128k",
-        "name": "Moonshot v1 128K",
+      "kimi-k2-0711-preview": {
+        "id": "kimi-k2-0711-preview",
+        "name": "Kimi K2 0711 Preview",
         "reasoning": false,
         "tool_call": true,
         "modalities": {
@@ -1364,7 +1374,95 @@
           ]
         },
         "context": 131072,
-        "max_output_tokens": 131072
+        "max_output_tokens": null,
+        "cost": {
+          "input_cache_hit": 1.5e-7,
+          "input": 6e-7,
+          "output": 2.5e-6
+        }
+      },
+      "kimi-latest": {
+        "id": "kimi-latest",
+        "name": "Kimi Latest (auto-tier)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072,
+        "max_output_tokens": null
+      },
+      "kimi-latest-8k": {
+        "id": "kimi-latest-8k",
+        "name": "Kimi Latest 8K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8192,
+        "max_output_tokens": 8192,
+        "cost": {
+          "input_cache_hit": 1.5e-7,
+          "input": 2e-7,
+          "output": 2e-6
+        }
+      },
+      "kimi-latest-32k": {
+        "id": "kimi-latest-32k",
+        "name": "Kimi Latest 32K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 32768,
+        "max_output_tokens": 32768,
+        "cost": {
+          "input_cache_hit": 1.5e-7,
+          "input": 1e-6,
+          "output": 3e-6
+        }
+      },
+      "kimi-latest-128k": {
+        "id": "kimi-latest-128k",
+        "name": "Kimi Latest 128K",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072,
+        "max_output_tokens": 131072,
+        "cost": {
+          "input_cache_hit": 1.5e-7,
+          "input": 2e-6,
+          "output": 5e-6
+        }
       }
     }
   }

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -756,7 +756,8 @@ fn show_secure_api_modal(
         storage_line,
         "Paste the key and press Enter when ready.".to_string(),
     ];
-    renderer.show_list_modal("Secure API key setup", lines, Vec::new(), None);
+    let prompt_label = format!("{} API key", selection.provider_label);
+    renderer.show_secure_prompt_modal("Secure API key setup", lines, prompt_label);
 }
 
 fn read_workspace_env(workspace: &Path, env_key: &str) -> Result<Option<String>> {

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -445,6 +445,7 @@ fn render_step_one_inline(
     current_reasoning: ReasoningEffortLevel,
 ) -> Result<()> {
     let mut items = Vec::new();
+    let mut first_section = true;
     for provider in Provider::all_providers() {
         let provider_models: Vec<&ModelOption> = options
             .iter()
@@ -453,6 +454,16 @@ fn render_step_one_inline(
         if provider_models.is_empty() {
             continue;
         }
+        if !first_section {
+            items.push(InlineListItem {
+                title: String::new(),
+                subtitle: None,
+                badge: None,
+                indent: 0,
+                selection: None,
+            });
+        }
+        first_section = false;
         items.push(InlineListItem {
             title: provider.label().to_string(),
             subtitle: None,
@@ -511,10 +522,15 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
         grouped.entry(option.provider).or_default().push(option);
     }
 
+    let mut first_section = true;
     for provider in Provider::all_providers() {
         let Some(list) = grouped.get(&provider) else {
             continue;
         };
+        if !first_section {
+            renderer.line(MessageStyle::Info, "")?;
+        }
+        first_section = false;
         renderer.line(MessageStyle::Info, &format!("[{}]", provider.label()))?;
         for option in list {
             let reasoning_marker = if option.supports_reasoning {
@@ -781,9 +797,13 @@ mod tests {
     #[test]
     fn model_picker_lists_new_moonshot_models() {
         let options = MODEL_OPTIONS.as_slice();
-        assert!(has_model(options, ModelId::MoonshotV18k));
-        assert!(has_model(options, ModelId::MoonshotV132k));
-        assert!(has_model(options, ModelId::MoonshotV1128k));
+        assert!(has_model(options, ModelId::MoonshotKimiK2TurboPreview));
+        assert!(has_model(options, ModelId::MoonshotKimiK20905Preview));
+        assert!(has_model(options, ModelId::MoonshotKimiK20711Preview));
+        assert!(has_model(options, ModelId::MoonshotKimiLatest));
+        assert!(has_model(options, ModelId::MoonshotKimiLatest8k));
+        assert!(has_model(options, ModelId::MoonshotKimiLatest32k));
+        assert!(has_model(options, ModelId::MoonshotKimiLatest128k));
         assert!(has_model(options, ModelId::OpenRouterMoonshotaiKimiK20905));
     }
 

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -4,6 +4,7 @@ use futures::StreamExt;
 use indicatif::ProgressStyle;
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write as FmtWrite;
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use tokio::task;
 use tokio::time::sleep;
 
 use serde_json::Value;
+use tempfile::Builder;
 use toml::Value as TomlValue;
 use tracing::warn;
 use vtcode_core::SimpleIndexer;
@@ -789,10 +791,57 @@ fn persist_env_value(workspace: &Path, key: &str, value: &str) -> Result<()> {
         lines.push(format!("{key}={value}"));
     }
 
-    let mut content = lines.join("\n");
-    content.push('\n');
-    std::fs::write(&env_path, content)
-        .with_context(|| format!("Failed to write {}", env_path.display()))?;
+    let parent = env_path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| workspace.to_path_buf());
+
+    if !parent.exists() {
+        std::fs::create_dir_all(&parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+
+    let temp = Builder::new()
+        .prefix(".env.")
+        .suffix(".tmp")
+        .tempfile_in(&parent)
+        .with_context(|| format!("Failed to create temporary file in {}", parent.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let permissions = std::fs::Permissions::from_mode(0o600);
+        temp.as_file()
+            .set_permissions(permissions)
+            .with_context(|| format!("Failed to set permissions on {}", temp.path().display()))?;
+    }
+
+    {
+        let mut writer = BufWriter::new(temp.as_file());
+        for line in &lines {
+            writeln!(writer, "{line}")
+                .with_context(|| format!("Failed to write .env entry for {key}"))?;
+        }
+        writer
+            .flush()
+            .with_context(|| format!("Failed to flush temporary .env for {}", key))?;
+    }
+
+    temp.as_file()
+        .sync_all()
+        .with_context(|| format!("Failed to sync temporary .env for {}", key))?;
+
+    let _file = temp
+        .persist(&env_path)
+        .with_context(|| format!("Failed to persist {}", env_path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&env_path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("Failed to set permissions on {}", env_path.display()))?;
+    }
+
     Ok(())
 }
 
@@ -2225,7 +2274,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                                         modal_lines.push(String::new());
                                         modal_lines.push(MODAL_CLOSE_HINT.to_string());
                                         handle.close_modal();
-                                        handle.show_modal(content.title.clone(), modal_lines);
+                                        handle.show_modal(content.title.clone(), modal_lines, None);
                                         renderer.line(
                                             MessageStyle::Info,
                                             &format!(

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -2133,7 +2133,8 @@ pub(crate) async fn run_single_agent_loop_unified(
                                 .as_ref()
                                 .map(|cfg| cfg.agent.reasoning_effort)
                                 .unwrap_or(config.reasoning_effort);
-                            match ModelPickerState::new(&mut renderer, reasoning) {
+                            let workspace_hint = Some(config.workspace.clone());
+                            match ModelPickerState::new(&mut renderer, reasoning, workspace_hint) {
                                 Ok(picker) => {
                                     model_picker_state = Some(picker);
                                 }

--- a/tests/llm_focused_test.rs
+++ b/tests/llm_focused_test.rs
@@ -55,7 +55,7 @@ fn test_provider_auto_detection() {
         Some("xai".to_string())
     );
     assert_eq!(
-        factory.provider_from_model(models::MOONSHOT_V1_32K),
+        factory.provider_from_model(models::MOONSHOT_KIMI_K2_TURBO_PREVIEW),
         Some("moonshot".to_string())
     );
     assert_eq!(factory.provider_from_model("unknown-model"), None);
@@ -88,7 +88,11 @@ fn test_unified_client_creation() {
     let xai = create_provider_for_model(models::xai::GROK_4, "test_key".to_string(), None);
     assert!(xai.is_ok());
 
-    let moonshot = create_provider_for_model(models::MOONSHOT_V1_32K, "test_key".to_string(), None);
+    let moonshot = create_provider_for_model(
+        models::MOONSHOT_KIMI_K2_TURBO_PREVIEW,
+        "test_key".to_string(),
+        None,
+    );
     assert!(moonshot.is_ok());
 }
 

--- a/tests/llm_providers_test.rs
+++ b/tests/llm_providers_test.rs
@@ -96,7 +96,7 @@ fn test_provider_auto_detection() {
 
     // Test Moonshot models
     assert_eq!(
-        factory.provider_from_model(models::MOONSHOT_V1_32K),
+        factory.provider_from_model(models::MOONSHOT_KIMI_K2_TURBO_PREVIEW),
         Some("moonshot".to_string())
     );
 
@@ -131,7 +131,11 @@ fn test_provider_creation() {
     let xai = create_provider_for_model(models::xai::GROK_4, "test_key".to_string(), None);
     assert!(xai.is_ok());
 
-    let moonshot = create_provider_for_model(models::MOONSHOT_V1_32K, "test_key".to_string(), None);
+    let moonshot = create_provider_for_model(
+        models::MOONSHOT_KIMI_K2_TURBO_PREVIEW,
+        "test_key".to_string(),
+        None,
+    );
     assert!(moonshot.is_ok());
 
     // Test invalid model
@@ -181,8 +185,11 @@ fn test_unified_client_creation() {
         assert_eq!(client.name(), "xai");
     }
 
-    let moonshot_client =
-        create_provider_for_model(models::MOONSHOT_V1_32K, "test_key".to_string(), None);
+    let moonshot_client = create_provider_for_model(
+        models::MOONSHOT_KIMI_K2_TURBO_PREVIEW,
+        "test_key".to_string(),
+        None,
+    );
     assert!(moonshot_client.is_ok());
     if let Ok(client) = moonshot_client {
         assert_eq!(client.name(), "moonshot");
@@ -249,9 +256,10 @@ fn test_provider_supported_models() {
 
     let moonshot = MoonshotProvider::new("test_key".to_string());
     let moonshot_models = moonshot.supported_models();
-    assert!(moonshot_models.contains(&models::MOONSHOT_V1_8K.to_string()));
-    assert!(moonshot_models.contains(&models::MOONSHOT_V1_32K.to_string()));
-    assert!(moonshot_models.len() >= 2);
+    assert!(moonshot_models.contains(&models::MOONSHOT_KIMI_K2_TURBO_PREVIEW.to_string()));
+    assert!(moonshot_models.contains(&models::MOONSHOT_KIMI_K2_0905_PREVIEW.to_string()));
+    assert!(moonshot_models.contains(&models::MOONSHOT_KIMI_LATEST_128K.to_string()));
+    assert!(moonshot_models.len() >= 3);
 }
 
 #[test]

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -84,8 +84,11 @@ crossterm = "0.27"
 ratatui = { version = "0.29", default-features = false, features = [
     "crossterm",
     "unstable-rendered-line-info",
+    "unstable-widget-ref",
 ] }
 tui-scrollview = "0.5.1"
+tui-popup = "0.6"
+tui-prompts = "0.5"
 ignore = "0.4"
 nucleo-matcher = "0.3"
 pulldown-cmark = { version = "0.9", default-features = false, features = [

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -73,13 +73,24 @@ pub mod models {
 
     // Moonshot.ai models (direct API)
     pub mod moonshot {
-        pub const DEFAULT_MODEL: &str = "moonshot-v1-32k";
-        pub const SUPPORTED_MODELS: &[&str] =
-            &["moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k"];
+        pub const DEFAULT_MODEL: &str = "kimi-k2-turbo-preview";
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            "kimi-k2-turbo-preview",
+            "kimi-k2-0905-preview",
+            "kimi-k2-0711-preview",
+            "kimi-latest",
+            "kimi-latest-8k",
+            "kimi-latest-32k",
+            "kimi-latest-128k",
+        ];
 
-        pub const MOONSHOT_V1_8K: &str = "moonshot-v1-8k";
-        pub const MOONSHOT_V1_32K: &str = "moonshot-v1-32k";
-        pub const MOONSHOT_V1_128K: &str = "moonshot-v1-128k";
+        pub const KIMI_K2_TURBO_PREVIEW: &str = "kimi-k2-turbo-preview";
+        pub const KIMI_K2_0905_PREVIEW: &str = "kimi-k2-0905-preview";
+        pub const KIMI_K2_0711_PREVIEW: &str = "kimi-k2-0711-preview";
+        pub const KIMI_LATEST: &str = "kimi-latest";
+        pub const KIMI_LATEST_8K: &str = "kimi-latest-8k";
+        pub const KIMI_LATEST_32K: &str = "kimi-latest-32k";
+        pub const KIMI_LATEST_128K: &str = "kimi-latest-128k";
     }
 
     // OpenRouter models (extensible via vtcode.toml)
@@ -314,9 +325,13 @@ pub mod models {
     pub const OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5: &str =
         openrouter::ANTHROPIC_CLAUDE_SONNET_4_5;
     pub const OPENROUTER_ANTHROPIC_CLAUDE_OPUS_4_1: &str = openrouter::ANTHROPIC_CLAUDE_OPUS_4_1;
-    pub const MOONSHOT_V1_8K: &str = moonshot::MOONSHOT_V1_8K;
-    pub const MOONSHOT_V1_32K: &str = moonshot::MOONSHOT_V1_32K;
-    pub const MOONSHOT_V1_128K: &str = moonshot::MOONSHOT_V1_128K;
+    pub const MOONSHOT_KIMI_K2_TURBO_PREVIEW: &str = moonshot::KIMI_K2_TURBO_PREVIEW;
+    pub const MOONSHOT_KIMI_K2_0905_PREVIEW: &str = moonshot::KIMI_K2_0905_PREVIEW;
+    pub const MOONSHOT_KIMI_K2_0711_PREVIEW: &str = moonshot::KIMI_K2_0711_PREVIEW;
+    pub const MOONSHOT_KIMI_LATEST: &str = moonshot::KIMI_LATEST;
+    pub const MOONSHOT_KIMI_LATEST_8K: &str = moonshot::KIMI_LATEST_8K;
+    pub const MOONSHOT_KIMI_LATEST_32K: &str = moonshot::KIMI_LATEST_32K;
+    pub const MOONSHOT_KIMI_LATEST_128K: &str = moonshot::KIMI_LATEST_128K;
     pub const XAI_GROK_4: &str = xai::GROK_4;
     pub const XAI_GROK_4_MINI: &str = xai::GROK_4_MINI;
     pub const XAI_GROK_4_CODE: &str = xai::GROK_4_CODE;

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -107,9 +107,9 @@ impl Provider {
     /// Get all supported providers
     pub fn all_providers() -> Vec<Provider> {
         vec![
-            Provider::Gemini,
             Provider::OpenAI,
             Provider::Anthropic,
+            Provider::Gemini,
             Provider::DeepSeek,
             Provider::OpenRouter,
             Provider::Moonshot,
@@ -250,12 +250,20 @@ pub enum ModelId {
     ZaiGlm432b0414128k,
 
     // Moonshot.ai models
-    /// Moonshot v1 8K - Fast deployment with 8K context window
-    MoonshotV18k,
-    /// Moonshot v1 32K - Balanced option for longer tasks
-    MoonshotV132k,
-    /// Moonshot v1 128K - Maximum context Moonshot flagship
-    MoonshotV1128k,
+    /// Kimi K2 Turbo Preview - Recommended high-speed K2 deployment
+    MoonshotKimiK2TurboPreview,
+    /// Kimi K2 0905 Preview - Flagship 256K K2 release with enhanced coding agents
+    MoonshotKimiK20905Preview,
+    /// Kimi K2 0711 Preview - Long-context K2 release tuned for balanced workloads
+    MoonshotKimiK20711Preview,
+    /// Kimi Latest - Auto-tier alias that selects 8K/32K/128K variants automatically
+    MoonshotKimiLatest,
+    /// Kimi Latest 8K - Vision-enabled 8K tier with automatic context caching
+    MoonshotKimiLatest8k,
+    /// Kimi Latest 32K - Vision-enabled mid-tier with extended context
+    MoonshotKimiLatest32k,
+    /// Kimi Latest 128K - Vision-enabled flagship tier with maximum context
+    MoonshotKimiLatest128k,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model
@@ -432,9 +440,13 @@ impl ModelId {
             ModelId::ZaiGlm45Flash => models::zai::GLM_4_5_FLASH,
             ModelId::ZaiGlm432b0414128k => models::zai::GLM_4_32B_0414_128K,
             // Moonshot models
-            ModelId::MoonshotV18k => models::MOONSHOT_V1_8K,
-            ModelId::MoonshotV132k => models::MOONSHOT_V1_32K,
-            ModelId::MoonshotV1128k => models::MOONSHOT_V1_128K,
+            ModelId::MoonshotKimiK2TurboPreview => models::MOONSHOT_KIMI_K2_TURBO_PREVIEW,
+            ModelId::MoonshotKimiK20905Preview => models::MOONSHOT_KIMI_K2_0905_PREVIEW,
+            ModelId::MoonshotKimiK20711Preview => models::MOONSHOT_KIMI_K2_0711_PREVIEW,
+            ModelId::MoonshotKimiLatest => models::MOONSHOT_KIMI_LATEST,
+            ModelId::MoonshotKimiLatest8k => models::MOONSHOT_KIMI_LATEST_8K,
+            ModelId::MoonshotKimiLatest32k => models::MOONSHOT_KIMI_LATEST_32K,
+            ModelId::MoonshotKimiLatest128k => models::MOONSHOT_KIMI_LATEST_128K,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -471,9 +483,13 @@ impl ModelId {
             | ModelId::ZaiGlm45Airx
             | ModelId::ZaiGlm45Flash
             | ModelId::ZaiGlm432b0414128k => Provider::ZAI,
-            ModelId::MoonshotV18k | ModelId::MoonshotV132k | ModelId::MoonshotV1128k => {
-                Provider::Moonshot
-            }
+            ModelId::MoonshotKimiK2TurboPreview
+            | ModelId::MoonshotKimiK20905Preview
+            | ModelId::MoonshotKimiK20711Preview
+            | ModelId::MoonshotKimiLatest
+            | ModelId::MoonshotKimiLatest8k
+            | ModelId::MoonshotKimiLatest32k
+            | ModelId::MoonshotKimiLatest128k => Provider::Moonshot,
             _ => unreachable!(),
         }
     }
@@ -522,9 +538,13 @@ impl ModelId {
             ModelId::ZaiGlm45Flash => "GLM 4.5 Flash",
             ModelId::ZaiGlm432b0414128k => "GLM 4 32B 0414 128K",
             // Moonshot models
-            ModelId::MoonshotV18k => "Moonshot v1 8K",
-            ModelId::MoonshotV132k => "Moonshot v1 32K",
-            ModelId::MoonshotV1128k => "Moonshot v1 128K",
+            ModelId::MoonshotKimiK2TurboPreview => "Kimi K2 Turbo Preview",
+            ModelId::MoonshotKimiK20905Preview => "Kimi K2 0905 Preview",
+            ModelId::MoonshotKimiK20711Preview => "Kimi K2 0711 Preview",
+            ModelId::MoonshotKimiLatest => "Kimi Latest (auto-tier)",
+            ModelId::MoonshotKimiLatest8k => "Kimi Latest 8K",
+            ModelId::MoonshotKimiLatest32k => "Kimi Latest 32K",
+            ModelId::MoonshotKimiLatest128k => "Kimi Latest 128K",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -589,14 +609,26 @@ impl ModelId {
                 "Legacy GLM 4 32B deployment offering extended 128K context window"
             }
             // Moonshot models
-            ModelId::MoonshotV18k => {
-                "Fast Moonshot v1 deployment tuned for quick iterations with 8K context"
+            ModelId::MoonshotKimiK2TurboPreview => {
+                "Recommended high-speed Kimi K2 turbo variant with 256K context and 60+ tok/s output"
             }
-            ModelId::MoonshotV132k => {
-                "Balanced Moonshot v1 configuration blending speed and 32K context support"
+            ModelId::MoonshotKimiK20905Preview => {
+                "Latest Kimi K2 0905 flagship with enhanced agentic coding, 256K context, and richer tool support"
             }
-            ModelId::MoonshotV1128k => {
-                "Flagship Moonshot v1 model delivering maximum 128K context window"
+            ModelId::MoonshotKimiK20711Preview => {
+                "Kimi K2 0711 preview tuned for balanced cost and capability with 131K context"
+            }
+            ModelId::MoonshotKimiLatest => {
+                "Auto-tier alias that selects the right Kimi Latest vision tier (8K/32K/128K) with context caching"
+            }
+            ModelId::MoonshotKimiLatest8k => {
+                "Kimi Latest 8K vision tier for short tasks with automatic context caching"
+            }
+            ModelId::MoonshotKimiLatest32k => {
+                "Kimi Latest 32K vision tier blending longer context with latest assistant features"
+            }
+            ModelId::MoonshotKimiLatest128k => {
+                "Kimi Latest 128K flagship vision tier delivering maximum context and newest capabilities"
             }
             _ => unreachable!(),
         }
@@ -638,9 +670,13 @@ impl ModelId {
             ModelId::ZaiGlm45Flash,
             ModelId::ZaiGlm432b0414128k,
             // Moonshot models
-            ModelId::MoonshotV18k,
-            ModelId::MoonshotV132k,
-            ModelId::MoonshotV1128k,
+            ModelId::MoonshotKimiK2TurboPreview,
+            ModelId::MoonshotKimiK20905Preview,
+            ModelId::MoonshotKimiK20711Preview,
+            ModelId::MoonshotKimiLatest,
+            ModelId::MoonshotKimiLatest8k,
+            ModelId::MoonshotKimiLatest32k,
+            ModelId::MoonshotKimiLatest128k,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -663,7 +699,7 @@ impl ModelId {
             ModelId::ClaudeOpus41,
             ModelId::ClaudeSonnet45,
             ModelId::DeepSeekReasoner,
-            ModelId::MoonshotV132k,
+            ModelId::MoonshotKimiK20905Preview,
             ModelId::XaiGrok4,
             ModelId::ZaiGlm46,
             ModelId::OpenRouterGrokCodeFast1,
@@ -692,7 +728,7 @@ impl ModelId {
             Provider::OpenAI => ModelId::GPT5,
             Provider::Anthropic => ModelId::ClaudeOpus41,
             Provider::DeepSeek => ModelId::DeepSeekReasoner,
-            Provider::Moonshot => ModelId::MoonshotV132k,
+            Provider::Moonshot => ModelId::MoonshotKimiK20905Preview,
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::ZAI => ModelId::ZaiGlm46,
@@ -706,7 +742,7 @@ impl ModelId {
             Provider::OpenAI => ModelId::GPT5Mini,
             Provider::Anthropic => ModelId::ClaudeSonnet45,
             Provider::DeepSeek => ModelId::DeepSeekChat,
-            Provider::Moonshot => ModelId::MoonshotV18k,
+            Provider::Moonshot => ModelId::MoonshotKimiK2TurboPreview,
             Provider::XAI => ModelId::XaiGrok4Code,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::ZAI => ModelId::ZaiGlm45Flash,
@@ -720,7 +756,7 @@ impl ModelId {
             Provider::OpenAI => ModelId::GPT5,
             Provider::Anthropic => ModelId::ClaudeOpus41,
             Provider::DeepSeek => ModelId::DeepSeekReasoner,
-            Provider::Moonshot => ModelId::MoonshotV132k,
+            Provider::Moonshot => ModelId::MoonshotKimiK2TurboPreview,
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::ZAI => ModelId::ZaiGlm46,
@@ -735,7 +771,8 @@ impl ModelId {
                 | ModelId::Gemini25Flash
                 | ModelId::Gemini25FlashLite
                 | ModelId::ZaiGlm45Flash
-                | ModelId::MoonshotV18k
+                | ModelId::MoonshotKimiK2TurboPreview
+                | ModelId::MoonshotKimiLatest8k
         )
     }
 
@@ -750,7 +787,8 @@ impl ModelId {
                 | ModelId::DeepSeekReasoner
                 | ModelId::XaiGrok4
                 | ModelId::ZaiGlm46
-                | ModelId::MoonshotV1128k
+                | ModelId::MoonshotKimiK20905Preview
+                | ModelId::MoonshotKimiLatest128k
         )
     }
 
@@ -771,7 +809,8 @@ impl ModelId {
                 | ModelId::ZaiGlm45Air
                 | ModelId::ZaiGlm45Airx
                 | ModelId::ZaiGlm45Flash
-                | ModelId::MoonshotV18k
+                | ModelId::MoonshotKimiK2TurboPreview
+                | ModelId::MoonshotKimiLatest8k
         )
     }
 
@@ -792,7 +831,8 @@ impl ModelId {
                 | ModelId::XaiGrok4
                 | ModelId::XaiGrok4CodeLatest
                 | ModelId::ZaiGlm46
-                | ModelId::MoonshotV1128k
+                | ModelId::MoonshotKimiK20905Preview
+                | ModelId::MoonshotKimiLatest128k
         )
     }
 
@@ -834,7 +874,13 @@ impl ModelId {
             | ModelId::ZaiGlm45Flash => "4.5",
             ModelId::ZaiGlm432b0414128k => "4-32B",
             // Moonshot generations
-            ModelId::MoonshotV18k | ModelId::MoonshotV132k | ModelId::MoonshotV1128k => "v1",
+            ModelId::MoonshotKimiK2TurboPreview
+            | ModelId::MoonshotKimiK20905Preview
+            | ModelId::MoonshotKimiK20711Preview => "k2",
+            ModelId::MoonshotKimiLatest
+            | ModelId::MoonshotKimiLatest8k
+            | ModelId::MoonshotKimiLatest32k
+            | ModelId::MoonshotKimiLatest128k => "latest",
             _ => unreachable!(),
         }
     }
@@ -885,9 +931,19 @@ impl FromStr for ModelId {
             s if s == models::zai::GLM_4_5_FLASH => Ok(ModelId::ZaiGlm45Flash),
             s if s == models::zai::GLM_4_32B_0414_128K => Ok(ModelId::ZaiGlm432b0414128k),
             // Moonshot models
-            s if s == models::MOONSHOT_V1_8K => Ok(ModelId::MoonshotV18k),
-            s if s == models::MOONSHOT_V1_32K => Ok(ModelId::MoonshotV132k),
-            s if s == models::MOONSHOT_V1_128K => Ok(ModelId::MoonshotV1128k),
+            s if s == models::MOONSHOT_KIMI_K2_TURBO_PREVIEW => {
+                Ok(ModelId::MoonshotKimiK2TurboPreview)
+            }
+            s if s == models::MOONSHOT_KIMI_K2_0905_PREVIEW => {
+                Ok(ModelId::MoonshotKimiK20905Preview)
+            }
+            s if s == models::MOONSHOT_KIMI_K2_0711_PREVIEW => {
+                Ok(ModelId::MoonshotKimiK20711Preview)
+            }
+            s if s == models::MOONSHOT_KIMI_LATEST => Ok(ModelId::MoonshotKimiLatest),
+            s if s == models::MOONSHOT_KIMI_LATEST_8K => Ok(ModelId::MoonshotKimiLatest8k),
+            s if s == models::MOONSHOT_KIMI_LATEST_32K => Ok(ModelId::MoonshotKimiLatest32k),
+            s if s == models::MOONSHOT_KIMI_LATEST_128K => Ok(ModelId::MoonshotKimiLatest128k),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -1117,16 +1173,40 @@ mod tests {
             ModelId::ZaiGlm432b0414128k
         );
         assert_eq!(
-            models::MOONSHOT_V1_8K.parse::<ModelId>().unwrap(),
-            ModelId::MoonshotV18k
+            models::MOONSHOT_KIMI_K2_TURBO_PREVIEW
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiK2TurboPreview
         );
         assert_eq!(
-            models::MOONSHOT_V1_32K.parse::<ModelId>().unwrap(),
-            ModelId::MoonshotV132k
+            models::MOONSHOT_KIMI_K2_0905_PREVIEW
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiK20905Preview
         );
         assert_eq!(
-            models::MOONSHOT_V1_128K.parse::<ModelId>().unwrap(),
-            ModelId::MoonshotV1128k
+            models::MOONSHOT_KIMI_K2_0711_PREVIEW
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiK20711Preview
+        );
+        assert_eq!(
+            models::MOONSHOT_KIMI_LATEST.parse::<ModelId>().unwrap(),
+            ModelId::MoonshotKimiLatest
+        );
+        assert_eq!(
+            models::MOONSHOT_KIMI_LATEST_8K.parse::<ModelId>().unwrap(),
+            ModelId::MoonshotKimiLatest8k
+        );
+        assert_eq!(
+            models::MOONSHOT_KIMI_LATEST_32K.parse::<ModelId>().unwrap(),
+            ModelId::MoonshotKimiLatest32k
+        );
+        assert_eq!(
+            models::MOONSHOT_KIMI_LATEST_128K
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiLatest128k
         );
         macro_rules! assert_openrouter_parse {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1167,7 +1247,10 @@ mod tests {
         assert_eq!(ModelId::DeepSeekChat.provider(), Provider::DeepSeek);
         assert_eq!(ModelId::XaiGrok4.provider(), Provider::XAI);
         assert_eq!(ModelId::ZaiGlm46.provider(), Provider::ZAI);
-        assert_eq!(ModelId::MoonshotV132k.provider(), Provider::Moonshot);
+        assert_eq!(
+            ModelId::MoonshotKimiK20905Preview.provider(),
+            Provider::Moonshot
+        );
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -1217,7 +1300,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_orchestrator_for_provider(Provider::Moonshot),
-            ModelId::MoonshotV132k
+            ModelId::MoonshotKimiK20905Preview
         );
 
         assert_eq!(
@@ -1250,7 +1333,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_subagent_for_provider(Provider::Moonshot),
-            ModelId::MoonshotV18k
+            ModelId::MoonshotKimiK2TurboPreview
         );
 
         assert_eq!(
@@ -1259,7 +1342,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_single_for_provider(Provider::Moonshot),
-            ModelId::MoonshotV132k
+            ModelId::MoonshotKimiK2TurboPreview
         );
     }
 
@@ -1278,7 +1361,8 @@ mod tests {
         assert!(ModelId::Gemini25FlashLite.is_flash_variant());
         assert!(!ModelId::GPT5.is_flash_variant());
         assert!(ModelId::ZaiGlm45Flash.is_flash_variant());
-        assert!(ModelId::MoonshotV18k.is_flash_variant());
+        assert!(ModelId::MoonshotKimiK2TurboPreview.is_flash_variant());
+        assert!(ModelId::MoonshotKimiLatest8k.is_flash_variant());
 
         // Pro variants
         assert!(ModelId::Gemini25Pro.is_pro_variant());
@@ -1286,7 +1370,8 @@ mod tests {
         assert!(ModelId::GPT5Codex.is_pro_variant());
         assert!(ModelId::DeepSeekReasoner.is_pro_variant());
         assert!(ModelId::ZaiGlm46.is_pro_variant());
-        assert!(ModelId::MoonshotV1128k.is_pro_variant());
+        assert!(ModelId::MoonshotKimiK20905Preview.is_pro_variant());
+        assert!(ModelId::MoonshotKimiLatest128k.is_pro_variant());
         assert!(!ModelId::Gemini25FlashPreview.is_pro_variant());
 
         // Efficient variants
@@ -1299,7 +1384,8 @@ mod tests {
         assert!(ModelId::ZaiGlm45Air.is_efficient_variant());
         assert!(ModelId::ZaiGlm45Airx.is_efficient_variant());
         assert!(ModelId::ZaiGlm45Flash.is_efficient_variant());
-        assert!(ModelId::MoonshotV18k.is_efficient_variant());
+        assert!(ModelId::MoonshotKimiK2TurboPreview.is_efficient_variant());
+        assert!(ModelId::MoonshotKimiLatest8k.is_efficient_variant());
         assert!(!ModelId::GPT5.is_efficient_variant());
 
         macro_rules! assert_openrouter_efficiency {
@@ -1319,7 +1405,8 @@ mod tests {
         assert!(ModelId::XaiGrok4CodeLatest.is_top_tier());
         assert!(ModelId::DeepSeekReasoner.is_top_tier());
         assert!(ModelId::ZaiGlm46.is_top_tier());
-        assert!(ModelId::MoonshotV1128k.is_top_tier());
+        assert!(ModelId::MoonshotKimiK20905Preview.is_top_tier());
+        assert!(ModelId::MoonshotKimiLatest128k.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
 
         macro_rules! assert_openrouter_top_tier {
@@ -1368,9 +1455,13 @@ mod tests {
         assert_eq!(ModelId::ZaiGlm45Airx.generation(), "4.5");
         assert_eq!(ModelId::ZaiGlm45Flash.generation(), "4.5");
         assert_eq!(ModelId::ZaiGlm432b0414128k.generation(), "4-32B");
-        assert_eq!(ModelId::MoonshotV18k.generation(), "v1");
-        assert_eq!(ModelId::MoonshotV132k.generation(), "v1");
-        assert_eq!(ModelId::MoonshotV1128k.generation(), "v1");
+        assert_eq!(ModelId::MoonshotKimiK2TurboPreview.generation(), "k2");
+        assert_eq!(ModelId::MoonshotKimiK20905Preview.generation(), "k2");
+        assert_eq!(ModelId::MoonshotKimiK20711Preview.generation(), "k2");
+        assert_eq!(ModelId::MoonshotKimiLatest.generation(), "latest");
+        assert_eq!(ModelId::MoonshotKimiLatest8k.generation(), "latest");
+        assert_eq!(ModelId::MoonshotKimiLatest32k.generation(), "latest");
+        assert_eq!(ModelId::MoonshotKimiLatest128k.generation(), "latest");
 
         macro_rules! assert_openrouter_generation {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1425,10 +1516,14 @@ mod tests {
         assert!(zai_models.contains(&ModelId::ZaiGlm432b0414128k));
 
         let moonshot_models = ModelId::models_for_provider(Provider::Moonshot);
-        assert!(moonshot_models.contains(&ModelId::MoonshotV18k));
-        assert!(moonshot_models.contains(&ModelId::MoonshotV132k));
-        assert!(moonshot_models.contains(&ModelId::MoonshotV1128k));
-        assert_eq!(moonshot_models.len(), 3);
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK2TurboPreview));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20905Preview));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20711Preview));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest8k));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest32k));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest128k));
+        assert_eq!(moonshot_models.len(), 7);
     }
 
     #[test]
@@ -1440,7 +1535,7 @@ mod tests {
         assert!(fallbacks.contains(&ModelId::ClaudeOpus41));
         assert!(fallbacks.contains(&ModelId::ClaudeSonnet45));
         assert!(fallbacks.contains(&ModelId::DeepSeekReasoner));
-        assert!(fallbacks.contains(&ModelId::MoonshotV132k));
+        assert!(fallbacks.contains(&ModelId::MoonshotKimiK20905Preview));
         assert!(fallbacks.contains(&ModelId::XaiGrok4));
         assert!(fallbacks.contains(&ModelId::ZaiGlm46));
         assert!(fallbacks.contains(&ModelId::OpenRouterGrokCodeFast1));

--- a/vtcode-core/src/llm/factory.rs
+++ b/vtcode-core/src/llm/factory.rs
@@ -215,7 +215,7 @@ impl LLMFactory {
             Some("xai".to_string())
         } else if m.starts_with("glm-") {
             Some("zai".to_string())
-        } else if m.starts_with("moonshot-") {
+        } else if m.starts_with("moonshot-") || m.starts_with("kimi-") {
             Some("moonshot".to_string())
         } else if m.contains('/') || m.contains('@') {
             Some("openrouter".to_string())

--- a/vtcode-core/src/ui/tui.rs
+++ b/vtcode-core/src/ui/tui.rs
@@ -12,7 +12,7 @@ pub use style::{convert_style, theme_from_styles};
 pub use types::{
     InlineCommand, InlineEvent, InlineHandle, InlineHeaderContext, InlineHeaderHighlight,
     InlineListItem, InlineListSelection, InlineMessageKind, InlineSegment, InlineSession,
-    InlineTextStyle, InlineTheme,
+    InlineTextStyle, InlineTheme, SecurePromptConfig,
 };
 
 use tui::run_tui;

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -2081,7 +2081,9 @@ impl Session {
             restore_input: self.input_enabled,
             restore_cursor: self.cursor_visible,
         };
-        self.input_enabled = false;
+        if state.secure_prompt.is_none() {
+            self.input_enabled = false;
+        }
         self.cursor_visible = false;
         self.modal = Some(state);
         self.mark_dirty();

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -7,13 +7,16 @@ use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Position, Rect},
     style::{Color, Modifier, Style},
-    text::{Line, Span},
+    symbols::border,
+    text::{Line, Span, Text},
     widgets::{
         Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Widget, Wrap,
     },
 };
 use terminal_size::{Height, Width, terminal_size};
 use tokio::sync::mpsc::UnboundedSender;
+use tui_popup::{Popup, PopupState, SizedWrapper};
+use tui_prompts::{Prompt, State, TextPrompt, TextRenderStyle, TextState};
 use tui_scrollview::ScrollViewState;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
@@ -21,6 +24,7 @@ use unicode_width::UnicodeWidthStr;
 use super::types::{
     InlineCommand, InlineEvent, InlineHeaderContext, InlineHeaderHighlight, InlineListItem,
     InlineListSelection, InlineMessageKind, InlineSegment, InlineTextStyle, InlineTheme,
+    SecurePromptConfig,
 };
 use crate::config::constants::ui;
 use crate::ui::slash::{SlashCommandInfo, suggestions_for};
@@ -46,6 +50,8 @@ struct ModalState {
     title: String,
     lines: Vec<String>,
     list: Option<ModalListState>,
+    secure_prompt: Option<SecurePromptConfig>,
+    popup_state: PopupState,
     restore_input: bool,
     restore_cursor: bool,
 }
@@ -108,7 +114,13 @@ fn terminal_dimensions() -> Option<(u16, u16)> {
     terminal_size().map(|(Width(width), Height(height))| (width, height))
 }
 
-fn compute_modal_area(viewport: Rect, width_hint: u16, text_lines: usize, has_list: bool) -> Rect {
+fn compute_modal_area(
+    viewport: Rect,
+    width_hint: u16,
+    text_lines: usize,
+    prompt_lines: usize,
+    has_list: bool,
+) -> Rect {
     if viewport.width == 0 || viewport.height == 0 {
         return Rect::new(viewport.x, viewport.y, 0, 0);
     }
@@ -140,7 +152,8 @@ fn compute_modal_area(viewport: Rect, width_hint: u16, text_lines: usize, has_li
         .max(ratio_width);
     width = width.min(max_width.max(min_width)).min(available_width);
 
-    let text_height = text_lines as u16;
+    let total_lines = text_lines.saturating_add(prompt_lines);
+    let text_height = total_lines as u16;
     let mut height = text_height
         .saturating_add(ui::MODAL_CONTENT_VERTICAL_PADDING)
         .max(min_height)
@@ -155,7 +168,11 @@ fn compute_modal_area(viewport: Rect, width_hint: u16, text_lines: usize, has_li
     Rect::new(x, y, width, height)
 }
 
-fn modal_content_width(lines: &[String], list: Option<&ModalListState>) -> u16 {
+fn modal_content_width(
+    lines: &[String],
+    list: Option<&ModalListState>,
+    secure_prompt: Option<&SecurePromptConfig>,
+) -> u16 {
     let mut width = lines
         .iter()
         .map(|line| UnicodeWidthStr::width(line.as_str()) as u16)
@@ -186,6 +203,12 @@ fn modal_content_width(lines: &[String], list: Option<&ModalListState>) -> u16 {
         }
     }
 
+    if let Some(prompt) = secure_prompt {
+        let label_width = measure_text_width(prompt.label.as_str());
+        let prompt_width = label_width.saturating_add(6).max(ui::MODAL_MIN_WIDTH);
+        width = width.max(prompt_width);
+    }
+
     width
 }
 
@@ -196,24 +219,114 @@ fn measure_text_width(text: &str) -> u16 {
 fn render_modal_list(
     frame: &mut Frame<'_>,
     area: Rect,
-    text_lines: &[Line<'static>],
     list: &mut ModalListState,
     styles: &ModalRenderStyles,
 ) {
-    let layout = ModalListLayout::new(area, text_lines.len());
-    if let Some(text_area) = layout.text_area {
-        if text_area.height > 0 && !text_lines.is_empty() {
-            let paragraph = Paragraph::new(text_lines.to_vec()).wrap(Wrap { trim: false });
-            frame.render_widget(paragraph, text_area);
-        }
-    }
-
-    list.ensure_visible(layout.list_area.height);
+    list.ensure_visible(area.height);
     let items = modal_list_items(list, styles);
     let widget = List::new(items)
         .block(Block::default())
         .highlight_style(styles.highlight.clone());
-    frame.render_stateful_widget(widget, layout.list_area, &mut list.list_state);
+    frame.render_stateful_widget(widget, area, &mut list.list_state);
+}
+
+#[derive(Clone, Copy)]
+enum ModalSection {
+    Instructions,
+    Prompt,
+    List,
+}
+
+fn render_modal_body(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    text_lines: &[Line<'static>],
+    list: Option<&mut ModalListState>,
+    styles: &ModalRenderStyles,
+    secure_prompt: Option<&SecurePromptConfig>,
+    input: &str,
+    cursor: usize,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let mut sections = Vec::new();
+    if !text_lines.is_empty() {
+        sections.push(ModalSection::Instructions);
+    }
+    if secure_prompt.is_some() {
+        sections.push(ModalSection::Prompt);
+    }
+    if list.is_some() {
+        sections.push(ModalSection::List);
+    }
+
+    if sections.is_empty() {
+        return;
+    }
+
+    let mut constraints = Vec::new();
+    for section in &sections {
+        match section {
+            ModalSection::Instructions => {
+                let height = text_lines.len().max(1) as u16;
+                constraints.push(Constraint::Length(height.min(area.height)));
+            }
+            ModalSection::Prompt => {
+                constraints.push(Constraint::Length(3.min(area.height)));
+            }
+            ModalSection::List => constraints.push(Constraint::Min(3)),
+        }
+    }
+
+    let chunks = Layout::vertical(constraints).split(area);
+    let mut list_state = list;
+
+    for (section, chunk) in sections.into_iter().zip(chunks.iter()) {
+        match section {
+            ModalSection::Instructions => {
+                if chunk.height > 0 && !text_lines.is_empty() {
+                    let paragraph = Paragraph::new(text_lines.to_vec()).wrap(Wrap { trim: false });
+                    frame.render_widget(paragraph, *chunk);
+                }
+            }
+            ModalSection::Prompt => {
+                if let Some(config) = secure_prompt {
+                    render_secure_prompt(frame, *chunk, config, input, cursor);
+                }
+            }
+            ModalSection::List => {
+                if let Some(list_state) = list_state.as_mut() {
+                    render_modal_list(frame, *chunk, list_state, styles);
+                }
+            }
+        }
+    }
+}
+
+fn render_secure_prompt(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    config: &SecurePromptConfig,
+    input: &str,
+    cursor: usize,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let grapheme_count = input.chars().count();
+    let sanitized: String = std::iter::repeat('•').take(grapheme_count).collect();
+    let cursor_chars = input[..cursor].chars().count();
+
+    let mut state = TextState::new().with_value(sanitized);
+    state.focus();
+    *state.position_mut() = cursor_chars;
+
+    let prompt =
+        TextPrompt::from(config.label.clone()).with_render_style(TextRenderStyle::Password);
+    prompt.draw(frame, area, &mut state);
 }
 
 fn modal_list_items(list: &ModalListState, styles: &ModalRenderStyles) -> Vec<ListItem<'static>> {
@@ -553,8 +666,12 @@ impl Session {
             InlineCommand::ForceRedraw => {
                 self.mark_dirty();
             }
-            InlineCommand::ShowModal { title, lines } => {
-                self.show_modal(title, lines);
+            InlineCommand::ShowModal {
+                title,
+                lines,
+                secure_prompt,
+            } => {
+                self.show_modal(title, lines, secure_prompt);
             }
             InlineCommand::ShowListModal {
                 title,
@@ -1232,7 +1349,7 @@ impl Session {
         }
 
         let instructions = self.slash_palette_instructions();
-        let area = compute_modal_area(viewport, width_hint, instructions.len(), true);
+        let area = compute_modal_area(viewport, width_hint, instructions.len(), 0, true);
 
         frame.render_widget(Clear, area);
         let block = Block::default()
@@ -1310,6 +1427,12 @@ impl Session {
         let prompt_style = ratatui_style_from_inline(&prompt_style, self.theme.foreground);
         spans.push(Span::styled(self.prompt_prefix.clone(), prompt_style));
 
+        let secure_prompt_active = self
+            .modal
+            .as_ref()
+            .and_then(|modal| modal.secure_prompt.as_ref())
+            .is_some();
+
         if self.input.is_empty() {
             if let Some(placeholder) = &self.placeholder {
                 let placeholder_style =
@@ -1326,6 +1449,13 @@ impl Session {
                 );
                 spans.push(Span::styled(placeholder.clone(), style));
             }
+        } else if secure_prompt_active {
+            let accent_style = self.accent_inline_style();
+            let style = ratatui_style_from_inline(&accent_style, self.theme.foreground);
+            let masked: String = std::iter::repeat('•')
+                .take(self.input.chars().count())
+                .collect();
+            spans.push(Span::styled(masked, style));
         } else {
             let accent_style = self.accent_inline_style();
             let style = ratatui_style_from_inline(&accent_style, self.theme.foreground);
@@ -1912,8 +2042,12 @@ impl Session {
 
     fn cursor_position(&self, area: Rect) -> (u16, u16) {
         let prompt_width = UnicodeWidthStr::width(self.prompt_prefix.as_str()) as u16;
-        let before_cursor = &self.input[..self.cursor];
-        let cursor_width = UnicodeWidthStr::width(before_cursor) as u16;
+        let cursor_width = if self.secure_prompt_active() {
+            u16::try_from(self.input[..self.cursor].chars().count()).unwrap_or(u16::MAX)
+        } else {
+            let before_cursor = &self.input[..self.cursor];
+            UnicodeWidthStr::width(before_cursor) as u16
+        };
         (area.x + prompt_width + cursor_width, area.y)
     }
 
@@ -1921,15 +2055,29 @@ impl Session {
         self.cursor_visible && self.input_enabled
     }
 
+    fn secure_prompt_active(&self) -> bool {
+        self.modal
+            .as_ref()
+            .and_then(|modal| modal.secure_prompt.as_ref())
+            .is_some()
+    }
+
     pub fn mark_dirty(&mut self) {
         self.needs_redraw = true;
     }
 
-    fn show_modal(&mut self, title: String, lines: Vec<String>) {
+    fn show_modal(
+        &mut self,
+        title: String,
+        lines: Vec<String>,
+        secure_prompt: Option<SecurePromptConfig>,
+    ) {
         let state = ModalState {
             title,
             lines,
             list: None,
+            secure_prompt,
+            popup_state: PopupState::default(),
             restore_input: self.input_enabled,
             restore_cursor: self.cursor_visible,
         };
@@ -1951,6 +2099,8 @@ impl Session {
             title,
             lines,
             list: Some(list_state),
+            secure_prompt: None,
+            popup_state: PopupState::default(),
             restore_input: self.input_enabled,
             restore_cursor: self.cursor_visible,
         };
@@ -1977,22 +2127,52 @@ impl Session {
         let Some(modal) = self.modal.as_mut() else {
             return;
         };
-        let width_hint = modal_content_width(&modal.lines, modal.list.as_ref());
+
+        let width_hint = modal_content_width(
+            &modal.lines,
+            modal.list.as_ref(),
+            modal.secure_prompt.as_ref(),
+        );
+        let prompt_lines = modal.secure_prompt.is_some().then_some(2).unwrap_or(0);
         let area = compute_modal_area(
             viewport,
             width_hint,
             modal.lines.len(),
+            prompt_lines,
             modal.list.is_some(),
         );
 
         frame.render_widget(Clear, area);
-        let block = Block::default()
+
+        let body = SizedWrapper {
+            inner: Text::raw(""),
+            width: area.width as usize,
+            height: area.height as usize,
+        };
+
+        let popup = Popup::new(body)
+            .title(Line::styled(modal.title.clone(), styles.title.clone()))
             .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .title(Span::styled(modal.title.clone(), styles.title.clone()))
+            .border_set(border::ROUNDED)
             .border_style(styles.border.clone());
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+
+        frame.render_stateful_widget_ref(popup, viewport, &mut modal.popup_state);
+
+        let Some(popup_area) = modal.popup_state.area() else {
+            return;
+        };
+
+        if popup_area.width <= 2 || popup_area.height <= 2 {
+            return;
+        }
+
+        let inner = Rect {
+            x: popup_area.x.saturating_add(1),
+            y: popup_area.y.saturating_add(1),
+            width: popup_area.width.saturating_sub(2),
+            height: popup_area.height.saturating_sub(2),
+        };
+
         if inner.width == 0 || inner.height == 0 {
             return;
         }
@@ -2003,13 +2183,16 @@ impl Session {
             .map(|line| Line::from(Span::raw(line.clone())))
             .collect();
 
-        match modal.list.as_mut() {
-            Some(list) => render_modal_list(frame, inner, &text_lines, list, &styles),
-            None => {
-                let paragraph = Paragraph::new(text_lines).wrap(Wrap { trim: false });
-                frame.render_widget(paragraph, inner);
-            }
-        }
+        render_modal_body(
+            frame,
+            inner,
+            &text_lines,
+            modal.list.as_mut(),
+            &styles,
+            modal.secure_prompt.as_ref(),
+            &self.input,
+            self.cursor,
+        );
     }
 
     fn modal_render_styles(&self) -> ModalRenderStyles {

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -141,6 +141,11 @@ pub struct InlineListItem {
     pub selection: Option<InlineListSelection>,
 }
 
+#[derive(Clone, Debug)]
+pub struct SecurePromptConfig {
+    pub label: String,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InlineMessageKind {
     Agent,
@@ -192,6 +197,7 @@ pub enum InlineCommand {
     ShowModal {
         title: String,
         lines: Vec<String>,
+        secure_prompt: Option<SecurePromptConfig>,
     },
     ShowListModal {
         title: String,
@@ -303,8 +309,17 @@ impl InlineHandle {
         let _ = self.sender.send(InlineCommand::Shutdown);
     }
 
-    pub fn show_modal(&self, title: String, lines: Vec<String>) {
-        let _ = self.sender.send(InlineCommand::ShowModal { title, lines });
+    pub fn show_modal(
+        &self,
+        title: String,
+        lines: Vec<String>,
+        secure_prompt: Option<SecurePromptConfig>,
+    ) {
+        let _ = self.sender.send(InlineCommand::ShowModal {
+            title,
+            lines,
+            secure_prompt,
+        });
     }
 
     pub fn show_list_modal(

--- a/vtcode-core/src/utils/ansi.rs
+++ b/vtcode-core/src/utils/ansi.rs
@@ -3,7 +3,8 @@ use crate::ui::markdown::{MarkdownLine, MarkdownSegment, render_markdown_to_line
 use crate::ui::theme;
 use crate::ui::tui::{
     InlineHandle, InlineListItem, InlineListSelection, InlineMessageKind, InlineSegment,
-    InlineTextStyle, convert_style as convert_to_inline_style, theme_from_styles,
+    InlineTextStyle, SecurePromptConfig, convert_style as convert_to_inline_style,
+    theme_from_styles,
 };
 use crate::utils::transcript;
 use anstream::{AutoStream, ColorChoice};
@@ -143,6 +144,17 @@ impl AnsiRenderer {
     ) {
         if let Some(sink) = &self.sink {
             sink.show_list_modal(title.to_string(), lines, items, selected);
+        }
+    }
+
+    pub fn show_secure_prompt_modal(
+        &mut self,
+        title: &str,
+        lines: Vec<String>,
+        prompt_label: String,
+    ) {
+        if let Some(sink) = &self.sink {
+            sink.show_secure_prompt_modal(title.to_string(), lines, prompt_label);
         }
     }
 
@@ -401,6 +413,16 @@ impl InlineSink {
         selected: Option<InlineListSelection>,
     ) {
         self.handle.show_list_modal(title, lines, items, selected);
+    }
+
+    fn show_secure_prompt_modal(&self, title: String, lines: Vec<String>, prompt_label: String) {
+        self.handle.show_modal(
+            title,
+            lines,
+            Some(SecurePromptConfig {
+                label: prompt_label,
+            }),
+        );
     }
 
     fn close_modal(&self) {


### PR DESCRIPTION
## Summary
- replace Moonshot v1 listings with the latest kimi-k2 and kimi-latest variants in model metadata and documentation
- refresh Moonshot constants, model IDs, and provider detection/tests to use the new identifiers
- add blank separators between providers in the model picker for clearer grouping
- move the OpenAI and Anthropic sections to the top of the model picker modal for quicker access

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e699088e2883238c73ca384f515a43