### PR TITLE
Improve TUI markdown rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +297,12 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -378,6 +390,12 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -491,6 +509,12 @@ dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "compact_str"
@@ -671,7 +695,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -687,7 +711,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "mio 1.0.4",
  "parking_lot",
@@ -926,6 +950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1057,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1648,8 +1689,17 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
  "libc",
 ]
 
@@ -1747,7 +1797,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -1757,7 +1807,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bd35dcd25f8578944c44cd75649d6487d74cf895002f6d86613164f2635b72"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1837,6 +1887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,13 +1969,39 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -1979,7 +2064,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -2019,7 +2104,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2047,7 +2132,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2233,6 +2318,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,7 +2429,7 @@ checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
  "indexmap",
- "nix",
+ "nix 0.30.1",
  "tokio",
  "tracing",
  "windows",
@@ -2314,7 +2441,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "memchr",
  "unicase",
 ]
@@ -2325,7 +2452,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -2366,7 +2493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2406,7 +2533,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -2494,7 +2621,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2544,7 +2671,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -2676,6 +2803,19 @@ dependencies = [
  "pin-project-lite",
  "reqwest",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rexpect"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1bcd4ac488e9d2d726d147031cceff5cff6425011ff1914049739770fa4726"
+dependencies = [
+ "comma",
+ "nix 0.30.1",
+ "regex",
+ "tempfile",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2853,7 +2993,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2866,7 +3006,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2986,7 +3126,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3099,6 +3239,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
+name = "serial2"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc76fa68e25e771492ca1e3c53d447ef0be3093e05cd3b47f4b712ba10c6f3c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,6 +3309,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -3319,7 +3522,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3355,6 +3558,15 @@ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix 1.1.2",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3636,7 +3848,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http",
@@ -3881,6 +4093,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-term"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72af159125ce32b02ceaced6cffae6394b0e6b6dfd4dc164a6c59a2db9b3c0b0"
+dependencies = [
+ "portable-pty 0.8.1",
+ "ratatui",
+ "vt100",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4041,6 +4264,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vt100"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+dependencies = [
+ "itoa",
+ "log",
+ "unicode-width 0.1.14",
+ "vte",
+]
+
+[[package]]
 name = "vtcode"
 version = "0.21.1"
 dependencies = [
@@ -4119,12 +4354,14 @@ dependencies = [
  "nucleo-matcher",
  "once_cell",
  "parking_lot",
+ "portable-pty 0.9.0",
  "pulldown-cmark 0.9.6",
  "quick_cache",
  "rand 0.8.5",
  "ratatui",
  "regex",
  "reqwest",
+ "rexpect",
  "rig-core",
  "rmcp",
  "roff",
@@ -4154,9 +4391,31 @@ dependencies = [
  "tui-popup",
  "tui-prompts",
  "tui-scrollview",
+ "tui-term",
  "unicode-segmentation",
  "unicode-width 0.2.0",
  "walkdir",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -4744,6 +5003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi-to-tui"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
+dependencies = [
+ "nom",
+ "ratatui",
+ "simdutf8",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1183,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2220,6 +2248,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2309,25 @@ dependencies = [
  "memchr",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-xml"
@@ -2702,7 +2759,19 @@ checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
 dependencies = [
  "futures",
  "futures-timer",
- "rstest_macros",
+ "rstest_macros 0.23.0",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros 0.25.0",
  "rustc_version",
 ]
 
@@ -2711,6 +2780,24 @@ name = "rstest_macros"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",
@@ -3064,6 +3151,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -3728,6 +3821,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-markdown"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10648c25931bfaaf5334ff4e7dc5f3d830e0c50d7b0119b1d5cfe771f540536"
+dependencies = [
+ "ansi-to-tui",
+ "itertools 0.14.0",
+ "pretty_assertions",
+ "pulldown-cmark 0.13.0",
+ "ratatui",
+ "rstest 0.25.0",
+ "syntect",
+ "tracing",
+]
+
+[[package]]
 name = "tui-popup"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3748,7 +3857,7 @@ dependencies = [
  "itertools 0.13.0",
  "ratatui",
  "ratatui-macros",
- "rstest",
+ "rstest 0.23.0",
 ]
 
 [[package]]
@@ -3759,7 +3868,7 @@ checksum = "ef6e1d736488ba64c2e74637089a6b9ca666ccd2eaade3ab83854f415f1d260b"
 dependencies = [
  "indoc",
  "ratatui",
- "rstest",
+ "rstest 0.23.0",
 ]
 
 [[package]]
@@ -4000,7 +4109,7 @@ dependencies = [
  "nucleo-matcher",
  "once_cell",
  "parking_lot",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.6",
  "quick_cache",
  "rand 0.8.5",
  "ratatui",
@@ -4031,6 +4140,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+ "tui-markdown",
  "tui-popup",
  "tui-prompts",
  "tui-scrollview",
@@ -4646,6 +4756,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9bd35dcd25f8578944c44cd75649d6487d74cf895002f6d86613164f2635b72"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4106,6 +4115,7 @@ dependencies = [
  "indexmap",
  "is-terminal",
  "itertools 0.14.0",
+ "line-clipping",
  "nucleo-matcher",
  "once_cell",
  "parking_lot",

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -99,6 +99,9 @@ pulldown-cmark = { version = "0.9", default-features = false, features = [
 catppuccin = { version = "2.5", default-features = false }
 similar = "2.4"
 rig = { package = "rig-core", version = "0.21", default-features = false, features = ["reqwest-rustls"] }
+tui-term = { version = "0.2.0", features = ["unstable"] }
+portable-pty = "0.9.0"
+rexpect = "0.6.2"
 
 # MCP (Model Context Protocol) support
 rmcp = { version = "0.7.0", features = ["client", "transport-child-process"] }

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -86,6 +86,7 @@ ratatui = { version = "0.29", default-features = false, features = [
     "unstable-rendered-line-info",
     "unstable-widget-ref",
 ] }
+tui-markdown = { version = "0.3.5", default-features = false, features = ["highlight-code"] }
 tui-scrollview = "0.5.1"
 tui-popup = "0.6"
 tui-prompts = "0.5"

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -92,6 +92,7 @@ tui-popup = "0.6"
 tui-prompts = "0.5"
 ignore = "0.4"
 nucleo-matcher = "0.3"
+line-clipping = "0.3"
 pulldown-cmark = { version = "0.9", default-features = false, features = [
     "simd",
 ] }

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -581,6 +581,10 @@ pub mod tools {
     pub const GREP_SEARCH: &str = "grep_search";
     pub const LIST_FILES: &str = "list_files";
     pub const RUN_TERMINAL_CMD: &str = "run_terminal_cmd";
+    pub const RUN_PTY_CMD: &str = "run_pty_cmd";
+    pub const CREATE_PTY_SESSION: &str = "create_pty_session";
+    pub const LIST_PTY_SESSIONS: &str = "list_pty_sessions";
+    pub const CLOSE_PTY_SESSION: &str = "close_pty_session";
     pub const READ_FILE: &str = "read_file";
     pub const WRITE_FILE: &str = "write_file";
     pub const EDIT_FILE: &str = "edit_file";

--- a/vtcode-core/src/tools/mod.rs
+++ b/vtcode-core/src/tools/mod.rs
@@ -134,6 +134,7 @@ pub mod file_ops;
 pub mod file_search;
 pub mod grep_search;
 pub mod plan;
+pub mod pty;
 pub mod registry;
 pub mod search;
 pub mod simple_search;
@@ -152,6 +153,7 @@ pub use plan::{
     PlanCompletionState, PlanManager, PlanStep, PlanSummary, PlanUpdateResult, StepStatus,
     TaskPlan, UpdatePlanArgs,
 };
+pub use pty::{PtyCommandRequest, PtyCommandResult, PtyManager};
 pub use registry::{ToolRegistration, ToolRegistry};
 pub use simple_search::SimpleSearchTool;
 pub use srgn::SrgnTool;

--- a/vtcode-core/src/tools/pty.rs
+++ b/vtcode-core/src/tools/pty.rs
@@ -219,9 +219,7 @@ impl PtyManager {
         let mut reader = master
             .try_clone_reader()
             .context("failed to clone PTY reader")?;
-        let writer = master
-            .take_writer()
-            .context("failed to take PTY writer")?;
+        let writer = master.take_writer().context("failed to take PTY writer")?;
 
         let parser = Arc::new(Mutex::new(Parser::new(size.rows, size.cols, 0)));
         let parser_clone = Arc::clone(&parser);
@@ -347,10 +345,9 @@ fn wait_status_code(status: WaitStatus) -> i32 {
     match status {
         WaitStatus::Exited(_, code) => code,
         WaitStatus::Signaled(_, signal, _) | WaitStatus::Stopped(_, signal) => -(signal as i32),
-        WaitStatus::StillAlive
-        | WaitStatus::Continued(_)
-        | WaitStatus::PtraceEvent(_, _, _)
-        | WaitStatus::PtraceSyscall(_) => 0,
+        WaitStatus::StillAlive | WaitStatus::Continued(_) => 0,
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        WaitStatus::PtraceEvent(_, _, _) | WaitStatus::PtraceSyscall(_) => 0,
     }
 }
 

--- a/vtcode-core/src/tools/pty.rs
+++ b/vtcode-core/src/tools/pty.rs
@@ -1,0 +1,371 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow};
+use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+use rexpect::{
+    process::wait::WaitStatus,
+    session::{Options, spawn_with_options},
+};
+use tracing::{debug, warn};
+use tui_term::vt100::Parser;
+
+use crate::config::PtyConfig;
+use crate::tools::types::VTCodePtySession;
+
+#[derive(Clone)]
+pub struct PtyManager {
+    workspace_root: PathBuf,
+    config: PtyConfig,
+    inner: Arc<PtyState>,
+}
+
+#[derive(Default)]
+struct PtyState {
+    sessions: Mutex<HashMap<String, PtySessionHandle>>,
+}
+
+struct PtySessionHandle {
+    master: Box<dyn MasterPty + Send>,
+    child: Mutex<Box<dyn Child + Send>>,
+    writer: Mutex<Option<Box<dyn Write + Send>>>,
+    parser: Arc<Mutex<Parser>>,
+    reader_thread: Mutex<Option<JoinHandle<()>>>,
+    metadata: VTCodePtySession,
+}
+
+impl PtySessionHandle {
+    fn snapshot_metadata(&self) -> VTCodePtySession {
+        let mut metadata = self.metadata.clone();
+        if let Ok(size) = self.master.get_size() {
+            metadata.rows = size.rows;
+            metadata.cols = size.cols;
+        }
+        if let Ok(parser) = self.parser.lock() {
+            metadata.screen_contents = Some(parser.screen().contents());
+        }
+        metadata
+    }
+}
+
+pub struct PtyCommandRequest {
+    pub command: Vec<String>,
+    pub working_dir: PathBuf,
+    pub timeout: Duration,
+    pub size: PtySize,
+}
+
+pub struct PtyCommandResult {
+    pub exit_code: i32,
+    pub output: String,
+    pub duration: Duration,
+    pub size: PtySize,
+}
+
+impl PtyManager {
+    pub fn new(workspace_root: PathBuf, config: PtyConfig) -> Self {
+        let resolved_root = workspace_root
+            .canonicalize()
+            .unwrap_or(workspace_root.clone());
+
+        Self {
+            workspace_root: resolved_root,
+            config,
+            inner: Arc::new(PtyState::default()),
+        }
+    }
+
+    pub fn config(&self) -> &PtyConfig {
+        &self.config
+    }
+
+    pub fn describe_working_dir(&self, path: &Path) -> String {
+        self.format_working_dir(path)
+    }
+
+    pub async fn run_command(&self, request: PtyCommandRequest) -> Result<PtyCommandResult> {
+        if request.command.is_empty() {
+            return Err(anyhow!("PTY command cannot be empty"));
+        }
+
+        let mut command = request.command.clone();
+        let program = command.remove(0);
+        let args = command;
+        let timeout = clamp_timeout(request.timeout);
+        let work_dir = request.working_dir.clone();
+        let size = request.size;
+        let start = Instant::now();
+
+        let result = tokio::task::spawn_blocking(move || -> Result<PtyCommandResult> {
+            let mut cmd = std::process::Command::new(&program);
+            cmd.args(&args);
+            cmd.current_dir(&work_dir);
+            cmd.env("TERM", "xterm-256color");
+            cmd.env("COLUMNS", size.cols.to_string());
+            cmd.env("LINES", size.rows.to_string());
+
+            let options = Options {
+                timeout_ms: Some(timeout),
+                strip_ansi_escape_codes: false,
+            };
+
+            let mut session = spawn_with_options(cmd, options)
+                .with_context(|| format!("failed to spawn PTY command '{program}'"))?;
+
+            let mut output = String::new();
+            let collected = session
+                .exp_eof()
+                .context("failed to read PTY command output")?;
+            output.push_str(&collected);
+
+            let status = session
+                .process
+                .wait()
+                .context("failed to wait for PTY command to exit")?;
+            let exit_code = wait_status_code(status);
+
+            Ok(PtyCommandResult {
+                exit_code,
+                output,
+                duration: start.elapsed(),
+                size,
+            })
+        })
+        .await
+        .context("failed to join PTY command task")??;
+
+        Ok(result)
+    }
+
+    pub fn resolve_working_dir(&self, requested: Option<&str>) -> Result<PathBuf> {
+        let requested = match requested {
+            Some(dir) if !dir.trim().is_empty() => dir,
+            _ => return Ok(self.workspace_root.clone()),
+        };
+
+        let candidate = self.workspace_root.join(requested);
+        let normalized = normalize_path(&candidate);
+        if !normalized.starts_with(&self.workspace_root) {
+            return Err(anyhow!(
+                "Working directory '{}' escapes the workspace root",
+                candidate.display()
+            ));
+        }
+        let metadata = fs::metadata(&normalized).with_context(|| {
+            format!(
+                "Working directory '{}' does not exist",
+                normalized.display()
+            )
+        })?;
+        if !metadata.is_dir() {
+            return Err(anyhow!(
+                "Working directory '{}' is not a directory",
+                normalized.display()
+            ));
+        }
+        Ok(normalized)
+    }
+
+    pub fn create_session(
+        &self,
+        session_id: String,
+        command: Vec<String>,
+        working_dir: PathBuf,
+        size: PtySize,
+    ) -> Result<VTCodePtySession> {
+        if command.is_empty() {
+            return Err(anyhow!("PTY session command cannot be empty"));
+        }
+
+        let mut sessions = self
+            .inner
+            .sessions
+            .lock()
+            .expect("PTY session mutex poisoned");
+        if sessions.contains_key(&session_id) {
+            return Err(anyhow!("PTY session '{}' already exists", session_id));
+        }
+
+        let mut command_parts = command.clone();
+        let program = command_parts.remove(0);
+        let args = command_parts;
+
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(size)
+            .context("failed to allocate PTY pair")?;
+
+        let mut builder = CommandBuilder::new(program.clone());
+        for arg in &args {
+            builder.arg(arg);
+        }
+        builder.cwd(&working_dir);
+        builder.env("TERM", "xterm-256color");
+        builder.env("COLUMNS", size.cols.to_string());
+        builder.env("LINES", size.rows.to_string());
+
+        let child = pair
+            .slave
+            .spawn_command(builder)
+            .context("failed to spawn PTY session command")?;
+        drop(pair.slave);
+
+        let master = pair.master;
+        let mut reader = master
+            .try_clone_reader()
+            .context("failed to clone PTY reader")?;
+        let writer = master
+            .take_writer()
+            .context("failed to take PTY writer")?;
+
+        let parser = Arc::new(Mutex::new(Parser::new(size.rows, size.cols, 0)));
+        let parser_clone = Arc::clone(&parser);
+        let session_name = session_id.clone();
+        let reader_thread = thread::Builder::new()
+            .name(format!("vtcode-pty-reader-{session_name}"))
+            .spawn(move || {
+                let mut buffer = [0u8; 4096];
+                loop {
+                    match reader.read(&mut buffer) {
+                        Ok(0) => {
+                            debug!("PTY session '{}' reader reached EOF", session_name);
+                            break;
+                        }
+                        Ok(bytes_read) => {
+                            if let Ok(mut parser) = parser_clone.lock() {
+                                parser.process(&buffer[..bytes_read]);
+                            }
+                        }
+                        Err(error) => {
+                            warn!("PTY session '{}' reader error: {}", session_name, error);
+                            break;
+                        }
+                    }
+                }
+            })
+            .context("failed to spawn PTY reader thread")?;
+
+        let metadata = VTCodePtySession {
+            id: session_id.clone(),
+            command: program,
+            args,
+            working_dir: Some(self.format_working_dir(&working_dir)),
+            rows: size.rows,
+            cols: size.cols,
+            screen_contents: None,
+        };
+
+        sessions.insert(
+            session_id.clone(),
+            PtySessionHandle {
+                master,
+                child: Mutex::new(child),
+                writer: Mutex::new(Some(writer)),
+                parser,
+                reader_thread: Mutex::new(Some(reader_thread)),
+                metadata: metadata.clone(),
+            },
+        );
+
+        Ok(metadata)
+    }
+
+    pub fn list_sessions(&self) -> Vec<VTCodePtySession> {
+        let sessions = self
+            .inner
+            .sessions
+            .lock()
+            .expect("PTY session mutex poisoned");
+        sessions
+            .values()
+            .map(PtySessionHandle::snapshot_metadata)
+            .collect()
+    }
+
+    pub fn close_session(&self, session_id: &str) -> Result<VTCodePtySession> {
+        let handle = {
+            let mut sessions = self
+                .inner
+                .sessions
+                .lock()
+                .expect("PTY session mutex poisoned");
+            sessions
+                .remove(session_id)
+                .ok_or_else(|| anyhow!("PTY session '{}' not found", session_id))?
+        };
+
+        if let Ok(mut writer_guard) = handle.writer.lock() {
+            if let Some(mut writer) = writer_guard.take() {
+                let _ = writer.write_all(b"exit\n");
+                let _ = writer.flush();
+            }
+        }
+
+        let mut child = handle.child.lock().expect("PTY child mutex poisoned");
+        if child
+            .try_wait()
+            .context("failed to poll PTY session status")?
+            .is_none()
+        {
+            child.kill().context("failed to terminate PTY session")?;
+            let _ = child.wait();
+        }
+
+        if let Ok(mut thread_guard) = handle.reader_thread.lock() {
+            if let Some(reader_thread) = thread_guard.take() {
+                if let Err(panic) = reader_thread.join() {
+                    warn!(
+                        "PTY session '{}' reader thread panicked: {:?}",
+                        session_id, panic
+                    );
+                }
+            }
+        }
+
+        Ok(handle.snapshot_metadata())
+    }
+
+    fn format_working_dir(&self, path: &Path) -> String {
+        match path.strip_prefix(&self.workspace_root) {
+            Ok(relative) if relative.as_os_str().is_empty() => ".".to_string(),
+            Ok(relative) => relative.to_string_lossy().replace("\\", "/"),
+            Err(_) => path.to_string_lossy().to_string(),
+        }
+    }
+}
+
+fn clamp_timeout(duration: Duration) -> u64 {
+    duration.as_millis().min(u64::MAX as u128) as u64
+}
+
+fn wait_status_code(status: WaitStatus) -> i32 {
+    match status {
+        WaitStatus::Exited(_, code) => code,
+        WaitStatus::Signaled(_, signal, _) | WaitStatus::Stopped(_, signal) => -(signal as i32),
+        WaitStatus::StillAlive
+        | WaitStatus::Continued(_)
+        | WaitStatus::PtraceEvent(_, _, _)
+        | WaitStatus::PtraceSyscall(_) => 0,
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}

--- a/vtcode-core/src/tools/registry/builtins.rs
+++ b/vtcode-core/src/tools/registry/builtins.rs
@@ -49,6 +49,30 @@ pub(super) fn builtin_tool_registrations() -> Vec<ToolRegistration> {
             ToolRegistry::run_terminal_cmd_executor,
         ),
         ToolRegistration::new(
+            tools::RUN_PTY_CMD,
+            CapabilityLevel::Bash,
+            true,
+            ToolRegistry::run_pty_cmd_executor,
+        ),
+        ToolRegistration::new(
+            tools::CREATE_PTY_SESSION,
+            CapabilityLevel::Bash,
+            false,
+            ToolRegistry::create_pty_session_executor,
+        ),
+        ToolRegistration::new(
+            tools::LIST_PTY_SESSIONS,
+            CapabilityLevel::Bash,
+            false,
+            ToolRegistry::list_pty_sessions_executor,
+        ),
+        ToolRegistration::new(
+            tools::CLOSE_PTY_SESSION,
+            CapabilityLevel::Bash,
+            false,
+            ToolRegistry::close_pty_session_executor,
+        ),
+        ToolRegistration::new(
             tools::CURL,
             CapabilityLevel::Bash,
             false,

--- a/vtcode-core/src/tools/registry/declarations.rs
+++ b/vtcode-core/src/tools/registry/declarations.rs
@@ -122,6 +122,104 @@ fn base_function_declarations() -> Vec<FunctionDeclaration> {
             }),
         },
         FunctionDeclaration {
+            name: tools::RUN_PTY_CMD.to_string(),
+            description: "Execute a command inside a pseudo-terminal. Use for interactive programs (e.g., REPLs, full-screen TUIs) that require TTY semantics. Provide the command as a string plus optional args array or as an array of program + args.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "description": "Command to run (string or [program, ...args])",
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}}
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Arguments to append when command is provided as string"
+                    },
+                    "working_dir": {
+                        "type": "string",
+                        "description": "Working directory relative to the workspace"
+                    },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "description": "Timeout before forcefully terminating the command",
+                        "default": 300
+                    },
+                    "rows": {
+                        "type": "integer",
+                        "description": "Pseudo-terminal rows",
+                        "default": 24
+                    },
+                    "cols": {
+                        "type": "integer",
+                        "description": "Pseudo-terminal columns",
+                        "default": 80
+                    }
+                },
+                "required": ["command"]
+            }),
+        },
+        FunctionDeclaration {
+            name: tools::CREATE_PTY_SESSION.to_string(),
+            description: "Spawn and register a persistent PTY session (e.g., bash shell) that can be reused across tool calls. Requires a unique session_id.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {"type": "string", "description": "Unique identifier for the PTY session"},
+                    "command": {
+                        "description": "Command to start in the session (string or [program, ...args])",
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}}
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Arguments to append when command is provided as string"
+                    },
+                    "working_dir": {
+                        "type": "string",
+                        "description": "Working directory relative to the workspace"
+                    },
+                    "rows": {
+                        "type": "integer",
+                        "description": "Pseudo-terminal rows",
+                        "default": 24
+                    },
+                    "cols": {
+                        "type": "integer",
+                        "description": "Pseudo-terminal columns",
+                        "default": 80
+                    }
+                },
+                "required": ["session_id", "command"]
+            }),
+        },
+        FunctionDeclaration {
+            name: tools::LIST_PTY_SESSIONS.to_string(),
+            description: "List active PTY sessions created via create_pty_session.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        },
+        FunctionDeclaration {
+            name: tools::CLOSE_PTY_SESSION.to_string(),
+            description: "Terminate and remove a persistent PTY session.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {"type": "string", "description": "Identifier returned by create_pty_session"}
+                },
+                "required": ["session_id"]
+            }),
+        },
+        FunctionDeclaration {
             name: tools::CURL.to_string(),
             description: "Fetch HTTPS content (sandboxed). Public hosts only—blocks localhost/private IPs. Size-limited. Returns security_notice. Use for documentation or small JSON payloads.".to_string(),
             parameters: json!({

--- a/vtcode-core/src/tools/registry/executors.rs
+++ b/vtcode-core/src/tools/registry/executors.rs
@@ -1,10 +1,12 @@
 use anyhow::{Context, Result, anyhow};
 use futures::future::BoxFuture;
+use portable_pty::PtySize;
 use serde_json::{Value, json};
+use std::time::Duration;
 
 use crate::tools::apply_patch::Patch;
 use crate::tools::traits::Tool;
-use crate::tools::{PlanUpdateResult, UpdatePlanArgs};
+use crate::tools::{PlanUpdateResult, PtyCommandRequest, UpdatePlanArgs};
 
 use super::ToolRegistry;
 
@@ -24,6 +26,31 @@ impl ToolRegistry {
         args: Value,
     ) -> BoxFuture<'_, Result<Value>> {
         Box::pin(async move { self.execute_run_terminal(args, false).await })
+    }
+
+    pub(super) fn run_pty_cmd_executor(&mut self, args: Value) -> BoxFuture<'_, Result<Value>> {
+        Box::pin(async move { self.execute_run_pty_command(args).await })
+    }
+
+    pub(super) fn create_pty_session_executor(
+        &mut self,
+        args: Value,
+    ) -> BoxFuture<'_, Result<Value>> {
+        Box::pin(async move { self.execute_create_pty_session(args).await })
+    }
+
+    pub(super) fn list_pty_sessions_executor(
+        &mut self,
+        _args: Value,
+    ) -> BoxFuture<'_, Result<Value>> {
+        Box::pin(async move { self.execute_list_pty_sessions().await })
+    }
+
+    pub(super) fn close_pty_session_executor(
+        &mut self,
+        args: Value,
+    ) -> BoxFuture<'_, Result<Value>> {
+        Box::pin(async move { self.execute_close_pty_session(args).await })
     }
 
     pub(super) fn curl_executor(&mut self, args: Value) -> BoxFuture<'_, Result<Value>> {
