### PR TITLE
Update DeepSeek model identifiers to latest naming

### DIFF
--- a/docs/MODEL_UPDATE_IMPLEMENTATION.md
+++ b/docs/MODEL_UPDATE_IMPLEMENTATION.md
@@ -83,11 +83,11 @@ Update the VT Code codebase to focus on the latest and most capable AI models as
     - Qwen3Coder (`qwen/qwen3-coder`)
     - Qwen3Max (`qwen/qwen3-max`)
 4. Added DeepSeek models to ModelId enum:
-    - DeepSeekReasoner (`deepseek-reasoner`)
-    - DeepSeekChat (`deepseek-chat`)
+    - DeepSeekReasoner (`deepseek-r1`)
+    - DeepSeekChat (`deepseek-v3.2-exp`)
 5. Added DeepSeek models to ModelId enum:
     - DeepSeekChat (`deepseek/deepseek-chat-v3.1`)
-    - DeepSeekReasoner (`deepseek/deepseek-reasoner`)
+    - DeepSeekReasoner (`deepseek/deepseek-r1`)
 
 ### Phase 3: Provider Updates
 
@@ -109,8 +109,8 @@ Update the VT Code codebase to focus on the latest and most capable AI models as
 -   **API Key**: `DEEPSEEK_API_KEY`
 -   **Specialization**: Advanced reasoning models
 -   **Models**:
-    -   `deepseek-reasoner` - Latest reasoning model (Jan 2025, updated Aug 2025)
-    -   `deepseek-chat` - Latest chat model (Dec 2024, updated Aug 2025)
+    -   `deepseek-r1` - Latest reasoning model (released May 2025)
+    -   `deepseek-v3.2-exp` - Latest chat model (released Sep 2025)
 
 ## Updated Existing Providers
 

--- a/docs/context_engineering.md
+++ b/docs/context_engineering.md
@@ -180,7 +180,7 @@ Our tools are designed with context efficiency in mind:
 [context.token_budget]
 enabled = true
 # Model for tokenizer - use latest models from docs/models.json
-# Examples: "gpt-5-mini", "claude-sonnet-4", "grok-4", "deepseek-chat"
+# Examples: "gpt-5-mini", "claude-sonnet-4", "grok-4", "deepseek-v3.2-exp"
 model = "gpt-4o-mini"
 warning_threshold = 0.75  # Warn at 75% usage
 compaction_threshold = 0.85  # Compact at 85% usage

