### PR TITLE
Add inline PTY snapshot rendering

### DIFF
--- a/vtcode-core/src/ui/tui.rs
+++ b/vtcode-core/src/ui/tui.rs
@@ -3,16 +3,19 @@ use tokio::sync::mpsc;
 
 use crate::config::types::UiSurfacePreference;
 
+mod pty;
 mod session;
 mod style;
 mod tui;
 mod types;
 
+pub use pty::{PtySnapshotRender, render_pty_snapshot};
 pub use style::{convert_style, theme_from_styles};
 pub use types::{
     InlineCommand, InlineEvent, InlineHandle, InlineHeaderContext, InlineHeaderHighlight,
-    InlineListItem, InlineListSearchConfig, InlineListSelection, InlineMessageKind, InlineSegment,
-    InlineSession, InlineTextStyle, InlineTheme, SecurePromptConfig,
+    InlineListItem, InlineListSearchConfig, InlineListSelection, InlineMessageKind,
+    InlinePtySnapshot, InlineSegment, InlineSession, InlineTextStyle, InlineTheme,
+    SecurePromptConfig,
 };
 
 use tui::run_tui;

--- a/vtcode-core/src/ui/tui/pty.rs
+++ b/vtcode-core/src/ui/tui/pty.rs
@@ -1,0 +1,185 @@
+use anstyle::{Ansi256Color, AnsiColor, Color as AnsiColorEnum, RgbColor};
+use anyhow::{Context, Result};
+use ratatui::{
+    Terminal,
+    backend::TestBackend,
+    layout::Position,
+    style::{Color as RatColor, Modifier, Style as RatStyle},
+};
+use tui_term::vt100::{Parser, Screen};
+use tui_term::widget::{Cursor as PtyCursor, PseudoTerminal};
+
+use super::types::{InlineSegment, InlineTextStyle};
+
+const MAX_PTY_RENDER_ROWS: u16 = 200;
+
+fn normalized_dimensions(rows: u16, cols: u16, fallback_rows: usize) -> (u16, u16) {
+    let height = rows.max(1).min(MAX_PTY_RENDER_ROWS);
+    let width = cols.max(1);
+    if fallback_rows == 0 {
+        (height, width)
+    } else {
+        (height.max(fallback_rows as u16), width)
+    }
+}
+
+/// Snapshot of a VT100 screen rendered into inline UI segments.
+pub struct PtySnapshotRender {
+    pub screen: Screen,
+    pub lines: Vec<Vec<InlineSegment>>,
+}
+
+/// Render a VT100 screen snapshot into inline UI segments.
+///
+/// The `contents` parameter should contain the escape sequence stream produced by the
+/// pseudoterminal. The dimensions are best-effort hints; when the snapshot was captured without
+/// explicit sizing information we fall back to the number of newline separated rows present in the
+/// content, clamped to a reasonable limit to avoid allocating excessively large buffers.
+pub fn render_pty_snapshot(contents: &str, rows: u16, cols: u16) -> Result<PtySnapshotRender> {
+    if contents.trim().is_empty() {
+        return Ok(PtySnapshotRender {
+            screen: Parser::new(1, 1, 0).screen().clone(),
+            lines: Vec::new(),
+        });
+    }
+
+    let inferred_rows = contents.lines().count().max(1);
+    let (height, width) = normalized_dimensions(rows, cols, inferred_rows);
+
+    let mut parser = Parser::new(height, width, 0);
+    parser.process(contents.as_bytes());
+    let screen = parser.screen().clone();
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).context("failed to create PTY snapshot terminal")?;
+    terminal
+        .draw(|frame| {
+            let cursor = PtyCursor::default().visibility(false);
+            let widget = PseudoTerminal::new(&screen).cursor(cursor);
+            frame.render_widget(widget, frame.area());
+        })
+        .context("failed to render PTY snapshot")?;
+
+    let buffer = terminal.backend().buffer();
+    let mut lines = Vec::with_capacity(height as usize);
+
+    for row in 0..height as usize {
+        let mut segments: Vec<InlineSegment> = Vec::new();
+        let mut current_style: Option<InlineTextStyle> = None;
+        let mut current_text = String::new();
+
+        for col in 0..width as usize {
+            let Some(cell) = buffer.cell(Position {
+                x: col as u16,
+                y: row as u16,
+            }) else {
+                continue;
+            };
+            let symbol = cell.symbol();
+            let style = inline_style_from_ratatui(cell.style());
+
+            match &current_style {
+                Some(existing) if existing == &style => current_text.push_str(symbol),
+                Some(existing) => {
+                    segments.push(InlineSegment {
+                        text: std::mem::take(&mut current_text),
+                        style: existing.clone(),
+                    });
+                    current_style = Some(style);
+                    current_text.push_str(symbol);
+                }
+                None => {
+                    current_style = Some(style);
+                    current_text.push_str(symbol);
+                }
+            }
+        }
+
+        if let Some(style) = current_style {
+            segments.push(InlineSegment {
+                text: current_text,
+                style,
+            });
+        }
+
+        trim_trailing_whitespace(&mut segments);
+        lines.push(segments);
+    }
+
+    while lines.last().map_or(false, |segments| {
+        segments
+            .iter()
+            .all(|segment| segment.text.trim().is_empty())
+    }) {
+        lines.pop();
+    }
+
+    Ok(PtySnapshotRender { screen, lines })
+}
+
+fn trim_trailing_whitespace(segments: &mut Vec<InlineSegment>) {
+    while let Some(last) = segments.last_mut() {
+        if last.text.trim_end().is_empty() {
+            segments.pop();
+            continue;
+        }
+
+        let trimmed = last.text.trim_end_matches(' ');
+        if trimmed.len() == last.text.len() {
+            break;
+        }
+
+        if trimmed.is_empty() {
+            segments.pop();
+        } else {
+            last.text.truncate(trimmed.len());
+        }
+        break;
+    }
+}
+
+fn inline_style_from_ratatui(style: RatStyle) -> InlineTextStyle {
+    let mut resolved = InlineTextStyle::default();
+    if let Some(color) = style.fg.and_then(ansi_from_ratatui_color) {
+        resolved.color = Some(color);
+    }
+
+    if style.add_modifier.contains(Modifier::BOLD) {
+        resolved.bold = true;
+    }
+    if style.add_modifier.contains(Modifier::ITALIC) {
+        resolved.italic = true;
+    }
+    if style.sub_modifier.contains(Modifier::BOLD) {
+        resolved.bold = false;
+    }
+    if style.sub_modifier.contains(Modifier::ITALIC) {
+        resolved.italic = false;
+    }
+
+    resolved
+}
+
+fn ansi_from_ratatui_color(color: RatColor) -> Option<AnsiColorEnum> {
+    match color {
+        RatColor::Reset => None,
+        RatColor::Black => Some(AnsiColorEnum::Ansi(AnsiColor::Black)),
+        RatColor::Red => Some(AnsiColorEnum::Ansi(AnsiColor::Red)),
+        RatColor::Green => Some(AnsiColorEnum::Ansi(AnsiColor::Green)),
+        RatColor::Yellow => Some(AnsiColorEnum::Ansi(AnsiColor::Yellow)),
+        RatColor::Blue => Some(AnsiColorEnum::Ansi(AnsiColor::Blue)),
+        RatColor::Magenta => Some(AnsiColorEnum::Ansi(AnsiColor::Magenta)),
+        RatColor::Cyan => Some(AnsiColorEnum::Ansi(AnsiColor::Cyan)),
+        RatColor::Gray => Some(AnsiColorEnum::Ansi(AnsiColor::White)),
+        RatColor::DarkGray => Some(AnsiColorEnum::Ansi(AnsiColor::BrightBlack)),
+        RatColor::LightRed => Some(AnsiColorEnum::Ansi(AnsiColor::BrightRed)),
+        RatColor::LightGreen => Some(AnsiColorEnum::Ansi(AnsiColor::BrightGreen)),
+        RatColor::LightYellow => Some(AnsiColorEnum::Ansi(AnsiColor::BrightYellow)),
+        RatColor::LightBlue => Some(AnsiColorEnum::Ansi(AnsiColor::BrightBlue)),
+        RatColor::LightMagenta => Some(AnsiColorEnum::Ansi(AnsiColor::BrightMagenta)),
+        RatColor::LightCyan => Some(AnsiColorEnum::Ansi(AnsiColor::BrightCyan)),
+        RatColor::White => Some(AnsiColorEnum::Ansi(AnsiColor::BrightWhite)),
+        RatColor::Rgb(r, g, b) => Some(AnsiColorEnum::Rgb(RgbColor(r, g, b))),
+        RatColor::Indexed(value) => Some(AnsiColorEnum::Ansi256(Ansi256Color(value))),
+    }
+}

