### PR TITLE
Add headless exec command with structured events

### DIFF
--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -122,6 +122,12 @@ pub async fn handle_exec_command(
         .context("Failed to apply workspace configuration to exec runner")?;
     runner.enable_full_auto(&automation_cfg.allowed_tools);
     runner.set_quiet(options.json);
+    if options.json {
+        runner.set_event_handler(|event| match serde_json::to_string(event) {
+            Ok(line) => println!("{}", line),
+            Err(err) => eprintln!("Failed to serialize exec event: {err}"),
+        });
+    }
 
     let task = Task {
         id: EXEC_TASK_ID.to_string(),
@@ -142,11 +148,7 @@ pub async fn handle_exec_command(
         event_lines.push(line);
     }
 
-    if options.json {
-        for line in &event_lines {
-            println!("{}", line);
-        }
-    } else {
+    if !options.json {
         if !result.summary.trim().is_empty() {
             println!(
                 "{} {}",

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,0 +1,200 @@
+use anyhow::{Context, Result, anyhow, bail};
+use console::style;
+use std::fs;
+use std::io::{self, IsTerminal, Read};
+use std::path::PathBuf;
+use std::str::FromStr;
+use vtcode_core::config::VTCodeConfig;
+use vtcode_core::config::models::ModelId;
+use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
+use vtcode_core::core::agent::runner::{AgentRunner, ContextItem, Task};
+use vtcode_core::core::agent::types::AgentType;
+use vtcode_core::exec::events::{ThreadEvent, ThreadItemDetails};
+use vtcode_core::utils::dot_config::WorkspaceTrustLevel;
+
+use crate::workspace_trust::workspace_trust_level;
+
+const EXEC_SESSION_PREFIX: &str = "exec-task";
+const EXEC_TASK_ID: &str = "exec-task";
+const EXEC_TASK_TITLE: &str = "Exec Task";
+
+#[derive(Debug, Clone)]
+pub struct ExecCommandOptions {
+    pub json: bool,
+    pub events_path: Option<PathBuf>,
+    pub last_message_file: Option<PathBuf>,
+}
+
+fn resolve_prompt(prompt_arg: Option<String>) -> Result<String> {
+    match prompt_arg {
+        Some(p) if p != "-" => Ok(p),
+        maybe_dash => {
+            let force_stdin = matches!(maybe_dash.as_deref(), Some("-"));
+            if io::stdin().is_terminal() && !force_stdin {
+                bail!(
+                    "No prompt provided. Pass a prompt argument, pipe input, or use '-' to read from stdin."
+                );
+            }
+            if !force_stdin {
+                eprintln!("Reading prompt from stdin...");
+            }
+            let mut buffer = String::new();
+            io::stdin()
+                .read_to_string(&mut buffer)
+                .context("Failed to read prompt from stdin")?;
+            if buffer.trim().is_empty() {
+                bail!("No prompt provided via stdin.");
+            }
+            Ok(buffer)
+        }
+    }
+}
+
+fn last_agent_message(events: &[ThreadEvent]) -> Option<&str> {
+    events.iter().rev().find_map(|event| match event {
+        ThreadEvent::ItemCompleted(completed) => match &completed.item.details {
+            ThreadItemDetails::AgentMessage(item) => Some(item.text.as_str()),
+            _ => None,
+        },
+        _ => None,
+    })
+}
+
+pub async fn handle_exec_command(
+    config: &CoreAgentConfig,
+    vt_cfg: &VTCodeConfig,
+    options: ExecCommandOptions,
+    prompt_arg: Option<String>,
+) -> Result<()> {
+    let prompt = resolve_prompt(prompt_arg)?;
+
+    let trust_level = workspace_trust_level(&config.workspace)
+        .context("Failed to determine workspace trust level")?;
+
+    match trust_level {
+        Some(WorkspaceTrustLevel::FullAuto) => {}
+        Some(level) => {
+            bail!(
+                "Workspace trust level '{level}' does not permit exec runs. Upgrade trust to full auto."
+            );
+        }
+        None => {
+            bail!(
+                "Workspace is not trusted. Start vtcode interactively once and mark it as full auto before using exec."
+            );
+        }
+    }
+
+    let automation_cfg = &vt_cfg.automation.full_auto;
+    if !automation_cfg.enabled {
+        bail!(
+            "Automation is disabled in configuration. Enable [automation.full_auto] to continue."
+        );
+    }
+
+    let model_id = ModelId::from_str(&config.model).with_context(|| {
+        format!(
+            "Model '{}' is not recognized for exec command. Update vtcode.toml to a supported identifier.",
+            config.model
+        )
+    })?;
+
+    let session_id = format!(
+        "{EXEC_SESSION_PREFIX}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|err| anyhow!("Failed to derive session identifier timestamp: {}", err))?
+            .as_secs()
+    );
+
+    let mut runner = AgentRunner::new(
+        AgentType::Single,
+        model_id,
+        config.api_key.clone(),
+        config.workspace.clone(),
+        session_id,
+        Some(config.reasoning_effort),
+    )?;
+
+    runner
+        .apply_workspace_configuration(vt_cfg)
+        .await
+        .context("Failed to apply workspace configuration to exec runner")?;
+    runner.enable_full_auto(&automation_cfg.allowed_tools);
+    runner.set_quiet(options.json);
+
+    let task = Task {
+        id: EXEC_TASK_ID.to_string(),
+        title: EXEC_TASK_TITLE.to_string(),
+        description: prompt.trim().to_string(),
+        instructions: None,
+    };
+
+    let result = runner
+        .execute_task(&task, &[] as &[ContextItem])
+        .await
+        .context("Failed to execute autonomous task")?;
+
+    let mut event_lines = Vec::new();
+    for event in &result.thread_events {
+        let line =
+            serde_json::to_string(event).context("Failed to serialize exec event to JSON")?;
+        event_lines.push(line);
+    }
+
+    if options.json {
+        for line in &event_lines {
+            println!("{}", line);
+        }
+    } else {
+        if !result.summary.trim().is_empty() {
+            println!(
+                "{} {}",
+                style("[SUMMARY]").green().bold(),
+                result.summary.trim()
+            );
+        }
+        if !result.modified_files.is_empty() {
+            println!(
+                "{} {}",
+                style("[FILES]").cyan().bold(),
+                result.modified_files.join(", ")
+            );
+        }
+        if !result.executed_commands.is_empty() {
+            println!(
+                "{} {}",
+                style("[COMMANDS]").cyan().bold(),
+                result.executed_commands.join(", ")
+            );
+        }
+        if !result.warnings.is_empty() {
+            for warning in &result.warnings {
+                println!("{} {}", style("[WARNING]").yellow().bold(), warning);
+            }
+        }
+    }
+
+    if let Some(path) = &options.events_path {
+        let mut body = event_lines.join("\n");
+        if !body.is_empty() {
+            body.push('\n');
+        }
+        fs::write(path, body)
+            .with_context(|| format!("Failed to write exec events to {}", path.display()))?;
+    }
+
+    if let Some(path) = &options.last_message_file {
+        let message = last_agent_message(&result.thread_events).unwrap_or_default();
+        fs::write(path, message)
+            .with_context(|| format!("Failed to write last message file {}", path.display()))?;
+        if message.is_empty() {
+            eprintln!(
+                "Warning: no last agent message; wrote empty content to {}",
+                path.display()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod chat_tools;
 pub mod compress_context;
 pub mod config;
 pub mod create_project;
+pub mod exec;
 pub mod init;
 pub mod init_project;
 pub mod man;
@@ -25,6 +26,7 @@ pub use analyze::handle_analyze_command;
 pub use ask::handle_ask_command as handle_ask_single_command;
 pub use auto::handle_auto_task_command;
 pub use benchmark::{BenchmarkCommandOptions, handle_benchmark_command};
+pub use exec::{ExecCommandOptions, handle_exec_command};
 // Use the modular runloop by default
 pub use chat_tools::handle_chat_command;
 pub use compress_context::handle_compress_context_command;

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,19 @@ async fn main() -> Result<()> {
         Some(Commands::Ask { prompt }) => {
             cli::handle_ask_single_command(&core_cfg, prompt).await?;
         }
+        Some(Commands::Exec {
+            json,
+            events,
+            last_message_file,
+            prompt,
+        }) => {
+            let options = cli::ExecCommandOptions {
+                json: *json,
+                events_path: events.clone(),
+                last_message_file: last_message_file.clone(),
+            };
+            cli::handle_exec_command(&core_cfg, cfg, options, prompt.clone()).await?;
+        }
         Some(Commands::ChatVerbose) => {
             // Reuse chat path; verbose behavior is handled in the module if applicable
             cli::handle_chat_command(&core_cfg, skip_confirmations, full_auto_requested).await?;

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -243,6 +243,31 @@ pub enum Commands {
     /// Example: vtcode ask "Explain Rust ownership"
     Ask { prompt: String },
 
+    /// **Headless execution mode** mirroring Codex exec semantics
+    ///
+    /// Features:
+    ///   • Autonomous run using workspace automation settings
+    ///   • Optional JSONL output stream for tool integrations
+    ///   • Support for writing the final message to disk
+    ///
+    /// Prompt handling:
+    ///   • Positional argument or `-` to read from stdin
+    ///   • When omitted and stdin is a TTY, the command exits with an error
+    Exec {
+        /// Emit structured JSON events to stdout (one per line)
+        #[arg(long)]
+        json: bool,
+        /// Optional path to write the JSONL transcript
+        #[arg(long, value_name = "PATH", value_hint = ValueHint::FilePath)]
+        events: Option<PathBuf>,
+        /// Write the last agent message to this file
+        #[arg(long, value_name = "PATH", value_hint = ValueHint::FilePath)]
+        last_message_file: Option<PathBuf>,
+        /// Prompt to execute. Use `-` to force reading from stdin.
+        #[arg(value_name = "PROMPT")]
+        prompt: Option<String>,
+    },
+
     /// **Verbose interactive chat** with enhanced transparency
     ///
     /// Shows:

--- a/vtcode-core/src/core/agent/runner.rs
+++ b/vtcode-core/src/core/agent/runner.rs
@@ -6,6 +6,11 @@ use crate::config::loader::ConfigManager;
 use crate::config::models::{ModelId, Provider as ModelProvider};
 use crate::config::types::ReasoningEffortLevel;
 use crate::core::agent::types::AgentType;
+use crate::exec::events::{
+    AgentMessageItem, CommandExecutionItem, CommandExecutionStatus, ErrorItem, FileChangeItem,
+    FileUpdateChange, ItemCompletedEvent, PatchApplyStatus, PatchChangeKind, ThreadEvent,
+    ThreadItem, ThreadItemDetails, ThreadStartedEvent, TurnCompletedEvent, TurnStartedEvent, Usage,
+};
 use crate::gemini::{Content, Part, Tool};
 use crate::llm::factory::create_provider_for_model;
 use crate::llm::provider as uni_provider;
@@ -22,6 +27,107 @@ use std::sync::Arc;
 use tokio::time::{Duration, timeout};
 use tracing::{info, warn};
 
+macro_rules! runner_println {
+    ($runner:expr, $($arg:tt)*) => {
+        if !$runner.quiet {
+            println!($($arg)*);
+        }
+    };
+}
+
+struct ExecEventRecorder {
+    events: Vec<ThreadEvent>,
+    next_item_index: u64,
+}
+
+impl ExecEventRecorder {
+    fn new(thread_id: String) -> Self {
+        let mut events = Vec::new();
+        events.push(ThreadEvent::ThreadStarted(ThreadStartedEvent { thread_id }));
+        Self {
+            events,
+            next_item_index: 0,
+        }
+    }
+
+    fn next_item_id(&mut self) -> String {
+        let id = self.next_item_index;
+        self.next_item_index += 1;
+        format!("item_{id}")
+    }
+
+    fn turn_started(&mut self) {
+        self.events
+            .push(ThreadEvent::TurnStarted(TurnStartedEvent::default()));
+    }
+
+    fn turn_completed(&mut self) {
+        self.events
+            .push(ThreadEvent::TurnCompleted(TurnCompletedEvent {
+                usage: Usage::default(),
+            }));
+    }
+
+    fn agent_message(&mut self, text: &str) {
+        if text.trim().is_empty() {
+            return;
+        }
+        let item = ThreadItem {
+            id: self.next_item_id(),
+            details: ThreadItemDetails::AgentMessage(AgentMessageItem {
+                text: text.to_string(),
+            }),
+        };
+        self.events
+            .push(ThreadEvent::ItemCompleted(ItemCompletedEvent { item }));
+    }
+
+    fn command_completed(&mut self, command: &str) {
+        let item = ThreadItem {
+            id: self.next_item_id(),
+            details: ThreadItemDetails::CommandExecution(CommandExecutionItem {
+                command: command.to_string(),
+                aggregated_output: String::new(),
+                exit_code: None,
+                status: CommandExecutionStatus::Completed,
+            }),
+        };
+        self.events
+            .push(ThreadEvent::ItemCompleted(ItemCompletedEvent { item }));
+    }
+
+    fn file_change_completed(&mut self, path: &str) {
+        let change = FileUpdateChange {
+            path: path.to_string(),
+            kind: PatchChangeKind::Update,
+        };
+        let item = ThreadItem {
+            id: self.next_item_id(),
+            details: ThreadItemDetails::FileChange(FileChangeItem {
+                changes: vec![change],
+                status: PatchApplyStatus::Completed,
+            }),
+        };
+        self.events
+            .push(ThreadEvent::ItemCompleted(ItemCompletedEvent { item }));
+    }
+
+    fn warning(&mut self, message: &str) {
+        let item = ThreadItem {
+            id: self.next_item_id(),
+            details: ThreadItemDetails::Error(ErrorItem {
+                message: message.to_string(),
+            }),
+        };
+        self.events
+            .push(ThreadEvent::ItemCompleted(ItemCompletedEvent { item }));
+    }
+
+    fn finish(self) -> Vec<ThreadEvent> {
+        self.events
+    }
+}
+
 /// Individual agent runner for executing specialized agent tasks
 pub struct AgentRunner {
     /// Agent type and configuration
@@ -35,7 +141,7 @@ pub struct AgentRunner {
     /// System prompt content
     system_prompt: String,
     /// Session information
-    _session_id: String,
+    session_id: String,
     /// Workspace path
     _workspace: PathBuf,
     /// Model identifier
@@ -44,10 +150,15 @@ pub struct AgentRunner {
     _api_key: String,
     /// Reasoning effort level for models that support it
     reasoning_effort: Option<ReasoningEffortLevel>,
+    /// Suppress stdout output when emitting structured events
+    quiet: bool,
 }
 
 impl AgentRunner {
-    fn print_compact_response(agent: AgentType, text: &str) {
+    fn print_compact_response(agent: AgentType, text: &str, quiet: bool) {
+        if quiet {
+            return;
+        }
         use console::style;
         const MAX_CHARS: usize = 1200;
         const HEAD_CHARS: usize = 800;
@@ -165,12 +276,18 @@ impl AgentRunner {
             provider_client,
             tool_registry: ToolRegistry::new(workspace.clone()),
             system_prompt,
-            _session_id: session_id,
+            session_id,
             _workspace: workspace,
             model: model.as_str().to_string(),
             _api_key: api_key,
             reasoning_effort,
+            quiet: false,
         })
+    }
+
+    /// Enable or disable console output for this runner.
+    pub fn set_quiet(&mut self, quiet: bool) {
+        self.quiet = quiet;
     }
 
     /// Enable full-auto execution with the provided allow-list.
@@ -219,13 +336,17 @@ impl AgentRunner {
     ) -> Result<TaskResults> {
         // Agent execution status
         let agent_prefix = format!("[{}]", self.agent_type);
-        println!(
+        let mut event_recorder = ExecEventRecorder::new(self.session_id.clone());
+        event_recorder.turn_started();
+        runner_println!(
+            self,
             "{} {}",
             agent_prefix,
             self.create_progress_message("thinking", None)
         );
 
-        println!(
+        runner_println!(
+            self,
             "{} Executing {} task: {}",
             style("[AGENT]").blue().bold().on_black(),
             self.agent_type,
@@ -299,7 +420,8 @@ impl AgentRunner {
                 break;
             }
 
-            println!(
+            runner_println!(
+                self,
                 "{} {} is processing turn {}...",
                 agent_prefix,
                 style("(PROC)").yellow().bold(),
@@ -370,7 +492,8 @@ impl AgentRunner {
                     .generate(request.clone())
                     .await
                     .map_err(|e| {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {} Failed",
                             agent_prefix,
                             style("(ERROR)").red().bold().on_black()
@@ -384,7 +507,8 @@ impl AgentRunner {
                     })?;
 
                 // Update progress for successful response
-                println!(
+                runner_println!(
+                    self,
                     "{} {}",
                     agent_prefix,
                     format!(
@@ -401,7 +525,8 @@ impl AgentRunner {
                         had_tool_call = true;
                         for call in tool_calls {
                             let name = call.function.name.as_str();
-                            println!(
+                            runner_println!(
+                                self,
                                 "{} [{}] Calling tool: {}",
                                 style("[TOOL_CALL]").blue().bold(),
                                 self.agent_type,
@@ -412,7 +537,8 @@ impl AgentRunner {
                                 .unwrap_or_else(|_| serde_json::json!({}));
                             match self.execute_tool(name, &args).await {
                                 Ok(result) => {
-                                    println!(
+                                    runner_println!(
+                                        self,
                                         "{} {}",
                                         agent_prefix,
                                         format!(
@@ -429,16 +555,19 @@ impl AgentRunner {
                                         }],
                                     });
                                     executed_commands.push(name.to_string());
+                                    event_recorder.command_completed(name);
                                     if name == tools::WRITE_FILE {
                                         if let Some(filepath) =
                                             args.get("path").and_then(|p| p.as_str())
                                         {
                                             modified_files.push(filepath.to_string());
+                                            event_recorder.file_change_completed(filepath);
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    println!(
+                                    runner_println!(
+                                        self,
                                         "{} {}",
                                         agent_prefix,
                                         format!(
@@ -448,7 +577,9 @@ impl AgentRunner {
                                             e
                                         )
                                     );
-                                    warnings.push(format!("Tool {} failed: {}", name, e));
+                                    let warning_message = format!("Tool {} failed: {}", name, e);
+                                    warnings.push(warning_message.clone());
+                                    event_recorder.warning(&warning_message);
                                     conversation.push(Content {
                                         role: "user".to_string(),
                                         parts: vec![Part::Text {
@@ -465,7 +596,8 @@ impl AgentRunner {
                 let response_text = resp.content.clone().unwrap_or_default();
                 if !had_tool_call {
                     if !response_text.trim().is_empty() {
-                        Self::print_compact_response(self.agent_type, &response_text);
+                        Self::print_compact_response(self.agent_type, &response_text, self.quiet);
+                        event_recorder.agent_message(&response_text);
                         conversation.push(Content {
                             role: "model".to_string(),
                             parts: vec![Part::Text {
@@ -506,7 +638,8 @@ impl AgentRunner {
                         || response_lower.contains("no more actions needed");
                     if is_completed || has_explicit_completion {
                         has_completed = true;
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -521,7 +654,8 @@ impl AgentRunner {
                 let should_continue = had_tool_call || (!has_completed && turn < 9);
                 if !should_continue {
                     if has_completed {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -531,7 +665,8 @@ impl AgentRunner {
                             )
                         );
                     } else if turn >= 9 {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -541,7 +676,8 @@ impl AgentRunner {
                             )
                         );
                     } else {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -563,7 +699,8 @@ impl AgentRunner {
                     .generate(&serde_json::to_string(&request)?)
                     .await
                     .map_err(|e| {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {} Failed",
                             agent_prefix,
                             style("(ERROR)").red().bold().on_black()
@@ -582,7 +719,8 @@ impl AgentRunner {
             let response = response_opt.expect("response should be set for Gemini path");
 
             // Update progress for successful response
-            println!(
+            runner_println!(
+                self,
                 "{} {}",
                 agent_prefix,
                 format!(
@@ -613,7 +751,8 @@ impl AgentRunner {
                                     function.get("name").and_then(|n| n.as_str()),
                                     function.get("arguments"),
                                 ) {
-                                    println!(
+                                    runner_println!(
+                                        self,
                                         "{} [{}] Calling tool: {}",
                                         style("[TOOL_CALL]").blue().bold(),
                                         self.agent_type,
@@ -623,7 +762,8 @@ impl AgentRunner {
                                     // Execute the tool
                                     match self.execute_tool(name, &arguments.clone()).await {
                                         Ok(result) => {
-                                            println!(
+                                            runner_println!(
+                                                self,
                                                 "{} {}",
                                                 agent_prefix,
                                                 format!(
@@ -647,6 +787,7 @@ impl AgentRunner {
 
                                             // Track what the agent did
                                             executed_commands.push(name.to_string());
+                                            event_recorder.command_completed(name);
 
                                             // Special handling for certain tools
                                             if name == tools::WRITE_FILE {
@@ -654,11 +795,13 @@ impl AgentRunner {
                                                     arguments.get("path").and_then(|p| p.as_str())
                                                 {
                                                     modified_files.push(filepath.to_string());
+                                                    event_recorder.file_change_completed(filepath);
                                                 }
                                             }
                                         }
                                         Err(e) => {
-                                            println!(
+                                            runner_println!(
+                                                self,
                                                 "{} {}",
                                                 agent_prefix,
                                                 format!(
@@ -668,7 +811,10 @@ impl AgentRunner {
                                                     e
                                                 )
                                             );
-                                            warnings.push(format!("Tool {} failed: {}", name, e));
+                                            let warning_message =
+                                                format!("Tool {} failed: {}", name, e);
+                                            warnings.push(warning_message.clone());
+                                            event_recorder.warning(&warning_message);
                                             conversation.push(Content {
                                                 role: "user".to_string(), // Gemini API only accepts "user" and "model"
                                                 parts: vec![Part::Text {
@@ -689,7 +835,8 @@ impl AgentRunner {
                             function_call.get("name").and_then(|n| n.as_str()),
                             function_call.get("args"),
                         ) {
-                            println!(
+                            runner_println!(
+                                self,
                                 "{} [{}] Calling tool: {}",
                                 style("[TOOL_CALL]").blue().bold(),
                                 self.agent_type,
@@ -699,7 +846,8 @@ impl AgentRunner {
                             // Execute the tool
                             match self.execute_tool(name, args).await {
                                 Ok(result) => {
-                                    println!(
+                                    runner_println!(
+                                        self,
                                         "{} {}",
                                         agent_prefix,
                                         format!(
@@ -720,6 +868,7 @@ impl AgentRunner {
 
                                     // Track what the agent did
                                     executed_commands.push(name.to_string());
+                                    event_recorder.command_completed(name);
 
                                     // Special handling for certain tools
                                     if name == tools::WRITE_FILE {
@@ -727,11 +876,13 @@ impl AgentRunner {
                                             args.get("path").and_then(|p| p.as_str())
                                         {
                                             modified_files.push(filepath.to_string());
+                                            event_recorder.file_change_completed(filepath);
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    println!(
+                                    runner_println!(
+                                        self,
                                         "{} {}",
                                         agent_prefix,
                                         format!(
@@ -741,7 +892,9 @@ impl AgentRunner {
                                             e
                                         )
                                     );
-                                    warnings.push(format!("Tool {} failed: {}", name, e));
+                                    let warning_message = format!("Tool {} failed: {}", name, e);
+                                    warnings.push(warning_message.clone());
+                                    event_recorder.warning(&warning_message);
                                     conversation.push(Content {
                                         role: "user".to_string(), // Gemini API only accepts "user" and "model"
                                         parts: vec![Part::Text {
@@ -759,7 +912,8 @@ impl AgentRunner {
                     {
                         had_tool_call = true;
 
-                        println!(
+                        runner_println!(
+                            self,
                             "{} [{}] Executing tool code: {}",
                             style("[TOOL_EXEC]").cyan().bold().on_black(),
                             self.agent_type,
@@ -769,7 +923,8 @@ impl AgentRunner {
                         // Try to parse the tool_code as a function call
                         // This is a simplified parser for the format: function_name(args)
                         if let Some((func_name, args_str)) = parse_tool_code(tool_code) {
-                            println!(
+                            runner_println!(
+                                self,
                                 "{} [{}] Parsed tool: {} with args: {}",
                                 style("[TOOL_PARSE]").yellow().bold().on_black(),
                                 self.agent_type,
@@ -783,7 +938,8 @@ impl AgentRunner {
                                     // Execute the tool
                                     match self.execute_tool(&func_name, &arguments).await {
                                         Ok(result) => {
-                                            println!(
+                                            runner_println!(
+                                                self,
                                                 "{} {}",
                                                 agent_prefix,
                                                 format!(
@@ -807,6 +963,7 @@ impl AgentRunner {
 
                                             // Track what the agent did
                                             executed_commands.push(func_name.to_string());
+                                            event_recorder.command_completed(&func_name);
 
                                             // Special handling for certain tools
                                             if func_name == tools::WRITE_FILE {
@@ -814,11 +971,13 @@ impl AgentRunner {
                                                     arguments.get("path").and_then(|p| p.as_str())
                                                 {
                                                     modified_files.push(filepath.to_string());
+                                                    event_recorder.file_change_completed(filepath);
                                                 }
                                             }
                                         }
                                         Err(e) => {
-                                            println!(
+                                            runner_println!(
+                                                self,
                                                 "{} {}",
                                                 agent_prefix,
                                                 format!(
@@ -828,8 +987,10 @@ impl AgentRunner {
                                                     e
                                                 )
                                             );
-                                            warnings
-                                                .push(format!("Tool {} failed: {}", func_name, e));
+                                            let warning_message =
+                                                format!("Tool {} failed: {}", func_name, e);
+                                            warnings.push(warning_message.clone());
+                                            event_recorder.warning(&warning_message);
                                             conversation.push(Content {
                                                 role: "user".to_string(), // Gemini API only accepts "user" and "model"
                                                 parts: vec![Part::Text {
@@ -847,6 +1008,7 @@ impl AgentRunner {
                                         "Failed to parse tool arguments '{}': {}",
                                         args_str, e
                                     );
+                                    event_recorder.warning(&error_msg);
                                     warnings.push(error_msg.clone());
                                     conversation.push(Content {
                                         role: "user".to_string(), // Gemini API only accepts "user" and "model"
@@ -856,6 +1018,7 @@ impl AgentRunner {
                             }
                         } else {
                             let error_msg = format!("Failed to parse tool code: {}", tool_code);
+                            event_recorder.warning(&error_msg);
                             warnings.push(error_msg.clone());
                             conversation.push(Content {
                                 role: "user".to_string(), // Gemini API only accepts "user" and "model"
@@ -870,7 +1033,8 @@ impl AgentRunner {
                     {
                         had_tool_call = true;
 
-                        println!(
+                        runner_println!(
+                            self,
                             "{} [{}] Calling tool: {}",
                             style("[TOOL_CALL]").blue().bold().on_black(),
                             self.agent_type,
@@ -881,7 +1045,8 @@ impl AgentRunner {
                             // Execute the tool
                             match self.execute_tool(tool_name, parameters).await {
                                 Ok(result) => {
-                                    println!(
+                                    runner_println!(
+                                        self,
                                         "{} {}",
                                         agent_prefix,
                                         format!(
@@ -905,6 +1070,7 @@ impl AgentRunner {
 
                                     // Track what the agent did
                                     executed_commands.push(tool_name.to_string());
+                                    event_recorder.command_completed(tool_name);
 
                                     // Special handling for certain tools
                                     if tool_name == tools::WRITE_FILE {
@@ -912,11 +1078,13 @@ impl AgentRunner {
                                             parameters.get("path").and_then(|p| p.as_str())
                                         {
                                             modified_files.push(filepath.to_string());
+                                            event_recorder.file_change_completed(filepath);
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    println!(
+                                    runner_println!(
+                                        self,
                                         "{} {}",
                                         agent_prefix,
                                         format!(
@@ -926,7 +1094,10 @@ impl AgentRunner {
                                             e
                                         )
                                     );
-                                    warnings.push(format!("Tool {} failed: {}", tool_name, e));
+                                    let warning_message =
+                                        format!("Tool {} failed: {}", tool_name, e);
+                                    warnings.push(warning_message.clone());
+                                    event_recorder.warning(&warning_message);
                                     conversation.push(Content {
                                         role: "user".to_string(), // Gemini API only accepts "user" and "model"
                                         parts: vec![Part::Text {
@@ -938,7 +1109,12 @@ impl AgentRunner {
                         }
                     } else {
                         // Regular content response
-                        Self::print_compact_response(self.agent_type, response.content.trim());
+                        Self::print_compact_response(
+                            self.agent_type,
+                            response.content.trim(),
+                            self.quiet,
+                        );
+                        event_recorder.agent_message(response.content.trim());
                         conversation.push(Content {
                             role: "model".to_string(),
                             parts: vec![Part::Text {
@@ -948,7 +1124,12 @@ impl AgentRunner {
                     }
                 } else {
                     // Regular text response
-                    Self::print_compact_response(self.agent_type, response.content.trim());
+                    Self::print_compact_response(
+                        self.agent_type,
+                        response.content.trim(),
+                        self.quiet,
+                    );
+                    event_recorder.agent_message(response.content.trim());
                     conversation.push(Content {
                         role: "model".to_string(),
                         parts: vec![Part::Text {
@@ -995,7 +1176,8 @@ impl AgentRunner {
 
                     if is_completed || has_explicit_completion {
                         has_completed = true;
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -1013,7 +1195,8 @@ impl AgentRunner {
 
                 if !should_continue {
                     if has_completed {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -1023,7 +1206,8 @@ impl AgentRunner {
                             )
                         );
                     } else if turn >= 9 {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -1033,7 +1217,8 @@ impl AgentRunner {
                             )
                         );
                     } else {
-                        println!(
+                        runner_println!(
+                            self,
                             "{} {}",
                             agent_prefix,
                             format!(
@@ -1048,7 +1233,8 @@ impl AgentRunner {
             } else {
                 // Empty response - check if we should continue or if task is actually complete
                 if has_completed {
-                    println!(
+                    runner_println!(
+                        self,
                         "{} {}",
                         agent_prefix,
                         format!(
@@ -1059,7 +1245,8 @@ impl AgentRunner {
                     );
                     break;
                 } else if turn >= 9 {
-                    println!(
+                    runner_println!(
+                        self,
                         "{} {}",
                         agent_prefix,
                         format!(
@@ -1071,7 +1258,8 @@ impl AgentRunner {
                     break;
                 } else {
                     // Empty response but task not complete - this might indicate an issue
-                    println!(
+                    runner_println!(
+                        self,
                         "{} {}",
                         agent_prefix,
                         format!(
@@ -1086,7 +1274,7 @@ impl AgentRunner {
         }
 
         // Agent execution completed
-        println!("{} Done", agent_prefix);
+        runner_println!(self, "{} Done", agent_prefix);
 
         // Generate meaningful summary based on agent actions
         let summary = self.generate_task_summary(
@@ -1096,6 +1284,13 @@ impl AgentRunner {
             &conversation,
         );
 
+        if !summary.trim().is_empty() {
+            event_recorder.agent_message(&summary);
+        }
+
+        event_recorder.turn_completed();
+        let thread_events = event_recorder.finish();
+
         // Return task results
         Ok(TaskResults {
             created_contexts,
@@ -1103,6 +1298,7 @@ impl AgentRunner {
             executed_commands,
             summary,
             warnings,
+            thread_events,
         })
     }
 
@@ -1435,4 +1631,7 @@ pub struct TaskResults {
     /// Collected warnings emitted while processing the task.
     #[serde(default)]
     pub warnings: Vec<String>,
+    /// Structured execution timeline for headless modes.
+    #[serde(default)]
+    pub thread_events: Vec<ThreadEvent>,
 }

--- a/vtcode-core/src/exec/events.rs
+++ b/vtcode-core/src/exec/events.rs
@@ -1,0 +1,123 @@
+use serde::{Deserialize, Serialize};
+
+/// Structured events emitted during autonomous execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum ThreadEvent {
+    /// Indicates that a new execution thread has started.
+    #[serde(rename = "thread.started")]
+    ThreadStarted(ThreadStartedEvent),
+    /// Marks the beginning of an execution turn.
+    #[serde(rename = "turn.started")]
+    TurnStarted(TurnStartedEvent),
+    /// Marks the completion of an execution turn.
+    #[serde(rename = "turn.completed")]
+    TurnCompleted(TurnCompletedEvent),
+    /// Indicates that an item reached a terminal state.
+    #[serde(rename = "item.completed")]
+    ItemCompleted(ItemCompletedEvent),
+    /// Represents a fatal error.
+    #[serde(rename = "error")]
+    Error(ThreadErrorEvent),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ThreadStartedEvent {
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TurnStartedEvent {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TurnCompletedEvent {
+    pub usage: Usage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ThreadErrorEvent {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub cached_input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ItemCompletedEvent {
+    pub item: ThreadItem,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ThreadItem {
+    pub id: String,
+    #[serde(flatten)]
+    pub details: ThreadItemDetails,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThreadItemDetails {
+    AgentMessage(AgentMessageItem),
+    CommandExecution(CommandExecutionItem),
+    FileChange(FileChangeItem),
+    Error(ErrorItem),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentMessageItem {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandExecutionStatus {
+    #[default]
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandExecutionItem {
+    pub command: String,
+    #[serde(default)]
+    pub aggregated_output: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub status: CommandExecutionStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileChangeItem {
+    pub changes: Vec<FileUpdateChange>,
+    pub status: PatchApplyStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileUpdateChange {
+    pub path: String,
+    pub kind: PatchChangeKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchApplyStatus {
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchChangeKind {
+    Add,
+    Delete,
+    Update,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorItem {
+    pub message: String,
+}

--- a/vtcode-core/src/exec/mod.rs
+++ b/vtcode-core/src/exec/mod.rs
@@ -1,0 +1,1 @@
+pub mod events;

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -129,6 +129,7 @@ pub mod commands;
 pub mod config;
 pub mod constants;
 pub mod core;
+pub mod exec;
 pub mod gemini;
 pub mod llm;
 pub mod markdown_storage;
@@ -170,6 +171,11 @@ pub use core::conversation_summarizer::ConversationSummarizer;
 pub use core::performance_profiler::PerformanceProfiler;
 pub use core::prompt_caching::{CacheStats, PromptCache, PromptCacheConfig, PromptOptimizer};
 pub use core::timeout_detector::TimeoutDetector;
+pub use exec::events::{
+    AgentMessageItem, CommandExecutionItem, CommandExecutionStatus, ErrorItem, FileChangeItem,
+    FileUpdateChange, PatchApplyStatus, PatchChangeKind, ThreadEvent, ThreadItem,
+    ThreadItemDetails, TurnCompletedEvent, TurnStartedEvent, Usage,
+};
 pub use gemini::{Content, FunctionDeclaration, Part};
 pub use llm::{AnyClient, make_client};
 pub use markdown_storage::{MarkdownStorage, ProjectData, ProjectStorage, SimpleKVStorage};


### PR DESCRIPTION
## Summary
- add a new `exec` CLI command that mirrors codex exec behaviors, including stdin prompt support, JSONL event emission, and optional last-message output
- extend the agent runner with a structured event recorder and quiet mode so exec can stream tool activity without interleaved human logs
- expose the new exec event models through `vtcode-core` and wire the command into the CLI surface

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea9e119fe483239bd514db340982ff