### PR TITLE
Fix Windows CI by gating rexpect usage on non-Unix targets

### DIFF
--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -101,13 +101,15 @@ similar = "2.4"
 rig = { package = "rig-core", version = "0.21", default-features = false, features = ["reqwest-rustls"] }
 tui-term = { version = "0.2.0", features = ["unstable"] }
 portable-pty = "0.9.0"
-rexpect = "0.6.2"
 
 # MCP (Model Context Protocol) support
 rmcp = { version = "0.7.0", features = ["client", "transport-child-process"] }
 
 # Token counting for attention budget management
 tiktoken-rs = "0.6"
+
+[target.'cfg(unix)'.dependencies]
+rexpect = "0.6.2"
 
 [[example]]
 name = "anstyle_test"


### PR DESCRIPTION
## Summary
- move the rexpect dependency to a Unix-specific target stanza
- guard the PTY command runner implementation behind `cfg(unix)` and provide a Windows-friendly stub

## Testing
- cargo fmt
- cargo check
- cargo clippy


------
https://chatgpt.com/codex/tasks/task_e_68e7bbe2b2f0832397de303bd381524e