--- a/vtcode-core/src/ui/tui/pty.rs
+++ b/vtcode-core/src/ui/tui/pty.rs
@@ -19,7 +19,10 @@ fn normalized_dimensions(rows: u16, cols: u16, fallback_rows: usize) -> (u16, u1
     if fallback_rows == 0 {
         (height, width)
     } else {
-        (height.max(fallback_rows as u16), width)
+        let fallback_height = fallback_rows
+            .max(1)
+            .min(MAX_PTY_RENDER_ROWS as usize) as u16;
+        (height.max(fallback_height), width)
     }
 }
 

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -114,6 +114,20 @@ pub struct InlineSegment {
 }
 
 #[derive(Clone, Default)]
+pub struct InlinePtySnapshot {
+    pub contents: String,
+    pub rows: u16,
+    pub cols: u16,
+}
+
+impl InlinePtySnapshot {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.contents.trim().is_empty()
+    }
+}
+
+#[derive(Clone, Default)]
 pub struct InlineTheme {
     pub foreground: Option<AnsiColorEnum>,
     pub primary: Option<AnsiColorEnum>,
@@ -172,6 +186,9 @@ pub enum InlineCommand {
     Inline {
         kind: InlineMessageKind,
         segment: InlineSegment,
+    },
+    AppendPtySnapshot {
+        snapshot: InlinePtySnapshot,
     },
     ReplaceLast {
         count: usize,
@@ -250,6 +267,12 @@ impl InlineHandle {
 
     pub fn inline(&self, kind: InlineMessageKind, segment: InlineSegment) {
         let _ = self.sender.send(InlineCommand::Inline { kind, segment });
+    }
+
+    pub fn append_pty_snapshot(&self, snapshot: InlinePtySnapshot) {
+        let _ = self
+            .sender
+            .send(InlineCommand::AppendPtySnapshot { snapshot });
     }
 
     pub fn replace_last(

--- a/vtcode-core/src/utils/ansi.rs
+++ b/vtcode-core/src/utils/ansi.rs
@@ -112,7 +112,7 @@ impl AnsiRenderer {
         match style {
             MessageStyle::Info => InlineMessageKind::Info,
             MessageStyle::Error => InlineMessageKind::Error,
-            MessageStyle::Output => InlineMessageKind::Pty,
+            MessageStyle::Output => InlineMessageKind::Tool,
             MessageStyle::Response => InlineMessageKind::Agent,
             MessageStyle::Tool | MessageStyle::ToolDetail => InlineMessageKind::Tool,
             MessageStyle::Status | MessageStyle::McpStatus => InlineMessageKind::Info,

--- a/vtcode-core/src/utils/ansi.rs
+++ b/vtcode-core/src/utils/ansi.rs
@@ -3,8 +3,8 @@ use crate::ui::markdown::{MarkdownLine, MarkdownSegment, render_markdown_to_line
 use crate::ui::theme;
 use crate::ui::tui::{
     InlineHandle, InlineListItem, InlineListSearchConfig, InlineListSelection, InlineMessageKind,
-    InlineSegment, InlineTextStyle, SecurePromptConfig, convert_style as convert_to_inline_style,
-    theme_from_styles,
+    InlinePtySnapshot, InlineSegment, InlineTextStyle, SecurePromptConfig,
+    convert_style as convert_to_inline_style, render_pty_snapshot, theme_from_styles,
 };
 use crate::utils::transcript;
 use anstream::{AutoStream, ColorChoice};
@@ -112,7 +112,7 @@ impl AnsiRenderer {
         match style {
             MessageStyle::Info => InlineMessageKind::Info,
             MessageStyle::Error => InlineMessageKind::Error,
-            MessageStyle::Output => InlineMessageKind::Pty,
+            MessageStyle::Output => InlineMessageKind::Tool,
             MessageStyle::Response => InlineMessageKind::Agent,
             MessageStyle::Tool | MessageStyle::ToolDetail => InlineMessageKind::Tool,
             MessageStyle::Status | MessageStyle::McpStatus => InlineMessageKind::Info,
@@ -266,6 +266,74 @@ impl AnsiRenderer {
         }
         self.writer.flush()?;
         transcript::append(text);
+        Ok(())
+    }
+
+    /// Append pre-rendered inline segments to the transcript output.
+    pub fn append_inline_segments(
+        &mut self,
+        style: MessageStyle,
+        segments: Vec<InlineSegment>,
+    ) -> Result<()> {
+        if let Some(sink) = &mut self.sink {
+            sink.append_segments(segments, Self::message_kind(style));
+            self.last_line_was_empty = false;
+            return Ok(());
+        }
+
+        let text: String = segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect();
+        self.line(style, &text)
+    }
+
+    /// Append a pseudoterminal snapshot to the transcript.
+    pub fn append_pty_snapshot(&mut self, contents: &str, rows: u16, cols: u16) -> Result<()> {
+        let snapshot = render_pty_snapshot(contents, rows, cols)?;
+
+        if let Some(sink) = &mut self.sink {
+            sink.append_pty_snapshot(InlinePtySnapshot {
+                contents: contents.to_string(),
+                rows,
+                cols,
+            });
+
+            let plain_lines: Vec<String> = snapshot
+                .lines
+                .iter()
+                .map(|line| {
+                    let mut buffer = String::from(MessageStyle::Output.indent());
+                    for segment in line {
+                        buffer.push_str(segment.text.as_str());
+                    }
+                    buffer
+                })
+                .collect();
+            if !plain_lines.is_empty() {
+                crate::utils::transcript::append(&plain_lines.join("\n"));
+                self.last_line_was_empty = plain_lines
+                    .last()
+                    .map(|line| line.trim().is_empty())
+                    .unwrap_or(false);
+            } else {
+                self.last_line_was_empty = true;
+            }
+            return Ok(());
+        }
+
+        if snapshot.lines.is_empty() {
+            return Ok(());
+        }
+
+        for line in snapshot.lines {
+            let mut buffer = String::from(MessageStyle::Output.indent());
+            for segment in line {
+                buffer.push_str(&segment.text);
+            }
+            self.line(MessageStyle::Output, &buffer)?;
+        }
+
         Ok(())
     }
 
@@ -730,6 +798,30 @@ impl InlineSink {
             converted.push(self.style_to_segment(segment.style, &segment.text));
         }
         converted
+    }
+}
+
+impl InlineSink {
+    fn append_segments(&mut self, segments: Vec<InlineSegment>, kind: InlineMessageKind) {
+        if segments.is_empty() {
+            self.handle.append_line(kind, Vec::new());
+            crate::utils::transcript::append("");
+            return;
+        }
+
+        let plain: String = segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect();
+        self.handle.append_line(kind, segments);
+        crate::utils::transcript::append(&plain);
+    }
+
+    fn append_pty_snapshot(&mut self, snapshot: InlinePtySnapshot) {
+        if snapshot.is_empty() {
+            return;
+        }
+        self.handle.append_pty_snapshot(snapshot);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a PTY snapshot renderer that returns both vt100 screen state and inline segments, and re-export it for callers
- extend the inline UI types and session logic to push PTY snapshots, cache them, and render the vt100 screen with the tui-term widget when fully visible
- expose `AnsiRenderer::append_pty_snapshot` and switch PTY tool output paths to send snapshots through the inline UI pipeline

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68e75ca06618832397e4bab6b90bb03d