### PR TITLE
Fix docs.rs warnings in vtcode-core doc comments

### DIFF
--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -434,7 +434,7 @@ pub enum Commands {
     /// Usage: vtcode init
     Init,
 
-    /// **Initialize project with dot-folder structure** - sets up ~/.vtcode/projects/<project-name> structure
+    /// **Initialize project with dot-folder structure** - sets up `~/.vtcode/projects/<project-name>` structure
     ///
     /// Features:
     ///   • Creates project directory structure in ~/.vtcode/projects/

--- a/vtcode-core/src/commands/init.rs
+++ b/vtcode-core/src/commands/init.rs
@@ -1,7 +1,7 @@
 //! Init command implementation - project analysis and Repository Guidelines generation
 //!
 //! Generates AGENTS.md files following the standardized contributor guide format
-//! as specified in https://github.com/openai/codex/blob/main/codex-rs/tui/prompt_for_init_command.md
+//! as specified in <https://github.com/openai/codex/blob/main/codex-rs/tui/prompt_for_init_command.md>
 //!
 //! This tool analyzes any repository and generates a concise (200-400 words) AGENTS.md file
 //! that serves as a contributor guide, adapting content based on the specific project structure,

--- a/vtcode-core/src/mcp_client.rs
+++ b/vtcode-core/src/mcp_client.rs
@@ -1,13 +1,13 @@
 //! MCP client management built on top of the Codex MCP building blocks.
 //!
 //! This module adapts the reference MCP client, server and type
-//! definitions from https://github.com/openai/codex to integrate them
+//! definitions from <https://github.com/openai/codex> to integrate them
 //! with VTCode's multi-provider configuration model. The original
 //! implementation inside this project had grown organically and mixed a
 //! large amount of bookkeeping logic with the lower level rmcp client
 //! transport. The rewritten version keeps the VTCode specific surface
 //! (allow lists, tool indexing, status reporting) but delegates the
-//! actual protocol interaction to a lightweight [`RmcpClient`] adapter
+//! actual protocol interaction to a lightweight `RmcpClient` adapter
 //! that mirrors Codex' `mcp-client` crate. This dramatically reduces
 //! the amount of bespoke glue we have to maintain while aligning the
 //! behaviour with the upstream MCP implementations.

--- a/vtcode-core/src/utils/utils.rs
+++ b/vtcode-core/src/utils/utils.rs
@@ -141,7 +141,7 @@ pub fn build_project_overview(root: &Path) -> Option<ProjectOverview> {
     Some(overview)
 }
 
-/// Extract a string value from a simple TOML key assignment within [package]
+/// Extract a string value from a simple TOML key assignment within \[package]
 pub fn extract_toml_str(content: &str, key: &str) -> Option<String> {
     // Only consider the [package] section to avoid matching other tables
     let pkg_section = if let Some(start) = content.find("[package]") {


### PR DESCRIPTION
## Summary
- escape bare links and HTML in vtcode-core documentation comments so docs.rs builds without warnings
- clarify MCP adapter reference without linking to a private type
- escape TOML section reference to avoid broken intra-doc links

## Testing
- cargo fmt
- cargo doc
- cargo clippy
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68eb452757fc8323824a6fe323775d52