### PR TITLE
Improve Zed ACP list_files tool path handling

### DIFF
--- a/vtcode-core/src/tools/types.rs
+++ b/vtcode-core/src/tools/types.rs
@@ -100,6 +100,7 @@ pub struct EditInput {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ListInput {
+    #[serde(default = "default_list_path")]
     pub path: String,
     #[serde(default = "default_max_items")]
     pub max_items: usize,
@@ -159,6 +160,10 @@ pub struct VTCodePtySession {
 // Default value functions
 fn default_max_items() -> usize {
     1000
+}
+
+fn default_list_path() -> String {
+    ".".to_string()
 }
 fn default_write_mode() -> String {
     "overwrite".to_string()


### PR DESCRIPTION
## Summary
- allow the Zed ACP `list_files` tool to resolve URIs and default to the workspace root when no path is provided
- extend the list files JSON schema and tool input defaults, and add regression tests covering URI and default path handling

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ed2a616c3483239f575a90859539c4