### PR TITLE
Set OpenAI GPT-5 as default provider and model

### DIFF
--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -854,18 +854,21 @@ impl Cli {
         if self.api_key_env == crate::config::constants::defaults::DEFAULT_API_KEY_ENV
             || self.api_key_env.is_empty()
         {
-            if let Some(provider) = &self.provider {
-                match provider.to_lowercase().as_str() {
-                    "openai" => "OPENAI_API_KEY".to_string(),
-                    "anthropic" => "ANTHROPIC_API_KEY".to_string(),
-                    "gemini" => "GEMINI_API_KEY".to_string(),
-                    "deepseek" => "DEEPSEEK_API_KEY".to_string(),
-                    "openrouter" => "OPENROUTER_API_KEY".to_string(),
-                    "xai" => "XAI_API_KEY".to_string(),
-                    _ => "GEMINI_API_KEY".to_string(),
-                }
-            } else {
-                "GEMINI_API_KEY".to_string()
+            let provider = self
+                .provider
+                .as_deref()
+                .unwrap_or(crate::config::constants::defaults::DEFAULT_PROVIDER);
+            let provider_key = provider.to_ascii_lowercase();
+
+            match provider_key.as_str() {
+                "openai" => "OPENAI_API_KEY".to_string(),
+                "anthropic" => "ANTHROPIC_API_KEY".to_string(),
+                "gemini" => "GEMINI_API_KEY".to_string(),
+                "deepseek" => "DEEPSEEK_API_KEY".to_string(),
+                "openrouter" => "OPENROUTER_API_KEY".to_string(),
+                "xai" => "XAI_API_KEY".to_string(),
+                "zai" => "ZAI_API_KEY".to_string(),
+                _ => crate::config::constants::defaults::DEFAULT_API_KEY_ENV.to_string(),
             }
         } else {
             self.api_key_env.clone()

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -464,10 +464,10 @@ pub mod env {
 pub mod defaults {
     use super::{models, ui};
 
-    pub const DEFAULT_MODEL: &str = models::openai::GPT_5;
-    pub const DEFAULT_CLI_MODEL: &str = models::openai::GPT_5;
-    pub const DEFAULT_PROVIDER: &str = "openai";
-    pub const DEFAULT_API_KEY_ENV: &str = "OPENAI_API_KEY";
+    pub const DEFAULT_MODEL: &str = models::google::GEMINI_2_5_FLASH_PREVIEW;
+    pub const DEFAULT_CLI_MODEL: &str = models::google::GEMINI_2_5_FLASH_PREVIEW;
+    pub const DEFAULT_PROVIDER: &str = "gemini";
+    pub const DEFAULT_API_KEY_ENV: &str = "GEMINI_API_KEY";
     pub const DEFAULT_THEME: &str = "ciapre-dark";
     pub const DEFAULT_MAX_TOOL_LOOPS: usize = 100;
     pub const ANTHROPIC_DEFAULT_MAX_TOKENS: u32 = 4_096;

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -464,10 +464,10 @@ pub mod env {
 pub mod defaults {
     use super::{models, ui};
 
-    pub const DEFAULT_MODEL: &str = models::google::GEMINI_2_5_FLASH_PREVIEW;
-    pub const DEFAULT_CLI_MODEL: &str = models::google::GEMINI_2_5_FLASH_PREVIEW;
-    pub const DEFAULT_PROVIDER: &str = "gemini";
-    pub const DEFAULT_API_KEY_ENV: &str = "GEMINI_API_KEY";
+    pub const DEFAULT_MODEL: &str = models::openai::GPT_5;
+    pub const DEFAULT_CLI_MODEL: &str = models::openai::GPT_5;
+    pub const DEFAULT_PROVIDER: &str = "openai";
+    pub const DEFAULT_API_KEY_ENV: &str = "OPENAI_API_KEY";
     pub const DEFAULT_THEME: &str = "ciapre-dark";
     pub const DEFAULT_MAX_TOOL_LOOPS: usize = 100;
     pub const ANTHROPIC_DEFAULT_MAX_TOKENS: u32 = 4_096;


### PR DESCRIPTION
## Summary
- switch the default model constants to OpenAI's gpt-5 for both general and CLI usage
- update the default provider and API key environment variable to use the OpenAI configuration

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f0b86ae6548323bd8c968d64abdbed