### PR TITLE
Update reasoning effort labels

### DIFF
--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -569,9 +569,9 @@ pub mod reasoning {
     pub const MEDIUM: &str = "medium";
     pub const HIGH: &str = "high";
     pub const ALLOWED_LEVELS: &[&str] = &[LOW, MEDIUM, HIGH];
-    pub const LABEL_LOW: &str = "Easy";
+    pub const LABEL_LOW: &str = "Low";
     pub const LABEL_MEDIUM: &str = "Medium";
-    pub const LABEL_HIGH: &str = "Hard";
+    pub const LABEL_HIGH: &str = "High";
     pub const DESCRIPTION_LOW: &str = "Fast responses with lightweight reasoning.";
     pub const DESCRIPTION_MEDIUM: &str = "Balanced depth and speed for general tasks.";
     pub const DESCRIPTION_HIGH: &str = "Maximum reasoning depth for complex problems.";


### PR DESCRIPTION
## Summary
- adjust the reasoning effort labels to display as low, medium, and high

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f06b7e45a08323a9b67998bbb55834