### PR TITLE
Add assert_cmd-based CLI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +949,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "document-features"
@@ -1077,6 +1105,15 @@ checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2010,6 +2047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2418,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3551,6 +3624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,6 +4344,7 @@ dependencies = [
  "anstyle-git",
  "anstyle-ls",
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "chrono",
  "clap",
@@ -4281,6 +4361,7 @@ dependencies = [
  "once_cell",
  "path-clean",
  "percent-encoding",
+ "predicates",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -4396,6 +4477,15 @@ checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,3 +135,5 @@ dialoguer = "0.9"
 indexmap = { version = "2.2", features = ["serde"] }
 rand = "0.8"
 regex = "1.10"
+assert_cmd = "2.0"
+predicates = "3.1"

--- a/tests/cli_assert_cmd.rs
+++ b/tests/cli_assert_cmd.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn config_command_writes_configuration_file() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let output_path = temp_dir.path().join("vtcode-config.toml");
+
+    let mut cmd = Command::cargo_bin("vtcode")?;
+    cmd.current_dir(temp_dir.path());
+    cmd.arg("config");
+    cmd.arg("--output");
+    cmd.arg(&output_path);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Configuration written"));
+
+    let contents = fs::read_to_string(&output_path)?;
+    assert!(
+        contents.contains("[agent]"),
+        "generated config should include the agent section"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn positional_workspace_path_must_exist() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let missing_workspace = temp_dir.path().join("missing-workspace");
+    let output_path = temp_dir.path().join("should-not-exist.toml");
+
+    let mut cmd = Command::cargo_bin("vtcode")?;
+    cmd.current_dir(temp_dir.path());
+    cmd.arg(&missing_workspace);
+    cmd.arg("config");
+    cmd.arg("--output");
+    cmd.arg(&output_path);
+
+    let assert = cmd.assert().failure();
+    assert.stderr(predicate::str::contains("does not exist"));
+
+    assert!(
+        !output_path.exists(),
+        "config command should not create output when workspace is invalid"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add the assert_cmd and predicates dev dependencies for CLI testing
- cover the config subcommand with assert_cmd smoke tests for generating output and handling missing workspaces

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e92b864be48323b52ed5ffc54eeec1