### PR TITLE
Improve OpenAI request capability gating

### DIFF
--- a/docs/models.json
+++ b/docs/models.json
@@ -82,7 +82,7 @@
       "gpt-5": {
         "id": "gpt-5",
         "name": "GPT-5",
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "modalities": {
           "input": [
@@ -112,7 +112,7 @@
       "gpt-5-mini": {
         "id": "gpt-5-mini",
         "name": "GPT-5 Mini",
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "modalities": {
           "input": [
@@ -127,7 +127,7 @@
       "gpt-5-nano": {
         "id": "gpt-5-nano",
         "name": "GPT-5 Nano",
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "modalities": {
           "input": [
@@ -1140,7 +1140,7 @@
       "openai/gpt-5": {
         "id": "openai/gpt-5",
         "name": "OpenAI: GPT-5",
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "modalities": {
           "input": [

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -34,8 +34,11 @@ pub mod models {
             "codex-mini-latest",
         ];
 
-        /// Models that support the OpenAI reasoning API extensions
-        pub const REASONING_MODELS: &[&str] = &[GPT_5, GPT_5_CODEX, GPT_5_MINI, GPT_5_NANO];
+        /// Models that require the OpenAI Responses API
+        pub const RESPONSES_API_MODELS: &[&str] = &[GPT_5, GPT_5_CODEX, GPT_5_MINI, GPT_5_NANO];
+
+        /// Models that support the OpenAI reasoning parameter payload
+        pub const REASONING_MODELS: &[&str] = &[GPT_5_CODEX];
 
         /// Models that do not expose structured tool calling on the OpenAI platform
         pub const TOOL_UNAVAILABLE_MODELS: &[&str] = &[];


### PR DESCRIPTION
## Summary
- gate OpenAI temperature, tool, and parallel tool options on actual model support to avoid unsupported payloads
- include optional parallel tool configuration in OpenAI requests when provided
- expand OpenAI provider tests to cover temperature-only payloads and parallel tool configuration serialization

## Testing
- cargo fmt
- cargo clippy
- cargo test -p vtcode-core openai -- --nocapture *(fails: existing vtcode-core compilation errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f0ccfab07c83238feba236ff45e010