### PR TITLE
Replace rexpect PTY helper with portable_pty implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,12 +511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "comma"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
-
-[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,19 +2800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rexpect"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1bcd4ac488e9d2d726d147031cceff5cff6425011ff1914049739770fa4726"
-dependencies = [
- "comma",
- "nix 0.30.1",
- "regex",
- "tempfile",
- "thiserror 2.0.16",
-]
-
-[[package]]
 name = "rig-core"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4361,7 +4342,6 @@ dependencies = [
  "ratatui",
  "regex",
  "reqwest",
- "rexpect",
  "rig-core",
  "rmcp",
  "roff",

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -109,7 +109,6 @@ rmcp = { version = "0.7.0", features = ["client", "transport-child-process"] }
 tiktoken-rs = "0.6"
 
 [target.'cfg(unix)'.dependencies]
-rexpect = "0.6.2"
 
 [[example]]
 name = "anstyle_test"


### PR DESCRIPTION
## Summary
- replace the rexpect-based PTY command runner with a native portable_pty implementation that enforces timeouts and collects output
- drop the rexpect dependency from vtcode-core to improve portability (e.g. FreeBSD)

## Testing
- cargo fmt
- cargo clippy
- cargo check -p vtcode-core

------
https://chatgpt.com/codex/tasks/task_e_68e923438c488323ab4c179f1afdf372