### PR TITLE
Add Claude Haiku 4.5 to Anthropic models

### DIFF
--- a/docs/models.json
+++ b/docs/models.json
@@ -1285,6 +1285,21 @@
           "output": 1.5e-05
         }
       },
+      "anthropic/claude-haiku-4.5": {
+        "id": "anthropic/claude-haiku-4.5",
+        "name": "Anthropic: Claude Haiku 4.5",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 200000
+      },
       "anthropic/claude-opus-4.1": {
         "id": "anthropic/claude-opus-4.1",
         "name": "Anthropic: Claude Opus 4.1",

--- a/docs/models.json
+++ b/docs/models.json
@@ -1288,7 +1288,7 @@
       "anthropic/claude-haiku-4.5": {
         "id": "anthropic/claude-haiku-4.5",
         "name": "Anthropic: Claude Haiku 4.5",
-        "reasoning": false,
+        "reasoning": true,
         "tool_call": true,
         "modalities": {
           "input": [

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -574,7 +574,10 @@ fn render_step_one_inline(
         if provider == Provider::Ollama {
             items.push(InlineListItem {
                 title: "Custom Ollama model".to_string(),
-                subtitle: Some("Enter a custom Ollama model ID (e.g., qwen3:1.7b, llama3:8b, etc.)".to_string()),
+                subtitle: Some(
+                    "Enter a custom Ollama model ID (e.g., qwen3:1.7b, llama3:8b, etc.)"
+                        .to_string(),
+                ),
                 badge: Some("Local".to_string()),
                 indent: 2,
                 selection: Some(InlineListSelection::CustomModel),
@@ -650,7 +653,7 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
             )?;
             renderer.line(MessageStyle::Info, &format!("      {}", option.description))?;
         }
-        
+
         // Add custom Ollama model option when in the Ollama provider section
         if provider == Provider::Ollama {
             renderer.line(
@@ -1044,6 +1047,15 @@ mod tests {
         assert!(has_model(options, ModelId::MoonshotKimiLatest32k));
         assert!(has_model(options, ModelId::MoonshotKimiLatest128k));
         assert!(has_model(options, ModelId::OpenRouterMoonshotaiKimiK20905));
+    }
+
+    #[test]
+    fn model_picker_lists_new_anthropic_models() {
+        let options = MODEL_OPTIONS.as_slice();
+        assert!(has_model(options, ModelId::ClaudeOpus41));
+        assert!(has_model(options, ModelId::ClaudeSonnet45));
+        assert!(has_model(options, ModelId::ClaudeHaiku45));
+        assert!(has_model(options, ModelId::ClaudeSonnet4));
     }
 
     #[test]

--- a/src/agent/runloop/text_tools.rs
+++ b/src/agent/runloop/text_tools.rs
@@ -348,7 +348,11 @@ fn parse_structured_block(block: &str) -> Option<(String, Value)> {
         raw_name[..pos].trim().to_string()
     } else {
         // Normal case - trim end of colons and equals
-        raw_name.trim().trim_end_matches([':', '=']).trim().to_string()
+        raw_name
+            .trim()
+            .trim_end_matches([':', '='])
+            .trim()
+            .to_string()
     };
 
     if name.is_empty() {
@@ -651,8 +655,6 @@ mod tests {
             })
         );
     }
-
-
 
     #[test]
     fn test_detect_textual_tool_call_canonicalizes_name_variants() {

--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -1381,8 +1381,6 @@ mod tests {
         assert_eq!(header, git.header);
     }
 
-
-
     #[test]
     fn detects_ls_styles_for_directories_and_executables() {
         use anstyle::AnsiColor;

--- a/tests/integration_modular.rs
+++ b/tests/integration_modular.rs
@@ -37,7 +37,15 @@ fn test_config_module_integration() {
     assert!(
         matches!(
             loaded_config.agent.provider.as_str(),
-            "gemini" | "openai" | "anthropic" | "openrouter" | "xai" | "zai" | "moonshot" | "deepseek" | "ollama"
+            "gemini"
+                | "openai"
+                | "anthropic"
+                | "openrouter"
+                | "xai"
+                | "zai"
+                | "moonshot"
+                | "deepseek"
+                | "ollama"
         ),
         "unexpected provider '{}' in loaded config",
         loaded_config.agent.provider

--- a/tests/llm_providers_test.rs
+++ b/tests/llm_providers_test.rs
@@ -259,9 +259,10 @@ fn test_provider_supported_models() {
     let anthropic = AnthropicProvider::new("test_key".to_string());
     let anthropic_models = anthropic.supported_models();
     assert!(anthropic_models.contains(&models::CLAUDE_SONNET_4_5.to_string()));
+    assert!(anthropic_models.contains(&models::CLAUDE_HAIKU_4_5.to_string()));
     assert!(anthropic_models.contains(&models::CLAUDE_SONNET_4_20250514.to_string()));
     assert!(anthropic_models.contains(&"claude-opus-4-1-20250805".to_string()));
-    assert!(anthropic_models.len() >= 2);
+    assert!(anthropic_models.len() >= 3);
 
     let openrouter = OpenRouterProvider::new("test_key".to_string());
     let openrouter_models = openrouter.supported_models();

--- a/tests/models_sync.rs
+++ b/tests/models_sync.rs
@@ -208,6 +208,7 @@ fn backwards_compatibility_constants() {
     assert!(!models::GEMINI_2_5_FLASH.is_empty());
     assert!(!models::GPT_5.is_empty());
     assert!(!models::CLAUDE_SONNET_4_5.is_empty());
+    assert!(!models::CLAUDE_HAIKU_4_5.is_empty());
     assert!(!models::CLAUDE_SONNET_4_20250514.is_empty());
 
     // Test that backwards compatibility constants match the new structure
@@ -216,6 +217,10 @@ fn backwards_compatibility_constants() {
     assert_eq!(
         models::CLAUDE_SONNET_4_5,
         models::anthropic::CLAUDE_SONNET_4_5
+    );
+    assert_eq!(
+        models::CLAUDE_HAIKU_4_5,
+        models::anthropic::CLAUDE_HAIKU_4_5
     );
     assert_eq!(
         models::CLAUDE_SONNET_4_20250514,

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -250,6 +250,13 @@ pub mod models {
         pub const CLAUDE_SONNET_4_5: &str = "claude-sonnet-4-5";
         pub const CLAUDE_HAIKU_4_5: &str = "claude-haiku-4-5";
         pub const CLAUDE_SONNET_4_20250514: &str = "claude-sonnet-4-20250514";
+
+        /// Models that accept the reasoning effort parameter
+        pub const REASONING_MODELS: &[&str] = &[
+            CLAUDE_OPUS_4_1_20250805,
+            CLAUDE_SONNET_4_5,
+            CLAUDE_SONNET_4_20250514,
+        ];
     }
 
     // xAI models

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -241,12 +241,14 @@ pub mod models {
         pub const SUPPORTED_MODELS: &[&str] = &[
             "claude-opus-4-1-20250805", // Latest: Opus 4.1 (2025-08-05)
             "claude-sonnet-4-5",        // Latest: Sonnet 4.5 (2025-09-29)
+            "claude-haiku-4-5",         // Latest: Haiku 4.5 (2025-09-29)
             "claude-sonnet-4-20250514", // Previous: Sonnet 4 (2025-05-14)
         ];
 
         // Convenience constants for commonly used models
         pub const CLAUDE_OPUS_4_1_20250805: &str = "claude-opus-4-1-20250805";
         pub const CLAUDE_SONNET_4_5: &str = "claude-sonnet-4-5";
+        pub const CLAUDE_HAIKU_4_5: &str = "claude-haiku-4-5";
         pub const CLAUDE_SONNET_4_20250514: &str = "claude-sonnet-4-20250514";
     }
 
@@ -281,6 +283,7 @@ pub mod models {
     pub const CODEX_MINI_LATEST: &str = openai::CODEX_MINI_LATEST;
     pub const CLAUDE_OPUS_4_1_20250805: &str = anthropic::CLAUDE_OPUS_4_1_20250805;
     pub const CLAUDE_SONNET_4_5: &str = anthropic::CLAUDE_SONNET_4_5;
+    pub const CLAUDE_HAIKU_4_5: &str = anthropic::CLAUDE_HAIKU_4_5;
     pub const CLAUDE_SONNET_4_20250514: &str = anthropic::CLAUDE_SONNET_4_20250514;
     pub const OPENROUTER_X_AI_GROK_CODE_FAST_1: &str = openrouter::X_AI_GROK_CODE_FAST_1;
     pub const OPENROUTER_X_AI_GROK_4_FAST: &str = openrouter::X_AI_GROK_4_FAST;

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -240,8 +240,8 @@ pub mod models {
         pub const DEFAULT_MODEL: &str = "claude-sonnet-4-5";
         pub const SUPPORTED_MODELS: &[&str] = &[
             "claude-opus-4-1-20250805", // Latest: Opus 4.1 (2025-08-05)
-            "claude-sonnet-4-5",        // Latest: Sonnet 4.5 (2025-09-29)
-            "claude-haiku-4-5",         // Latest: Haiku 4.5 (2025-09-29)
+            "claude-sonnet-4-5",        // Latest: Sonnet 4.5 (2025-10-15)
+            "claude-haiku-4-5",         // Latest: Haiku 4.5 (2025-10-15)
             "claude-sonnet-4-20250514", // Previous: Sonnet 4 (2025-05-14)
         ];
 
@@ -255,6 +255,7 @@ pub mod models {
         pub const REASONING_MODELS: &[&str] = &[
             CLAUDE_OPUS_4_1_20250805,
             CLAUDE_SONNET_4_5,
+            CLAUDE_HAIKU_4_5,
             CLAUDE_SONNET_4_20250514,
         ];
     }

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -144,7 +144,7 @@ impl Provider {
         match self {
             Provider::Gemini => model == models::google::GEMINI_2_5_PRO,
             Provider::OpenAI => models::openai::REASONING_MODELS.contains(&model),
-            Provider::Anthropic => models::anthropic::SUPPORTED_MODELS.contains(&model),
+            Provider::Anthropic => models::anthropic::REASONING_MODELS.contains(&model),
             Provider::DeepSeek => model == models::deepseek::DEEPSEEK_REASONER,
             Provider::OpenRouter => models::openrouter::REASONING_MODELS.contains(&model),
             Provider::Ollama => false,

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -220,6 +220,8 @@ pub enum ModelId {
     ClaudeOpus41,
     /// Claude Sonnet 4.5 - Latest balanced Anthropic model (2025-09-29)
     ClaudeSonnet45,
+    /// Claude Haiku 4.5 - Latest efficient Anthropic model (2025-09-29)
+    ClaudeHaiku45,
     /// Claude Sonnet 4 - Previous balanced Anthropic model (2025-05-14)
     ClaudeSonnet4,
 
@@ -435,6 +437,7 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41 => models::CLAUDE_OPUS_4_1_20250805,
             ModelId::ClaudeSonnet45 => models::CLAUDE_SONNET_4_5,
+            ModelId::ClaudeHaiku45 => models::CLAUDE_HAIKU_4_5,
             ModelId::ClaudeSonnet4 => models::CLAUDE_SONNET_4_20250514,
             // DeepSeek models
             ModelId::DeepSeekChat => models::DEEPSEEK_CHAT,
@@ -484,9 +487,10 @@ impl ModelId {
             | ModelId::GPT5Mini
             | ModelId::GPT5Nano
             | ModelId::CodexMiniLatest => Provider::OpenAI,
-            ModelId::ClaudeOpus41 | ModelId::ClaudeSonnet45 | ModelId::ClaudeSonnet4 => {
-                Provider::Anthropic
-            }
+            ModelId::ClaudeOpus41
+            | ModelId::ClaudeSonnet45
+            | ModelId::ClaudeHaiku45
+            | ModelId::ClaudeSonnet4 => Provider::Anthropic,
             ModelId::DeepSeekChat | ModelId::DeepSeekReasoner => Provider::DeepSeek,
             ModelId::XaiGrok4
             | ModelId::XaiGrok4Mini
@@ -538,6 +542,7 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41 => "Claude Opus 4.1",
             ModelId::ClaudeSonnet45 => "Claude Sonnet 4.5",
+            ModelId::ClaudeHaiku45 => "Claude Haiku 4.5",
             ModelId::ClaudeSonnet4 => "Claude Sonnet 4",
             // DeepSeek models
             ModelId::DeepSeekChat => "DeepSeek V3.2-Exp (Chat)",
@@ -600,6 +605,9 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41 => "Latest most capable Anthropic model with advanced reasoning",
             ModelId::ClaudeSonnet45 => "Latest balanced Anthropic model for general tasks",
+            ModelId::ClaudeHaiku45 => {
+                "Latest efficient Anthropic model optimized for low-latency agent workflows"
+            }
             ModelId::ClaudeSonnet4 => {
                 "Previous balanced Anthropic model maintained for compatibility"
             }
@@ -654,7 +662,7 @@ impl ModelId {
             }
             ModelId::OllamaGptOss20b => {
                 "Open-source GPT-OSS 20B served locally through Ollama without external API requirements"
-            },
+            }
             ModelId::OllamaQwen317b => {
                 "Qwen3 1.7B served locally through Ollama without external API requirements"
             }
@@ -679,6 +687,7 @@ impl ModelId {
             // Anthropic models
             ModelId::ClaudeOpus41,
             ModelId::ClaudeSonnet45,
+            ModelId::ClaudeHaiku45,
             ModelId::ClaudeSonnet4,
             // DeepSeek models
             ModelId::DeepSeekChat,
@@ -838,6 +847,7 @@ impl ModelId {
                 | ModelId::Gemini25FlashLite
                 | ModelId::GPT5Mini
                 | ModelId::GPT5Nano
+                | ModelId::ClaudeHaiku45
                 | ModelId::DeepSeekChat
                 | ModelId::XaiGrok4Code
                 | ModelId::ZaiGlm45Air
@@ -888,7 +898,7 @@ impl ModelId {
             | ModelId::GPT5Nano
             | ModelId::CodexMiniLatest => "5",
             // Anthropic generations
-            ModelId::ClaudeSonnet45 => "4.5",
+            ModelId::ClaudeSonnet45 | ModelId::ClaudeHaiku45 => "4.5",
             ModelId::ClaudeSonnet4 => "4",
             ModelId::ClaudeOpus41 => "4.1",
             // DeepSeek generations
@@ -947,6 +957,7 @@ impl FromStr for ModelId {
             // Anthropic models
             s if s == models::CLAUDE_OPUS_4_1_20250805 => Ok(ModelId::ClaudeOpus41),
             s if s == models::CLAUDE_SONNET_4_5 => Ok(ModelId::ClaudeSonnet45),
+            s if s == models::CLAUDE_HAIKU_4_5 => Ok(ModelId::ClaudeHaiku45),
             s if s == models::CLAUDE_SONNET_4_20250514 => Ok(ModelId::ClaudeSonnet4),
             // DeepSeek models
             s if s == models::DEEPSEEK_CHAT => Ok(ModelId::DeepSeekChat),
@@ -1058,6 +1069,7 @@ mod tests {
         assert_eq!(ModelId::CodexMiniLatest.as_str(), models::CODEX_MINI_LATEST);
         // Anthropic models
         assert_eq!(ModelId::ClaudeSonnet45.as_str(), models::CLAUDE_SONNET_4_5);
+        assert_eq!(ModelId::ClaudeHaiku45.as_str(), models::CLAUDE_HAIKU_4_5);
         assert_eq!(
             ModelId::ClaudeSonnet4.as_str(),
             models::CLAUDE_SONNET_4_20250514
@@ -1141,6 +1153,10 @@ mod tests {
         assert_eq!(
             models::CLAUDE_SONNET_4_5.parse::<ModelId>().unwrap(),
             ModelId::ClaudeSonnet45
+        );
+        assert_eq!(
+            models::CLAUDE_HAIKU_4_5.parse::<ModelId>().unwrap(),
+            ModelId::ClaudeHaiku45
         );
         assert_eq!(
             models::CLAUDE_SONNET_4_20250514.parse::<ModelId>().unwrap(),
@@ -1280,6 +1296,7 @@ mod tests {
         assert_eq!(ModelId::GPT5.provider(), Provider::OpenAI);
         assert_eq!(ModelId::GPT5Codex.provider(), Provider::OpenAI);
         assert_eq!(ModelId::ClaudeSonnet45.provider(), Provider::Anthropic);
+        assert_eq!(ModelId::ClaudeHaiku45.provider(), Provider::Anthropic);
         assert_eq!(ModelId::ClaudeSonnet4.provider(), Provider::Anthropic);
         assert_eq!(ModelId::DeepSeekChat.provider(), Provider::DeepSeek);
         assert_eq!(ModelId::XaiGrok4.provider(), Provider::XAI);
@@ -1429,6 +1446,7 @@ mod tests {
         assert!(ModelId::Gemini25Flash.is_efficient_variant());
         assert!(ModelId::Gemini25FlashLite.is_efficient_variant());
         assert!(ModelId::GPT5Mini.is_efficient_variant());
+        assert!(ModelId::ClaudeHaiku45.is_efficient_variant());
         assert!(ModelId::XaiGrok4Code.is_efficient_variant());
         assert!(ModelId::DeepSeekChat.is_efficient_variant());
         assert!(ModelId::ZaiGlm45Air.is_efficient_variant());
@@ -1458,6 +1476,7 @@ mod tests {
         assert!(ModelId::MoonshotKimiK20905Preview.is_top_tier());
         assert!(ModelId::MoonshotKimiLatest128k.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
+        assert!(!ModelId::ClaudeHaiku45.is_top_tier());
 
         macro_rules! assert_openrouter_top_tier {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1484,6 +1503,7 @@ mod tests {
 
         // Anthropic generations
         assert_eq!(ModelId::ClaudeSonnet45.generation(), "4.5");
+        assert_eq!(ModelId::ClaudeHaiku45.generation(), "4.5");
         assert_eq!(ModelId::ClaudeSonnet4.generation(), "4");
         assert_eq!(ModelId::ClaudeOpus41.generation(), "4.1");
 
@@ -1534,6 +1554,7 @@ mod tests {
 
         let anthropic_models = ModelId::models_for_provider(Provider::Anthropic);
         assert!(anthropic_models.contains(&ModelId::ClaudeSonnet45));
+        assert!(anthropic_models.contains(&ModelId::ClaudeHaiku45));
         assert!(anthropic_models.contains(&ModelId::ClaudeSonnet4));
         assert!(!anthropic_models.contains(&ModelId::GPT5));
 

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -61,7 +61,7 @@ macro_rules! each_openrouter_variant {
             (OpenRouterOpenAIGpt4oSearchPreview, OPENROUTER_OPENAI_GPT_4O_SEARCH_PREVIEW, "OpenAI GPT-4o Search Preview", "GPT-4o search preview endpoint via OpenRouter", false, false, "4o-Search"),
             (OpenRouterOpenAIGpt4oMiniSearchPreview, OPENROUTER_OPENAI_GPT_4O_MINI_SEARCH_PREVIEW, "OpenAI GPT-4o Mini Search Preview", "GPT-4o mini search preview endpoint", false, false, "4o-Search"),
             (OpenRouterOpenAIChatgpt4oLatest, OPENROUTER_OPENAI_CHATGPT_4O_LATEST, "OpenAI ChatGPT-4o Latest", "ChatGPT 4o latest listing via OpenRouter", false, false, "4o"),
-            (OpenRouterAnthropicClaudeSonnet45, OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5, "Claude Sonnet 4.5", "Anthropic Claude Sonnet 4.5 listing", false, true, "2025-09-29"),
+            (OpenRouterAnthropicClaudeSonnet45, OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5, "Claude Sonnet 4.5", "Anthropic Claude Sonnet 4.5 listing", false, true, "2025-10-15"),
             (OpenRouterAnthropicClaudeOpus41, OPENROUTER_ANTHROPIC_CLAUDE_OPUS_4_1, "Claude Opus 4.1", "Anthropic Claude Opus 4.1 listing", false, true, "2025-08-05"),
         }
     };
@@ -218,9 +218,9 @@ pub enum ModelId {
     // Anthropic models
     /// Claude Opus 4.1 - Latest most capable Anthropic model (2025-08-05)
     ClaudeOpus41,
-    /// Claude Sonnet 4.5 - Latest balanced Anthropic model (2025-09-29)
+    /// Claude Sonnet 4.5 - Latest balanced Anthropic model (2025-10-15)
     ClaudeSonnet45,
-    /// Claude Haiku 4.5 - Latest efficient Anthropic model (2025-09-29)
+    /// Claude Haiku 4.5 - Latest efficient Anthropic model (2025-10-15)
     ClaudeHaiku45,
     /// Claude Sonnet 4 - Previous balanced Anthropic model (2025-05-14)
     ClaudeSonnet4,

--- a/vtcode-core/src/llm/providers/anthropic.rs
+++ b/vtcode-core/src/llm/providers/anthropic.rs
@@ -768,7 +768,7 @@ impl LLMProvider for AnthropicProvider {
         } else {
             model
         };
-        models::anthropic::SUPPORTED_MODELS
+        models::anthropic::REASONING_MODELS
             .iter()
             .any(|candidate| *candidate == requested)
     }


### PR DESCRIPTION
## Summary
- add the claude-haiku-4-5 identifier to the Anthropic constants, model enum, and tests so it is treated as a supported model
- document the new model in docs/models.json and surface it through the /model picker along with coverage tests

## Testing
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68efe3fefedc8323927b295189aa980a