### PR TITLE
Handle token counting failures gracefully

### DIFF
--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -573,13 +573,11 @@ async fn build_curator_messages(
         }
 
         let component = map_role_to_component(&message.role);
+        let component_id = format!("msg_{}", index);
+        let component_id_ref = Some(component_id.as_str());
         let estimated_tokens = if token_budget_enabled {
             match token_budget
-                .count_tokens_for_component(
-                    &materialized,
-                    component,
-                    Some(&format!("msg_{}", index)),
-                )
+                .count_tokens_for_component(&materialized, component, component_id_ref)
                 .await
             {
                 Ok(count) => count,
@@ -588,7 +586,11 @@ async fn build_curator_messages(
                         ?err,
                         "Failed to count tokens for conversation message; using rough estimate"
                     );
-                    materialized.len() / 4
+                    let estimate = materialized.len() / 4;
+                    token_budget
+                        .record_tokens_for_component(component, estimate, component_id_ref)
+                        .await;
+                    estimate
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- fall back to a rough estimate when token budget counting fails for conversation messages
- log a warning instead of surfacing an error so sessions continue without tokenizer support

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68e9d765f1908323aba78edbac743a6a