### PR TITLE
Fix run_terminal_cmd compatibility for ACP

### DIFF
--- a/vtcode-core/src/tools/registry/declarations.rs
+++ b/vtcode-core/src/tools/registry/declarations.rs
@@ -112,11 +112,22 @@ fn base_function_declarations() -> Vec<FunctionDeclaration> {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "command": {"type": "array", "items": {"type": "string"}, "description": "Program + args as array"},
+                    "command": {
+                        "description": "Program + args as array or legacy string",
+                        "oneOf": [
+                            {"type": "array", "items": {"type": "string"}},
+                            {"type": "string"}
+                        ]
+                    },
                     "working_dir": {"type": "string", "description": "Working directory relative to workspace"},
+                    "cwd": {"type": "string", "description": "Deprecated alias for working_dir"},
                     "timeout_secs": {"type": "integer", "description": "Command timeout in seconds (default: 30)", "default": 30},
+                    "timeout": {"type": ["integer", "number"], "description": "Deprecated alias for timeout_secs"},
                     "mode": {"type": "string", "description": "Execution mode: 'terminal' | 'pty' (delegates to interactive shell)", "default": "terminal"},
-                    "response_format": {"type": "string", "description": "'concise' (default) or 'detailed'", "default": "concise"}
+                    "tty": {"type": "boolean", "description": "Deprecated alias for mode='pty'"},
+                    "response_format": {"type": "string", "description": "'concise' (default) or 'detailed'", "default": "concise"},
+                    "shell": {"type": "string", "description": "Preferred shell executable"},
+                    "login": {"type": "boolean", "description": "Use login shell semantics when spawning the shell"}
                 },
                 "required": ["command"]
             }),


### PR DESCRIPTION
## Summary
- accept legacy ACP payload fields for `run_terminal_cmd`, including `cwd`, `timeout`, and `tty`
- document the backwards compatible parameters in the `run_terminal_cmd` function schema so ACP clients can send either strings or arrays

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68ee9e19ddd08323860bc119bcac57b3