### PR TITLE
Handle think-tag reasoning traces

### DIFF
--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -1429,6 +1429,8 @@ fn apply_prompt_style(handle: &InlineHandle) {
 }
 
 const SPINNER_UPDATE_INTERVAL_MS: u64 = 120;
+const REASONING_HEADING: &str = "Thinking";
+const REASONING_PREFIX: &str = "Thinking: ";
 
 struct SpinnerFrameGenerator {
     style: ProgressStyle,
@@ -1571,6 +1573,153 @@ fn stream_plain_response_delta(
     Ok(())
 }
 
+#[derive(Default)]
+struct StreamingReasoningState {
+    aggregated: String,
+    inline_line_count: usize,
+    last_rendered: Vec<String>,
+    cli_prefix_printed: bool,
+    cli_pending_indent: bool,
+    inline_enabled: bool,
+}
+
+impl StreamingReasoningState {
+    fn new(inline_enabled: bool) -> Self {
+        Self {
+            inline_enabled,
+            ..Self::default()
+        }
+    }
+
+    fn handle_delta(&mut self, renderer: &mut AnsiRenderer, delta: &str) -> Result<()> {
+        if delta.trim().is_empty() {
+            return Ok(());
+        }
+
+        self.append_delta(delta);
+
+        if self.inline_enabled {
+            self.render_inline(renderer)
+        } else {
+            self.render_cli(renderer, delta)
+        }
+    }
+
+    fn finalize(
+        &mut self,
+        renderer: &mut AnsiRenderer,
+        final_reasoning: Option<&str>,
+    ) -> Result<()> {
+        if self.inline_enabled {
+            if let Some(reasoning) = final_reasoning.map(str::trim) {
+                if !reasoning.is_empty() && reasoning != self.aggregated.trim() {
+                    self.aggregated = reasoning.to_string();
+                    self.render_inline(renderer)?;
+                }
+            }
+            Ok(())
+        } else {
+            self.finalize_cli(renderer)?;
+            if let Some(reasoning) = final_reasoning.map(str::trim) {
+                if reasoning.is_empty() {
+                    return Ok(());
+                }
+
+                if !self.cli_prefix_printed {
+                    renderer.line(
+                        MessageStyle::Reasoning,
+                        &format!("{REASONING_PREFIX}{reasoning}"),
+                    )?;
+                    self.cli_prefix_printed = true;
+                } else if self.aggregated.trim() != reasoning {
+                    renderer.line(MessageStyle::Reasoning, reasoning)?;
+                }
+
+                self.aggregated = reasoning.to_string();
+            }
+            Ok(())
+        }
+    }
+
+    fn handle_stream_failure(&mut self, renderer: &mut AnsiRenderer) -> Result<()> {
+        if !self.inline_enabled {
+            self.finalize_cli(renderer)?;
+        }
+        Ok(())
+    }
+
+    fn append_delta(&mut self, delta: &str) {
+        let delta = if self.aggregated.is_empty() {
+            delta.trim_start_matches(['\n', '\r'])
+        } else {
+            delta
+        };
+
+        if delta.is_empty() {
+            return;
+        }
+
+        self.aggregated.push_str(delta);
+    }
+
+    fn render_inline(&mut self, renderer: &mut AnsiRenderer) -> Result<()> {
+        let lines = self.display_lines();
+        if lines.is_empty() || lines == self.last_rendered {
+            return Ok(());
+        }
+
+        renderer.render_reasoning_stream(&lines, &mut self.inline_line_count)?;
+        self.last_rendered = lines;
+        Ok(())
+    }
+
+    fn render_cli(&mut self, renderer: &mut AnsiRenderer, delta: &str) -> Result<()> {
+        if !self.cli_prefix_printed {
+            let indent = MessageStyle::Reasoning.indent();
+            if !indent.is_empty() {
+                renderer.inline_with_style(MessageStyle::Reasoning, indent)?;
+            }
+            renderer.inline_with_style(MessageStyle::Reasoning, REASONING_PREFIX)?;
+            self.cli_prefix_printed = true;
+            self.cli_pending_indent = false;
+        }
+
+        stream_plain_response_delta(
+            renderer,
+            MessageStyle::Reasoning,
+            MessageStyle::Reasoning.indent(),
+            &mut self.cli_pending_indent,
+            delta,
+        )
+    }
+
+    fn finalize_cli(&mut self, renderer: &mut AnsiRenderer) -> Result<()> {
+        if self.cli_prefix_printed && !self.cli_pending_indent {
+            renderer.inline_with_style(MessageStyle::Reasoning, "\n")?;
+            self.cli_pending_indent = true;
+        }
+        Ok(())
+    }
+
+    fn display_lines(&self) -> Vec<String> {
+        let trimmed = self.aggregated.trim_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            return Vec::new();
+        }
+
+        if trimmed.contains('\n') {
+            let mut lines = Vec::new();
+            lines.push(format!("{REASONING_HEADING}:"));
+            for line in trimmed.lines() {
+                lines.push(line.trim_end().to_string());
+            }
+            lines
+        } else {
+            vec![format!("{REASONING_PREFIX}{}", trimmed.trim())]
+        }
+    }
+}
+
 async fn stream_and_render_response(
     provider: &dyn uni::LLMProvider,
     request: uni::LLMRequest,
@@ -1596,10 +1745,14 @@ async fn stream_and_render_response(
         }
     };
     let mut emitted_tokens = false;