--- a/docs/models.json
+++ b/docs/models.json
@@ -224,9 +224,9 @@
     "name": "DeepSeek",
     "doc": "https://platform.deepseek.com/api-docs",
     "models": {
-      "deepseek-chat": {
-        "id": "deepseek-chat",
-        "name": "DeepSeek Chat",
+      "deepseek-v3.2-exp": {
+        "id": "deepseek-v3.2-exp",
+        "name": "DeepSeek V3.2 Exp",
         "reasoning": false,
         "tool_call": true,
         "modalities": {
@@ -239,9 +239,9 @@
         },
         "context": 128000
       },
-      "deepseek-reasoner": {
-        "id": "deepseek-reasoner",
-        "name": "DeepSeek Reasoner",
+      "deepseek-r1": {
+        "id": "deepseek-r1",
+        "name": "DeepSeek R1",
         "reasoning": true,
         "tool_call": true,
         "modalities": {

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -35,7 +35,8 @@ pub struct Cli {
     ///   • gpt-5 - OpenAI's latest
     ///   • claude-sonnet-4-5 - Anthropic's latest
     ///   • qwen/qwen3-4b-2507 - Qwen3 local model
-    ///   • deepseek-reasoner - DeepSeek reasoning model
+    ///   • deepseek-v3.2-exp - DeepSeek flagship chat model
+    ///   • deepseek-r1 - DeepSeek reasoning model
     ///   • x-ai/grok-code-fast-1 - OpenRouter Grok fast coding model
     ///   • qwen/qwen3-coder - OpenRouter Qwen3 Coder optimized for IDE usage
     ///   • grok-2-latest - xAI Grok flagship model
@@ -492,7 +493,7 @@ pub enum Commands {
         command: crate::cli::mcp_commands::McpCommands,
     },
 
-    /// **Manage models and providers** - configure and switch between LLM providers\n\n**Features:**\n• Support for latest models (DeepSeek, etc.)\n• Provider configuration and testing\n• Model performance comparison\n• API key management\n\n**Examples:**\n  vtcode models list\n  vtcode models set-provider deepseek\n  vtcode models set-model deepseek-reasoner
+    /// **Manage models and providers** - configure and switch between LLM providers\n\n**Features:**\n• Support for latest models (DeepSeek, etc.)\n• Provider configuration and testing\n• Model performance comparison\n• API key management\n\n**Examples:**\n  vtcode models list\n  vtcode models set-provider deepseek\n  vtcode models set-model deepseek-r1
     Models {
         #[command(subcommand)]
         command: ModelCommands,
@@ -536,7 +537,7 @@ pub enum ModelCommands {
         provider: String,
     },
 
-    /// Set default model (e.g., deepseek-reasoner, gpt-5, claude-sonnet-4-5)
+    /// Set default model (e.g., deepseek-r1, gpt-5, claude-sonnet-4-5)
     #[command(name = "set-model")]
     SetModel {
         /// Model name to set as default

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -219,11 +219,11 @@ pub mod models {
 
     // DeepSeek models (native API)
     pub mod deepseek {
-        pub const DEFAULT_MODEL: &str = "deepseek-chat";
-        pub const SUPPORTED_MODELS: &[&str] = &["deepseek-chat", "deepseek-reasoner"];
+        pub const DEFAULT_MODEL: &str = "deepseek-v3.2-exp";
+        pub const SUPPORTED_MODELS: &[&str] = &["deepseek-v3.2-exp", "deepseek-r1"];
 
-        pub const DEEPSEEK_CHAT: &str = "deepseek-chat";
-        pub const DEEPSEEK_REASONER: &str = "deepseek-reasoner";
+        pub const DEEPSEEK_CHAT: &str = "deepseek-v3.2-exp";
+        pub const DEEPSEEK_REASONER: &str = "deepseek-r1";
     }
 
     // Anthropic models (from docs/models.json) - Updated for tool use best practices

--- a/vtcode-core/src/llm/mod.rs
+++ b/vtcode-core/src/llm/mod.rs
@@ -21,7 +21,7 @@
 //! | OpenAI | ✓ | gpt-5, gpt-4.1, gpt-5-mini |
 //! | Anthropic | ✓ | claude-4.1-opus, claude-4-sonnet |
 //! | xAI | ✓ | grok-2-latest, grok-2-mini |
-//! | DeepSeek | ✓ | deepseek-chat, deepseek-reasoner |
+//! | DeepSeek | ✓ | deepseek-v3.2-exp, deepseek-r1 |
 //! | Z.AI | ✓ | glm-4.6 |
 //!
 //! ## Basic Usage

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -170,7 +170,7 @@ enabled = true
 # - GPT: "gpt-5", "gpt-5-mini", "gpt-4o-mini"
 # - Claude: "claude-sonnet-4", "claude-opus-4", "claude-3.5-haiku"
 # - Grok: "grok-4", "grok-3-mini"
-# - DeepSeek: "deepseek-chat", "deepseek-reasoner"
+# - DeepSeek: "deepseek-v3.2-exp", "deepseek-r1"
 model = "gpt-4o-mini"
 # Warning threshold (0.75 = 75% of context window)
 warning_threshold = 0.75


### PR DESCRIPTION
## Summary
- update the DeepSeek provider defaults to the new `deepseek-v3.2-exp` and `deepseek-r1` identifiers from the latest pricing guide
- refresh CLI help, documentation, and example configuration to reference the new DeepSeek model names
- align `docs/models.json` with the current DeepSeek model IDs so tooling uses the latest naming

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea9d1b98e88323b5f9f86fadfbbc61