### PR TITLE
Add git branch status under chat input

### DIFF
--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -477,7 +477,7 @@ pub mod ui {
     pub const MODAL_CONTENT_HORIZONTAL_PADDING: u16 = 8;
     pub const MODAL_CONTENT_VERTICAL_PADDING: u16 = 6;
     pub const INLINE_HEADER_HEIGHT: u16 = 4;
-    pub const INLINE_INPUT_HEIGHT: u16 = 3;
+    pub const INLINE_INPUT_HEIGHT: u16 = 4;
     pub const INLINE_NAVIGATION_PERCENT: u16 = 32;
     pub const INLINE_NAVIGATION_MIN_WIDTH: u16 = 24;
     pub const INLINE_CONTENT_MIN_WIDTH: u16 = 48;

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -193,6 +193,10 @@ pub enum InlineCommand {
     SetHeaderContext {
         context: InlineHeaderContext,
     },
+    SetInputStatus {
+        left: Option<String>,
+        right: Option<String>,
+    },
     SetTheme {
         theme: InlineTheme,
     },
@@ -287,6 +291,12 @@ impl InlineHandle {
         let _ = self
             .sender
             .send(InlineCommand::SetHeaderContext { context });
+    }
+
+    pub fn set_input_status(&self, left: Option<String>, right: Option<String>) {
+        let _ = self
+            .sender
+            .send(InlineCommand::SetInputStatus { left, right });
     }
 
     pub fn set_theme(&self, theme: InlineTheme) {


### PR DESCRIPTION
## Summary
- add a git status helper to read the current branch and dirty state
- surface the branch and model/reasoning footer in the chat input area and refresh it during the agent loop
- extend the inline UI to render a two-line input footer and expose a handle command to update its content

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68ea383fed2483238df299feeb8fdf8f