@@ -183,5 +210,278 @@ impl ToolRegistry {
 
         let tool = self.command_tool.clone();
         tool.execute(Value::Object(sanitized)).await
+    }
+
+    async fn execute_run_pty_command(&self, args: Value) -> Result<Value> {
+        let payload = args
+            .as_object()
+            .ok_or_else(|| anyhow!("run_pty_cmd expects an object payload"))?;
+
+        let mut command_parts = match payload.get("command") {
+            Some(Value::String(command)) => vec![command.to_string()],
+            Some(Value::Array(parts)) => parts
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(|part| part.to_string())
+                        .ok_or_else(|| anyhow!("command array must contain only strings"))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            Some(_) => {
+                return Err(anyhow!("command must be a string or string array"));
+            }
+            None => {
+                return Err(anyhow!("run_pty_cmd requires a 'command' value"));
+            }
+        };
+
+        if let Some(args_value) = payload.get("args") {
+            if let Some(array) = args_value.as_array() {
+                for value in array {
+                    let Some(part) = value.as_str() else {
+                        return Err(anyhow!("args array must contain only strings"));
+                    };
+                    command_parts.push(part.to_string());
+                }
+            } else {
+                return Err(anyhow!("args must be an array of strings"));
+            }
+        }
+
+        if command_parts.is_empty() {
+            return Err(anyhow!("PTY command cannot be empty"));
+        }
+
+        let timeout_secs = payload
+            .get("timeout_secs")
+            .map(|value| {
+                value
+                    .as_u64()
+                    .ok_or_else(|| anyhow!("timeout_secs must be a positive integer"))
+            })
+            .transpose()?
+            .unwrap_or(self.pty_config.command_timeout_seconds);
+        if timeout_secs == 0 {
+            return Err(anyhow!("timeout_secs must be greater than zero"));
+        }
+
+        let parse_dimension = |name: &str, value: Option<&Value>, default: u16| -> Result<u16> {
+            let Some(raw) = value else {
+                return Ok(default);
+            };
+            let numeric = raw
+                .as_u64()
+                .ok_or_else(|| anyhow!("{name} must be an integer"))?;
+            if numeric == 0 {
+                return Err(anyhow!("{name} must be greater than zero"));
+            }
+            if numeric > u16::MAX as u64 {
+                return Err(anyhow!("{name} exceeds maximum value {}", u16::MAX));
+            }
+            Ok(numeric as u16)
+        };
+
+        let rows = parse_dimension("rows", payload.get("rows"), self.pty_config.default_rows)?;
+        let cols = parse_dimension("cols", payload.get("cols"), self.pty_config.default_cols)?;
+
+        let working_dir = self
+            .pty_manager
+            .resolve_working_dir(payload.get("working_dir").and_then(|value| value.as_str()))?;
+        let working_dir_display = self.pty_manager.describe_working_dir(&working_dir);
+
+        let request = PtyCommandRequest {
+            command: command_parts.clone(),
+            working_dir: working_dir.clone(),
+            timeout: Duration::from_secs(timeout_secs),
+            size: PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            },
+        };
+
+        let result = self.pty_manager.run_command(request).await?;
+
+        Ok(json!({
+            "success": true,
+            "command": command_parts,
+            "output": result.output,
+            "code": result.exit_code,
+            "mode": "pty",
+            "pty": {
+                "rows": result.size.rows,
+                "cols": result.size.cols,
+            },
+            "working_directory": working_dir_display,
+            "timeout_secs": timeout_secs,
+            "duration_ms": result.duration.as_millis(),
+        }))
+    }
+
+    async fn execute_create_pty_session(&mut self, args: Value) -> Result<Value> {
+        let payload = args
+            .as_object()
+            .ok_or_else(|| anyhow!("create_pty_session expects an object payload"))?;
+
+        let session_id = payload
+            .get("session_id")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| anyhow!("create_pty_session requires a 'session_id' string"))?
+            .trim();
+
+        if session_id.is_empty() {
+            return Err(anyhow!("session_id cannot be empty"));
+        }
+
+        let mut command_parts = match payload.get("command") {
+            Some(Value::String(command)) => vec![command.to_string()],
+            Some(Value::Array(parts)) => parts
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(|part| part.to_string())
+                        .ok_or_else(|| anyhow!("command array must contain only strings"))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            Some(_) => {
+                return Err(anyhow!("command must be a string or string array"));
+            }
+            None => {
+                return Err(anyhow!("create_pty_session requires a 'command' value"));
+            }
+        };
+
+        if let Some(args_value) = payload.get("args") {
+            if let Some(array) = args_value.as_array() {
+                for value in array {
+                    let Some(part) = value.as_str() else {
+                        return Err(anyhow!("args array must contain only strings"));
+                    };
+                    command_parts.push(part.to_string());
+                }
+            } else {
+                return Err(anyhow!("args must be an array of strings"));
+            }
+        }
+
+        if command_parts.is_empty() {
+            return Err(anyhow!("PTY session command cannot be empty"));
+        }
+
+        let working_dir = self
+            .pty_manager
+            .resolve_working_dir(payload.get("working_dir").and_then(|value| value.as_str()))?;
+
+        let parse_dimension = |name: &str, value: Option<&Value>, default: u16| -> Result<u16> {
+            let Some(raw) = value else {
+                return Ok(default);
+            };
+            let numeric = raw
+                .as_u64()
+                .ok_or_else(|| anyhow!("{name} must be an integer"))?;
+            if numeric == 0 {
+                return Err(anyhow!("{name} must be greater than zero"));
+            }
+            if numeric > u16::MAX as u64 {
+                return Err(anyhow!("{name} exceeds maximum value {}", u16::MAX));
+            }
+            Ok(numeric as u16)
+        };
+
+        let rows = parse_dimension("rows", payload.get("rows"), self.pty_config.default_rows)?;
+        let cols = parse_dimension("cols", payload.get("cols"), self.pty_config.default_cols)?;
+
+        let size = PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+
+        self.start_pty_session()?;
+        let result = match self.pty_manager.create_session(
+            session_id.to_string(),
+            command_parts.clone(),
+            working_dir,
+            size,
+        ) {
+            Ok(meta) => meta,
+            Err(error) => {
+                self.end_pty_session();
+                return Err(error);
+            }
+        };
+
+        Ok(json!({
+            "success": true,
+            "session_id": result.id,
+            "command": result.command,
+            "args": result.args,
+            "rows": result.rows,
+            "cols": result.cols,
+            "working_directory": result.working_dir.unwrap_or_else(|| ".".to_string()),
+            "screen_contents": result.screen_contents,
+        }))
+    }
+
+    async fn execute_list_pty_sessions(&self) -> Result<Value> {
+        let sessions = self.pty_manager.list_sessions();
+        let identifiers: Vec<String> = sessions.iter().map(|session| session.id.clone()).collect();
+        let details: Vec<Value> = sessions
+            .into_iter()
+            .map(|session| {
+                json!({
+                    "session_id": session.id,
+                    "command": session.command,
+                    "args": session.args,
+                    "working_directory": session.working_dir.unwrap_or_else(|| ".".to_string()),
+                    "rows": session.rows,
+                    "cols": session.cols,
+                    "screen_contents": session.screen_contents,
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "success": true,
+            "sessions": identifiers,
+            "details": details,
+        }))
+    }
+
+    async fn execute_close_pty_session(&mut self, args: Value) -> Result<Value> {
+        let payload = args
+            .as_object()
+            .ok_or_else(|| anyhow!("close_pty_session expects an object payload"))?;
+
+        let session_id = payload
+            .get("session_id")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| anyhow!("close_pty_session requires a 'session_id' string"))?
+            .trim();
+
+        if session_id.is_empty() {
+            return Err(anyhow!("session_id cannot be empty"));
+        }
+
+        let metadata = self
+            .pty_manager
+            .close_session(session_id)
+            .with_context(|| format!("failed to close PTY session '{session_id}'"))?;
+        self.end_pty_session();
+
+        Ok(json!({
+            "success": true,
+            "session_id": metadata.id,
+            "command": metadata.command,
+            "args": metadata.args,
+            "rows": metadata.rows,
+            "cols": metadata.cols,
+            "working_directory": metadata.working_dir.unwrap_or_else(|| ".".to_string()),
+            "screen_contents": metadata.screen_contents,
+        }))
     }
 }