+    let mut reasoning_state = StreamingReasoningState::new(supports_streaming_markdown);
 
     loop {
         if ctrl_c_state.is_cancel_requested() {
             finish_spinner(&mut spinner_active);
+            reasoning_state
+                .handle_stream_failure(renderer)
+                .map_err(|err| map_render_error(provider_name, err))?;
             return Err(uni::LLMError::Provider(error_display::format_llm_error(
                 provider_name,
                 "Interrupted by user",
@@ -1611,6 +1764,9 @@ async fn stream_and_render_response(
 
             _ = ctrl_c_notify.notified(), if ctrl_c_state.is_cancel_requested() => {
                 finish_spinner(&mut spinner_active);
+                reasoning_state
+                    .handle_stream_failure(renderer)
+                    .map_err(|err| map_render_error(provider_name, err))?;
                 return Err(uni::LLMError::Provider(error_display::format_llm_error(
                     provider_name,
                     "Interrupted by user",
@@ -1643,12 +1799,20 @@ async fn stream_and_render_response(
                 }
                 emitted_tokens = true;
             }
-            Ok(LLMStreamEvent::Reasoning { .. }) => {}
+            Ok(LLMStreamEvent::Reasoning { delta }) => {
+                finish_spinner(&mut spinner_active);
+                reasoning_state
+                    .handle_delta(renderer, &delta)
+                    .map_err(|err| map_render_error(provider_name, err))?;
+            }
             Ok(LLMStreamEvent::Completed { response }) => {
                 final_response = Some(response);
             }
             Err(err) => {
                 finish_spinner(&mut spinner_active);
+                reasoning_state
+                    .handle_stream_failure(renderer)
+                    .map_err(|render_err| map_render_error(provider_name, render_err))?;
                 return Err(err);
             }
         }
@@ -1656,13 +1820,23 @@ async fn stream_and_render_response(
 
     finish_spinner(&mut spinner_active);
 
-    let response = final_response.ok_or_else(|| {
-        let formatted_error = error_display::format_llm_error(
-            provider_name,
-            "Stream ended without a completion event",
-        );
-        uni::LLMError::Provider(formatted_error)
-    })?;
+    let response = match final_response {
+        Some(response) => response,
+        None => {
+            reasoning_state
+                .handle_stream_failure(renderer)
+                .map_err(|err| map_render_error(provider_name, err))?;
+            let formatted_error = error_display::format_llm_error(
+                provider_name,
+                "Stream ended without a completion event",
+            );
+            return Err(uni::LLMError::Provider(formatted_error));
+        }
+    };
+
+    reasoning_state
+        .finalize(renderer, response.reasoning.as_deref())
+        .map_err(|err| map_render_error(provider_name, err))?;
 
     if aggregated.is_empty() {
         if let Some(content) = response.content.clone() {

--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -12,7 +12,7 @@ mod codex_prompt;
 mod reasoning;
 
 pub(crate) use codex_prompt::gpt5_codex_developer_prompt;
-pub(crate) use reasoning::extract_reasoning_trace;
+pub(crate) use reasoning::{extract_reasoning_trace, split_reasoning_from_text};
 
 pub use anthropic::AnthropicProvider;
 pub use deepseek::DeepSeekProvider;

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -17,7 +17,7 @@ use reqwest::{Client as HttpClient, Response, StatusCode};
 use serde_json::{Map, Value, json};
 use std::borrow::Cow;
 
-use super::{extract_reasoning_trace, gpt5_codex_developer_prompt};
+use super::{extract_reasoning_trace, gpt5_codex_developer_prompt, split_reasoning_from_text};
 
 #[derive(Default, Clone)]
 struct ToolCallBuilder {
@@ -217,6 +217,53 @@ impl ReasoningBuffer {
     }
 }
 
+fn append_text_with_reasoning(
+    text: &str,
+    aggregated_content: &mut String,
+    reasoning: &mut ReasoningBuffer,
+    deltas: &mut StreamDelta,
+) {
+    let (segments, cleaned) = split_reasoning_from_text(text);
+
+    if segments.is_empty() && cleaned.is_none() {
+        if !text.is_empty() {
+            aggregated_content.push_str(text);
+            deltas.push_content(text);
+        }
+        return;
+    }
+
+    for segment in segments {
+        if let Some(delta) = reasoning.push(&segment) {
+            deltas.push_reasoning(&delta);
+        }
+    }
+
+    if let Some(cleaned_text) = cleaned {
+        if !cleaned_text.is_empty() {
+            aggregated_content.push_str(&cleaned_text);
+            deltas.push_content(&cleaned_text);
+        }
+    }
+}
+
+fn append_reasoning_segment(segments: &mut Vec<String>, text: &str) {
+    for line in text.split('\n') {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if segments
+            .last()
+            .map(|last| last.as_str() == trimmed)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        segments.push(trimmed.to_string());
+    }
+}
+
 fn apply_tool_call_delta_from_content(
     builders: &mut Vec<ToolCallBuilder>,
     container: &Map<String, Value>,
@@ -304,18 +351,12 @@ fn process_content_object(
     }
 
     if let Some(text_value) = map.get("text").and_then(|value| value.as_str()) {
-        if !text_value.is_empty() {
-            aggregated_content.push_str(text_value);
-            deltas.push_content(text_value);
-        }
+        append_text_with_reasoning(text_value, aggregated_content, reasoning, deltas);
         return;
     }
 
     if let Some(text_value) = map.get("output_text").and_then(|value| value.as_str()) {
-        if !text_value.is_empty() {
-            aggregated_content.push_str(text_value);
-            deltas.push_content(text_value);
-        }
+        append_text_with_reasoning(text_value, aggregated_content, reasoning, deltas);
         return;
     }
 
@@ -323,10 +364,7 @@ fn process_content_object(
         .get("output_text_delta")
         .and_then(|value| value.as_str())
     {
-        if !text_value.is_empty() {
-            aggregated_content.push_str(text_value);
-            deltas.push_content(text_value);
-        }
+        append_text_with_reasoning(text_value, aggregated_content, reasoning, deltas);
         return;
     }
 
@@ -351,10 +389,7 @@ fn process_content_part(
     deltas: &mut StreamDelta,
 ) {
     if let Some(text) = part.as_str() {
-        if !text.is_empty() {
-            aggregated_content.push_str(text);
-            deltas.push_content(text);
-        }
+        append_text_with_reasoning(text, aggregated_content, reasoning, deltas);
         return;
     }
 
@@ -389,10 +424,7 @@ fn process_content_value(
 ) {
     match value {
         Value::String(text) => {
-            if !text.is_empty() {
-                aggregated_content.push_str(text);
-                deltas.push_content(text);
-            }
+            append_text_with_reasoning(text, aggregated_content, reasoning, deltas);
         }
         Value::Array(parts) => {
             for part in parts {
@@ -488,6 +520,21 @@ fn extract_reasoning_from_message_content(message: &Value) -> Option<String> {
     let parts = message.get("content")?.as_array()?;
     let mut segments: Vec<String> = Vec::new();
 
+    fn push_segment(segments: &mut Vec<String>, value: &str) {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        if segments
+            .last()
+            .map(|last| last.as_str() == trimmed)
+            .unwrap_or(false)
+        {
+            return;
+        }
+        segments.push(trimmed.to_string());
+    }
+
     for part in parts {
         match part {
             Value::Object(map) => {
@@ -507,15 +554,22 @@ fn extract_reasoning_from_message_content(message: &Value) -> Option<String> {
                     if let Some(text) = map.get("text").and_then(|value| value.as_str()) {
                         let trimmed = text.trim();
                         if !trimmed.is_empty() {
-                            segments.push(trimmed.to_string());
+                            push_segment(&mut segments, trimmed);
                         }
                     }
                 }
             }
             Value::String(text) => {
-                let trimmed = text.trim();
-                if !trimmed.is_empty() {
-                    segments.push(trimmed.to_string());
+                let (mut markup_segments, cleaned) = split_reasoning_from_text(text);
+                if !markup_segments.is_empty() {
+                    for segment in markup_segments.drain(..) {
+                        push_segment(&mut segments, &segment);
+                    }
+                    if let Some(cleaned_text) = cleaned {
+                        push_segment(&mut segments, &cleaned_text);
+                    }
+                } else {
+                    push_segment(&mut segments, text);
                 }
             }
             _ => {}
@@ -1685,7 +1739,7 @@ impl OpenRouterProvider {
                 LLMError::Provider(formatted_error)
             })?;
 
-            let content = match message.get("content") {
+            let mut content = match message.get("content") {
                 Some(Value::String(text)) => Some(text.to_string()),
                 Some(Value::Array(parts)) => {
                     let text = parts
@@ -1726,14 +1780,46 @@ impl OpenRouterProvider {
                 })
                 .filter(|calls| !calls.is_empty());
 
-            let mut reasoning = message
+            let mut reasoning_segments: Vec<String> = Vec::new();
+
+            if let Some(initial) = message
                 .get("reasoning")
                 .and_then(extract_reasoning_trace)
-                .or_else(|| choice.get("reasoning").and_then(extract_reasoning_trace));
-
-            if reasoning.is_none() {
-                reasoning = extract_reasoning_from_message_content(message);
+                .or_else(|| choice.get("reasoning").and_then(extract_reasoning_trace))
+            {
+                append_reasoning_segment(&mut reasoning_segments, &initial);
             }
+
+            if reasoning_segments.is_empty() {
+                if let Some(from_content) = extract_reasoning_from_message_content(message) {
+                    append_reasoning_segment(&mut reasoning_segments, &from_content);
+                }
+            } else if let Some(extra) = extract_reasoning_from_message_content(message) {
+                append_reasoning_segment(&mut reasoning_segments, &extra);
+            }
+
+            if let Some(original_content) = content.take() {
+                let (markup_segments, cleaned) = split_reasoning_from_text(&original_content);
+                for segment in markup_segments {
+                    append_reasoning_segment(&mut reasoning_segments, &segment);
+                }
+                content = match cleaned {
+                    Some(cleaned_text) => {
+                        if cleaned_text.is_empty() {
+                            None
+                        } else {
+                            Some(cleaned_text)
+                        }
+                    }
+                    None => Some(original_content),
+                };
+            }
+
+            let reasoning = if reasoning_segments.is_empty() {
+                None
+            } else {
+                Some(reasoning_segments.join("\n"))
+            };
 
             let finish_reason = choice
                 .get("finish_reason")
@@ -1815,20 +1901,54 @@ impl OpenRouterProvider {
             tool_calls = extract_tool_calls_from_content(message);
         }
 
-        let mut reasoning = reasoning_buffer.finalize();
-        if reasoning.is_none() {
-            reasoning = extract_reasoning_from_message_content(message)
-                .or_else(|| message.get("reasoning").and_then(extract_reasoning_trace))
-                .or_else(|| payload.get("reasoning").and_then(extract_reasoning_trace));
+        let mut reasoning_segments: Vec<String> = Vec::new();
+
+        if let Some(buffer_reasoning) = reasoning_buffer.finalize() {
+            append_reasoning_segment(&mut reasoning_segments, &buffer_reasoning);
         }
 
-        let content = if aggregated_content.is_empty() {
+        let fallback_reasoning = extract_reasoning_from_message_content(message)
+            .or_else(|| message.get("reasoning").and_then(extract_reasoning_trace))
+            .or_else(|| payload.get("reasoning").and_then(extract_reasoning_trace));
+
+        if reasoning_segments.is_empty() {
+            if let Some(extra) = fallback_reasoning {
+                append_reasoning_segment(&mut reasoning_segments, &extra);
+            }
+        } else if let Some(extra) = fallback_reasoning {
+            append_reasoning_segment(&mut reasoning_segments, &extra);
+        }
+
+        let mut content = if aggregated_content.is_empty() {
             message
                 .get("output_text")
                 .and_then(|value| value.as_str())
                 .map(|value| value.to_string())
         } else {
             Some(aggregated_content)
+        };
+
+        if let Some(original_content) = content.take() {
+            let (markup_segments, cleaned) = split_reasoning_from_text(&original_content);
+            for segment in markup_segments {
+                append_reasoning_segment(&mut reasoning_segments, &segment);
+            }
+            content = match cleaned {
+                Some(cleaned_text) => {
+                    if cleaned_text.is_empty() {
+                        None
+                    } else {
+                        Some(cleaned_text)
+                    }
+                }
+                None => Some(original_content),
+            };
+        }
+
+        let reasoning = if reasoning_segments.is_empty() {
+            None
+        } else {
+            Some(reasoning_segments.join("\n"))
         };
 
         let mut usage = payload.get("usage").map(parse_usage_value);

--- a/vtcode-core/src/llm/providers/reasoning.rs
+++ b/vtcode-core/src/llm/providers/reasoning.rs
@@ -13,8 +13,9 @@ const SECONDARY_COLLECTION_KEYS: &[&str] = &[
     "logs",
 ];
 
-const REASONING_TAGS: &[&str] = &["think", "thinking", "reasoning", "analysis", "thought"];
-const ANSWER_TAGS: &[&str] = &["answer", "final"];
+pub(crate) const REASONING_TAGS: &[&str] =
+    &["think", "thinking", "reasoning", "analysis", "thought"];
+pub(crate) const ANSWER_TAGS: &[&str] = &["answer", "final"];
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TagCategory {

--- a/vtcode-core/src/llm/providers/reasoning.rs
+++ b/vtcode-core/src/llm/providers/reasoning.rs
@@ -46,17 +46,11 @@ fn collect_reasoning_segments(value: &Value, segments: &mut Vec<String>) {
         Value::Null => {}
         Value::Bool(_) | Value::Number(_) => {}
         Value::String(text) => {
-            let (mut tagged_segments, cleaned) = split_reasoning_from_text(text);
+            let (mut tagged_segments, _cleaned) = split_reasoning_from_text(text);
 
             if !tagged_segments.is_empty() {
                 for segment in tagged_segments.drain(..) {
                     push_unique_segment(segments, &segment);
-                }
-                if let Some(cleaned_text) = cleaned {
-                    let trimmed = cleaned_text.trim();
-                    if !trimmed.is_empty() {
-                        push_unique_segment(segments, trimmed);
-                    }
                 }
                 return;
             }
@@ -326,5 +320,12 @@ mod tests {
             vec!["deep dive".to_string(), "summary".to_string()]
         );
         assert!(cleaned.is_none());
+    }
+
+    #[test]
+    fn reasoning_trace_excludes_answer_from_cleaned_text() {
+        let value = Value::String("<think>plan</think><answer>final output</answer>".to_string());
+        let extracted = extract_reasoning_trace(&value);
+        assert_eq!(extracted, Some("plan".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
- parse `<think>`-style reasoning markup into structured segments, including regression tests
- route OpenRouter streaming and final responses through the markup splitter so transcripts show reasoning without leaking tags
- re-export the new splitter helper for provider modules

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f0d9e0ce7083239bc1f37649fa3aca