--- a/vtcode-core/src/tools/registry/mod.rs
+++ b/vtcode-core/src/tools/registry/mod.rs
@@ -41,6 +41,7 @@ use super::command::CommandTool;
 use super::curl_tool::CurlTool;
 use super::file_ops::FileOpsTool;
 use super::plan::PlanManager;
+use super::pty::PtyManager;
 use super::search::SearchTool;
 use super::simple_search::SimpleSearchTool;
 use super::srgn::SrgnTool;
@@ -63,6 +64,7 @@ pub struct ToolRegistry {
     grep_search: Arc<GrepSearchManager>,
     ast_grep_engine: Option<Arc<AstGrepEngine>>,
     tool_policy: Option<ToolPolicyManager>,
+    pty_manager: PtyManager,
     pty_config: PtyConfig,
     active_pty_sessions: Arc<AtomicUsize>,
     srgn_tool: SrgnTool,
@@ -114,6 +116,7 @@ impl ToolRegistry {
         let curl_tool = CurlTool::new();
         let srgn_tool = SrgnTool::new(workspace_root.clone());
         let plan_manager = PlanManager::new();
+        let pty_manager = PtyManager::new(workspace_root.clone(), pty_config.clone());
 
         let ast_grep_engine = match AstGrepEngine::new() {
             Ok(engine) => Some(Arc::new(engine)),
@@ -142,6 +145,7 @@ impl ToolRegistry {
             grep_search,
             ast_grep_engine,
             tool_policy: policy_manager,
+            pty_manager,
             pty_config,
             active_pty_sessions: Arc::new(AtomicUsize::new(0)),
             srgn_tool,
@@ -238,6 +242,10 @@ impl ToolRegistry {
 
     pub fn workspace_root(&self) -> &PathBuf {
         &self.workspace_root
+    }
+
+    pub fn pty_manager(&self) -> &PtyManager {
+        &self.pty_manager
     }
 
     pub fn plan_manager(&self) -> PlanManager {

--- a/vtcode-core/src/tools/types.rs
+++ b/vtcode-core/src/tools/types.rs
@@ -144,7 +144,7 @@ pub struct EnhancedTerminalInput {
 }
 
 /// PTY Session structure for managing interactive terminal sessions
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VTCodePtySession {
     pub id: String,
     pub command: String,
@@ -152,6 +152,8 @@ pub struct VTCodePtySession {
     pub working_dir: Option<String>,
     pub rows: u16,
     pub cols: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub screen_contents: Option<String>,
 }
 
 // Default value functions


### PR DESCRIPTION
## Summary
- add the `tui-markdown` dependency so the inline UI can reuse its parser
- extend the inline ANSI renderer to convert markdown into inline segments using `tui-markdown`
- translate ratatui styles into the existing inline styling pipeline and reuse it for streaming updates

## Testing
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e72f27a38c8323bb8da723a2203cae