### PR TITLE
Support Ollama tool choice with SDK integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ollama-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659dd1460a1079db751a236b301e78e63486758fee7e2db1ddcd2372c264be36"
+dependencies = [
+ "async-stream",
+ "http",
+ "log",
+ "reqwest",
+ "schemars 1.0.4",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4462,6 +4482,7 @@ dependencies = [
  "line-clipping",
  "mcp-types",
  "nucleo-matcher",
+ "ollama-rs",
  "once_cell",
  "parking_lot",
  "portable-pty 0.9.0",

--- a/docs/models.json
+++ b/docs/models.json
@@ -1492,7 +1492,82 @@
         "id": "gpt-oss:20b",
         "name": "GPT-OSS 20B",
         "reasoning": false,
-        "tool_call": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "qwen3:1.7b": {
+        "id": "qwen3:1.7b",
+        "name": "Qwen3 1.7B",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "qwen3-coder:30b": {
+        "id": "qwen3-coder:30b",
+        "name": "Qwen3 Coder 30B",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "qwen3-coder:480b": {
+        "id": "qwen3-coder:480b",
+        "name": "Qwen3 Coder 480B",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "qwen3-coder:480b-cloud": {
+        "id": "qwen3-coder:480b-cloud",
+        "name": "Qwen3 Coder 480B (Cloud)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "glm-4.6:cloud": {
+        "id": "glm-4.6:cloud",
+        "name": "GLM 4.6 (Cloud)",
+        "reasoning": false,
+        "tool_call": true,
         "modalities": {
           "input": [
             "text"

--- a/docs/models.json
+++ b/docs/models.json
@@ -1503,6 +1503,36 @@
         },
         "context": 131072
       },
+      "gpt-oss:20b-cloud": {
+        "id": "gpt-oss:20b-cloud",
+        "name": "GPT-OSS 20B (Cloud)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "gpt-oss:120b-cloud": {
+        "id": "gpt-oss:120b-cloud",
+        "name": "GPT-OSS 120B (Cloud)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
       "qwen3:1.7b": {
         "id": "qwen3:1.7b",
         "name": "Qwen3 1.7B",
@@ -1552,6 +1582,36 @@
         "id": "qwen3-coder:480b-cloud",
         "name": "Qwen3 Coder 480B (Cloud)",
         "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "deepseek-v3.1:671b-cloud": {
+        "id": "deepseek-v3.1:671b-cloud",
+        "name": "DeepSeek V3.1 671B (Cloud)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "kimi-k2:1t-cloud": {
+        "id": "kimi-k2:1t-cloud",
+        "name": "Kimi K2 1T (Cloud)",
+        "reasoning": true,
         "tool_call": true,
         "modalities": {
           "input": [

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -73,6 +73,8 @@ Ollama's latest hosted releases, showcased in the [New coding models & integrati
 - `qwen3-coder:480b-cloud` for the hosted 480B Qwen3 coder
 - `qwen3-coder:480b` and `qwen3-coder:30b` when you have the VRAM to run them locally
 
+These presets — along with the lightweight `qwen3:1.7b` and default `gpt-oss:20b` options — now appear directly inside VT Code's `/model` modal so you can switch between local and cloud Ollama tiers without typing model IDs.
+
 To target Ollama Cloud, provide your API key and point the provider at `https://ollama.com`:
 
 ```bash

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -65,6 +65,27 @@ vtcode --provider ollama --model codellama:7b ask "Explain this function"
 vtcode --provider ollama --model gpt-oss-20b ask "Help with this implementation"
 ```
 
+### Cloud coding models
+
+Ollama's latest hosted releases, showcased in the [New coding models & integrations blog post](https://ollama.com/blog/coding-models), are available directly from VT Code:
+
+- `glm-4.6:cloud` for the GLM 4.6 coding model
+- `qwen3-coder:480b-cloud` for the hosted 480B Qwen3 coder
+- `qwen3-coder:480b` and `qwen3-coder:30b` when you have the VRAM to run them locally
+
+To target Ollama Cloud, provide your API key and point the provider at `https://ollama.com`:
+
+```bash
+export OLLAMA_API_KEY="your_cloud_key"
+
+vtcode --provider ollama \
+  --model glm-4.6:cloud \
+  --base-url https://ollama.com \
+  ask "Generate a Typescript CRUD backend"
+```
+
+VT Code automatically injects the `Authorization: Bearer` header whenever an API key is configured, so the same command works for streaming, tool-calling, and JSON request workflows.
+
 ## Tool Calling
 
 Ollama supports structured tool calling with the same schema used by OpenAI-compatible APIs. When invoking VT Code via JSON,
@@ -95,6 +116,10 @@ include your `tools` array and optional `tool_choice` directive to guide the mod
 ```
 
 `tool_choice` accepts `"auto"`, `"none"`, `"required"`, or a specific function descriptor (`{"type":"function","function":{"name":"..."}}`). VT Code forwards these values to Ollama so you can disable tool usage, force a tool call, or pin a particular function when needed.
+
+### Reasoning traces
+
+If you enable reasoning (`reasoning_effort = "medium"` or similar in `vtcode.toml`), VT Code automatically sets Ollama's `think` flag. Streaming sessions show the model's intermediate reasoning as separate "thinking" updates while still emitting the final assistant response as normal completion tokens.
 
 ## OpenAI OSS Models Support
 
@@ -139,6 +164,10 @@ curl http://localhost:11434/api/tags
 - Performance varies significantly based on model size and local hardware
 - Larger models (30B+) require substantial RAM (32GB+) for reasonable performance
 - Smaller models (7B-13B) work well on consumer hardware with 16GB+ RAM
+
+## Sharing models with Droid
+
+The blog's ["Usage with Droid"](https://ollama.com/blog/coding-models#usage-with-droid) example configures Factory AI's Droid CLI against Ollama's OpenAI-compatible `/v1` endpoint. When you want VT Code and Droid to share the same local or proxied models, keep the VT Code `base_url` pointed at the root Ollama host (for example `http://localhost:11434`). VT Code talks directly to `/api/chat`, so omitting the `/v1` suffix avoids conflicting with Droid's compatibility shim while still letting both tools pull models like `glm-4.6:cloud` from the same server.
 
 ## Using Ollama Cloud
 

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -1081,6 +1081,17 @@ mod tests {
     }
 
     #[test]
+    fn model_picker_lists_new_ollama_models() {
+        let options = MODEL_OPTIONS.as_slice();
+        assert!(has_model(options, ModelId::OllamaGptOss20b));
+        assert!(has_model(options, ModelId::OllamaQwen317b));
+        assert!(has_model(options, ModelId::OllamaQwen3Coder30b));
+        assert!(has_model(options, ModelId::OllamaQwen3Coder480b));
+        assert!(has_model(options, ModelId::OllamaQwen3Coder480bCloud));
+        assert!(has_model(options, ModelId::OllamaGlm46Cloud));
+    }
+
+    #[test]
     fn read_workspace_env_returns_value_when_present() -> Result<()> {
         let dir = tempdir()?;
         let env_path = dir.path().join(".env");

--- a/tests/tool_call_verification.rs
+++ b/tests/tool_call_verification.rs
@@ -277,7 +277,7 @@ fn test_all_providers_tool_validation() {
         reasoning_effort: None,
     };
 
-    assert!(ollama.validate_request(&ollama_request).is_err());
+    assert!(ollama.validate_request(&ollama_request).is_ok());
 }
 
 #[test]
@@ -394,8 +394,8 @@ fn test_provider_tool_support_matrix() {
     }
 
     assert!(
-        !ollama.supports_tools(models::ollama::DEFAULT_MODEL),
-        "Ollama should disable tool calling for {}",
+        ollama.supports_tools(models::ollama::DEFAULT_MODEL),
+        "Ollama should advertise tool calling for {}",
         models::ollama::DEFAULT_MODEL
     );
 

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["development-tools", "api-bindings"]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"] }
+ollama-rs = { version = "0.3.2", features = ["stream", "headers"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.9.7"

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -223,21 +223,29 @@ pub mod models {
     pub mod ollama {
         pub const DEFAULT_MODEL: &str = "gpt-oss:20b";
         pub const GPT_OSS_20B: &str = DEFAULT_MODEL;
+        pub const GPT_OSS_20B_CLOUD: &str = "gpt-oss:20b-cloud";
+        pub const GPT_OSS_120B_CLOUD: &str = "gpt-oss:120b-cloud";
         pub const QWEN3_1_7B: &str = "qwen3:1.7b";
         pub const QWEN3_CODER_30B: &str = "qwen3-coder:30b";
         pub const QWEN3_CODER_480B: &str = "qwen3-coder:480b";
         pub const QWEN3_CODER_480B_CLOUD: &str = "qwen3-coder:480b-cloud";
         pub const GLM_4_6_CLOUD: &str = "glm-4.6:cloud";
         pub const GLM_4_6_DIRECT: &str = "glm-4.6";
+        pub const DEEPSEEK_V3_1_671B_CLOUD: &str = "deepseek-v3.1:671b-cloud";
+        pub const KIMI_K2_1T_CLOUD: &str = "kimi-k2:1t-cloud";
 
         pub const SUPPORTED_MODELS: &[&str] = &[
             DEFAULT_MODEL,
+            GPT_OSS_20B_CLOUD,
+            GPT_OSS_120B_CLOUD,
             QWEN3_1_7B,
             QWEN3_CODER_30B,
             QWEN3_CODER_480B,
             QWEN3_CODER_480B_CLOUD,
             GLM_4_6_CLOUD,
             GLM_4_6_DIRECT,
+            DEEPSEEK_V3_1_671B_CLOUD,
+            KIMI_K2_1T_CLOUD,
         ];
     }
 

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -222,10 +222,23 @@ pub mod models {
 
     pub mod ollama {
         pub const DEFAULT_MODEL: &str = "gpt-oss:20b";
-        pub const SUPPORTED_MODELS: &[&str] = &[DEFAULT_MODEL, QWEN3_1_7B];
-
         pub const GPT_OSS_20B: &str = DEFAULT_MODEL;
         pub const QWEN3_1_7B: &str = "qwen3:1.7b";
+        pub const QWEN3_CODER_30B: &str = "qwen3-coder:30b";
+        pub const QWEN3_CODER_480B: &str = "qwen3-coder:480b";
+        pub const QWEN3_CODER_480B_CLOUD: &str = "qwen3-coder:480b-cloud";
+        pub const GLM_4_6_CLOUD: &str = "glm-4.6:cloud";
+        pub const GLM_4_6_DIRECT: &str = "glm-4.6";
+
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            DEFAULT_MODEL,
+            QWEN3_1_7B,
+            QWEN3_CODER_30B,
+            QWEN3_CODER_480B,
+            QWEN3_CODER_480B_CLOUD,
+            GLM_4_6_CLOUD,
+            GLM_4_6_DIRECT,
+        ];
     }
 
     // DeepSeek models (native API)

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -280,6 +280,14 @@ pub enum ModelId {
     OllamaGptOss20b,
     /// Qwen3 1.7B - Qwen3 1.7B model served via Ollama
     OllamaQwen317b,
+    /// Qwen3 Coder 30B - Balanced local coding model via Ollama
+    OllamaQwen3Coder30b,
+    /// Qwen3 Coder 480B - Flagship local coding model via Ollama (requires significant resources)
+    OllamaQwen3Coder480b,
+    /// Qwen3 Coder 480B (Cloud) - Hosted Qwen3 Coder tier via Ollama Cloud
+    OllamaQwen3Coder480bCloud,
+    /// GLM 4.6 (Cloud) - Hosted GLM 4.6 coding model via Ollama Cloud
+    OllamaGlm46Cloud,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model
@@ -467,6 +475,10 @@ impl ModelId {
             // Ollama models
             ModelId::OllamaGptOss20b => models::ollama::GPT_OSS_20B,
             ModelId::OllamaQwen317b => models::ollama::QWEN3_1_7B,
+            ModelId::OllamaQwen3Coder30b => models::ollama::QWEN3_CODER_30B,
+            ModelId::OllamaQwen3Coder480b => models::ollama::QWEN3_CODER_480B,
+            ModelId::OllamaQwen3Coder480bCloud => models::ollama::QWEN3_CODER_480B_CLOUD,
+            ModelId::OllamaGlm46Cloud => models::ollama::GLM_4_6_CLOUD,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -511,8 +523,12 @@ impl ModelId {
             | ModelId::MoonshotKimiLatest8k
             | ModelId::MoonshotKimiLatest32k
             | ModelId::MoonshotKimiLatest128k => Provider::Moonshot,
-            ModelId::OllamaGptOss20b => Provider::Ollama,
-            ModelId::OllamaQwen317b => Provider::Ollama,
+            ModelId::OllamaGptOss20b
+            | ModelId::OllamaQwen317b
+            | ModelId::OllamaQwen3Coder30b
+            | ModelId::OllamaQwen3Coder480b
+            | ModelId::OllamaQwen3Coder480bCloud
+            | ModelId::OllamaGlm46Cloud => Provider::Ollama,
             _ => unreachable!(),
         }
     }
@@ -572,6 +588,10 @@ impl ModelId {
             // Ollama models
             ModelId::OllamaGptOss20b => "GPT-OSS 20B (local)",
             ModelId::OllamaQwen317b => "Qwen3 1.7B (local)",
+            ModelId::OllamaQwen3Coder30b => "Qwen3 Coder 30B (local)",
+            ModelId::OllamaQwen3Coder480b => "Qwen3 Coder 480B (local)",
+            ModelId::OllamaQwen3Coder480bCloud => "Qwen3 Coder 480B (cloud)",
+            ModelId::OllamaGlm46Cloud => "GLM 4.6 (cloud)",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -666,6 +686,18 @@ impl ModelId {
             ModelId::OllamaQwen317b => {
                 "Qwen3 1.7B served locally through Ollama without external API requirements"
             }
+            ModelId::OllamaQwen3Coder30b => {
+                "Qwen3 Coder 30B balanced local coding model delivered through Ollama"
+            }
+            ModelId::OllamaQwen3Coder480b => {
+                "Qwen3 Coder 480B flagship local coding model delivered through Ollama (requires substantial GPU resources)"
+            }
+            ModelId::OllamaQwen3Coder480bCloud => {
+                "Hosted Qwen3 Coder 480B via Ollama Cloud for managed large-context coding workloads"
+            }
+            ModelId::OllamaGlm46Cloud => {
+                "Hosted GLM 4.6 coding model available through Ollama Cloud"
+            }
             _ => unreachable!(),
         }
     }
@@ -717,6 +749,10 @@ impl ModelId {
             // Ollama models
             ModelId::OllamaGptOss20b,
             ModelId::OllamaQwen317b,
+            ModelId::OllamaQwen3Coder30b,
+            ModelId::OllamaQwen3Coder480b,
+            ModelId::OllamaQwen3Coder480bCloud,
+            ModelId::OllamaGlm46Cloud,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -832,6 +868,9 @@ impl ModelId {
                 | ModelId::ZaiGlm46
                 | ModelId::MoonshotKimiK20905Preview
                 | ModelId::MoonshotKimiLatest128k
+                | ModelId::OllamaQwen3Coder480b
+                | ModelId::OllamaQwen3Coder480bCloud
+                | ModelId::OllamaGlm46Cloud
         )
     }
 
@@ -877,6 +916,8 @@ impl ModelId {
                 | ModelId::ZaiGlm46
                 | ModelId::MoonshotKimiK20905Preview
                 | ModelId::MoonshotKimiLatest128k
+                | ModelId::OllamaQwen3Coder480bCloud
+                | ModelId::OllamaGlm46Cloud
         )
     }
 
@@ -926,6 +967,11 @@ impl ModelId {
             | ModelId::MoonshotKimiLatest32k
             | ModelId::MoonshotKimiLatest128k => "latest",
             ModelId::OllamaGptOss20b => "oss",
+            ModelId::OllamaQwen317b
+            | ModelId::OllamaQwen3Coder30b
+            | ModelId::OllamaQwen3Coder480b
+            | ModelId::OllamaQwen3Coder480bCloud => "qwen3",
+            ModelId::OllamaGlm46Cloud => "4.6 cloud",
             _ => unreachable!(),
         }
     }
@@ -992,6 +1038,12 @@ impl FromStr for ModelId {
             s if s == models::MOONSHOT_KIMI_LATEST_128K => Ok(ModelId::MoonshotKimiLatest128k),
             s if s == models::ollama::GPT_OSS_20B => Ok(ModelId::OllamaGptOss20b),
             s if s == models::ollama::QWEN3_1_7B => Ok(ModelId::OllamaQwen317b),
+            s if s == models::ollama::QWEN3_CODER_30B => Ok(ModelId::OllamaQwen3Coder30b),
+            s if s == models::ollama::QWEN3_CODER_480B => Ok(ModelId::OllamaQwen3Coder480b),
+            s if s == models::ollama::QWEN3_CODER_480B_CLOUD => {
+                Ok(ModelId::OllamaQwen3Coder480bCloud)
+            }
+            s if s == models::ollama::GLM_4_6_CLOUD => Ok(ModelId::OllamaGlm46Cloud),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -1439,6 +1491,9 @@ mod tests {
         assert!(ModelId::ZaiGlm46.is_pro_variant());
         assert!(ModelId::MoonshotKimiK20905Preview.is_pro_variant());
         assert!(ModelId::MoonshotKimiLatest128k.is_pro_variant());
+        assert!(ModelId::OllamaQwen3Coder480b.is_pro_variant());
+        assert!(ModelId::OllamaQwen3Coder480bCloud.is_pro_variant());
+        assert!(ModelId::OllamaGlm46Cloud.is_pro_variant());
         assert!(!ModelId::Gemini25FlashPreview.is_pro_variant());
 
         // Efficient variants
@@ -1475,6 +1530,8 @@ mod tests {
         assert!(ModelId::ZaiGlm46.is_top_tier());
         assert!(ModelId::MoonshotKimiK20905Preview.is_top_tier());
         assert!(ModelId::MoonshotKimiLatest128k.is_top_tier());
+        assert!(ModelId::OllamaQwen3Coder480bCloud.is_top_tier());
+        assert!(ModelId::OllamaGlm46Cloud.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
         assert!(!ModelId::ClaudeHaiku45.is_top_tier());
 
@@ -1598,7 +1655,12 @@ mod tests {
 
         let ollama_models = ModelId::models_for_provider(Provider::Ollama);
         assert!(ollama_models.contains(&ModelId::OllamaGptOss20b));
-        assert_eq!(ollama_models.len(), 1);
+        assert!(ollama_models.contains(&ModelId::OllamaQwen317b));
+        assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder30b));
+        assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder480b));
+        assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder480bCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaGlm46Cloud));
+        assert_eq!(ollama_models.len(), 6);
     }
 
     #[test]

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -286,6 +286,14 @@ pub enum ModelId {
     OllamaQwen3Coder480b,
     /// Qwen3 Coder 480B (Cloud) - Hosted Qwen3 Coder tier via Ollama Cloud
     OllamaQwen3Coder480bCloud,
+    /// GPT-OSS 20B (Cloud) - Managed GPT-OSS 20B via Ollama Cloud
+    OllamaGptOss20bCloud,
+    /// GPT-OSS 120B (Cloud) - Flagship GPT-OSS 120B via Ollama Cloud
+    OllamaGptOss120bCloud,
+    /// DeepSeek V3.1 671B (Cloud) - Hosted DeepSeek reasoning tier via Ollama Cloud
+    OllamaDeepseekV31_671bCloud,
+    /// Kimi K2 1T (Cloud) - Hosted Kimi K2 flagship tier via Ollama Cloud
+    OllamaKimiK21tCloud,
     /// GLM 4.6 (Cloud) - Hosted GLM 4.6 coding model via Ollama Cloud
     OllamaGlm46Cloud,
 
@@ -478,6 +486,10 @@ impl ModelId {
             ModelId::OllamaQwen3Coder30b => models::ollama::QWEN3_CODER_30B,
             ModelId::OllamaQwen3Coder480b => models::ollama::QWEN3_CODER_480B,
             ModelId::OllamaQwen3Coder480bCloud => models::ollama::QWEN3_CODER_480B_CLOUD,
+            ModelId::OllamaGptOss20bCloud => models::ollama::GPT_OSS_20B_CLOUD,
+            ModelId::OllamaGptOss120bCloud => models::ollama::GPT_OSS_120B_CLOUD,
+            ModelId::OllamaDeepseekV31_671bCloud => models::ollama::DEEPSEEK_V3_1_671B_CLOUD,
+            ModelId::OllamaKimiK21tCloud => models::ollama::KIMI_K2_1T_CLOUD,
             ModelId::OllamaGlm46Cloud => models::ollama::GLM_4_6_CLOUD,
             // OpenRouter models
             _ => unreachable!(),
@@ -528,6 +540,10 @@ impl ModelId {
             | ModelId::OllamaQwen3Coder30b
             | ModelId::OllamaQwen3Coder480b
             | ModelId::OllamaQwen3Coder480bCloud
+            | ModelId::OllamaGptOss20bCloud
+            | ModelId::OllamaGptOss120bCloud
+            | ModelId::OllamaDeepseekV31_671bCloud
+            | ModelId::OllamaKimiK21tCloud
             | ModelId::OllamaGlm46Cloud => Provider::Ollama,
             _ => unreachable!(),
         }
@@ -591,6 +607,10 @@ impl ModelId {
             ModelId::OllamaQwen3Coder30b => "Qwen3 Coder 30B (local)",
             ModelId::OllamaQwen3Coder480b => "Qwen3 Coder 480B (local)",
             ModelId::OllamaQwen3Coder480bCloud => "Qwen3 Coder 480B (cloud)",
+            ModelId::OllamaGptOss20bCloud => "GPT-OSS 20B (cloud)",
+            ModelId::OllamaGptOss120bCloud => "GPT-OSS 120B (cloud)",
+            ModelId::OllamaDeepseekV31_671bCloud => "DeepSeek V3.1 671B (cloud)",
+            ModelId::OllamaKimiK21tCloud => "Kimi K2 1T (cloud)",
             ModelId::OllamaGlm46Cloud => "GLM 4.6 (cloud)",
             // OpenRouter models
             _ => unreachable!(),
@@ -695,6 +715,18 @@ impl ModelId {
             ModelId::OllamaQwen3Coder480bCloud => {
                 "Hosted Qwen3 Coder 480B via Ollama Cloud for managed large-context coding workloads"
             }
+            ModelId::OllamaGptOss20bCloud => {
+                "Managed GPT-OSS 20B served through Ollama Cloud with zero local GPU requirements"
+            }
+            ModelId::OllamaGptOss120bCloud => {
+                "Hosted GPT-OSS 120B flagship deployment through Ollama Cloud for maximum capability"
+            }
+            ModelId::OllamaDeepseekV31_671bCloud => {
+                "Hosted DeepSeek V3.1 671B reasoning tier available through Ollama Cloud for agent workflows"
+            }
+            ModelId::OllamaKimiK21tCloud => {
+                "Hosted Kimi K2 1T flagship tier via Ollama Cloud delivering managed large-context reasoning"
+            }
             ModelId::OllamaGlm46Cloud => {
                 "Hosted GLM 4.6 coding model available through Ollama Cloud"
             }
@@ -752,6 +784,10 @@ impl ModelId {
             ModelId::OllamaQwen3Coder30b,
             ModelId::OllamaQwen3Coder480b,
             ModelId::OllamaQwen3Coder480bCloud,
+            ModelId::OllamaGptOss20bCloud,
+            ModelId::OllamaGptOss120bCloud,
+            ModelId::OllamaDeepseekV31_671bCloud,
+            ModelId::OllamaKimiK21tCloud,
             ModelId::OllamaGlm46Cloud,
         ];
         models.extend(Self::openrouter_models());
@@ -870,6 +906,9 @@ impl ModelId {
                 | ModelId::MoonshotKimiLatest128k
                 | ModelId::OllamaQwen3Coder480b
                 | ModelId::OllamaQwen3Coder480bCloud
+                | ModelId::OllamaGptOss120bCloud
+                | ModelId::OllamaDeepseekV31_671bCloud
+                | ModelId::OllamaKimiK21tCloud
                 | ModelId::OllamaGlm46Cloud
         )
     }
@@ -917,6 +956,9 @@ impl ModelId {
                 | ModelId::MoonshotKimiK20905Preview
                 | ModelId::MoonshotKimiLatest128k
                 | ModelId::OllamaQwen3Coder480bCloud
+                | ModelId::OllamaGptOss120bCloud
+                | ModelId::OllamaDeepseekV31_671bCloud
+                | ModelId::OllamaKimiK21tCloud
                 | ModelId::OllamaGlm46Cloud
         )
     }
@@ -967,10 +1009,13 @@ impl ModelId {
             | ModelId::MoonshotKimiLatest32k
             | ModelId::MoonshotKimiLatest128k => "latest",
             ModelId::OllamaGptOss20b => "oss",
+            ModelId::OllamaGptOss20bCloud | ModelId::OllamaGptOss120bCloud => "oss cloud",
             ModelId::OllamaQwen317b
             | ModelId::OllamaQwen3Coder30b
             | ModelId::OllamaQwen3Coder480b
             | ModelId::OllamaQwen3Coder480bCloud => "qwen3",
+            ModelId::OllamaDeepseekV31_671bCloud => "v3.1 cloud",
+            ModelId::OllamaKimiK21tCloud => "k2 cloud",
             ModelId::OllamaGlm46Cloud => "4.6 cloud",
             _ => unreachable!(),
         }
@@ -1043,6 +1088,12 @@ impl FromStr for ModelId {
             s if s == models::ollama::QWEN3_CODER_480B_CLOUD => {
                 Ok(ModelId::OllamaQwen3Coder480bCloud)
             }
+            s if s == models::ollama::GPT_OSS_20B_CLOUD => Ok(ModelId::OllamaGptOss20bCloud),
+            s if s == models::ollama::GPT_OSS_120B_CLOUD => Ok(ModelId::OllamaGptOss120bCloud),
+            s if s == models::ollama::DEEPSEEK_V3_1_671B_CLOUD => {
+                Ok(ModelId::OllamaDeepseekV31_671bCloud)
+            }
+            s if s == models::ollama::KIMI_K2_1T_CLOUD => Ok(ModelId::OllamaKimiK21tCloud),
             s if s == models::ollama::GLM_4_6_CLOUD => Ok(ModelId::OllamaGlm46Cloud),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
@@ -1493,6 +1544,9 @@ mod tests {
         assert!(ModelId::MoonshotKimiLatest128k.is_pro_variant());
         assert!(ModelId::OllamaQwen3Coder480b.is_pro_variant());
         assert!(ModelId::OllamaQwen3Coder480bCloud.is_pro_variant());
+        assert!(ModelId::OllamaGptOss120bCloud.is_pro_variant());
+        assert!(ModelId::OllamaDeepseekV31_671bCloud.is_pro_variant());
+        assert!(ModelId::OllamaKimiK21tCloud.is_pro_variant());
         assert!(ModelId::OllamaGlm46Cloud.is_pro_variant());
         assert!(!ModelId::Gemini25FlashPreview.is_pro_variant());
 
@@ -1531,6 +1585,9 @@ mod tests {
         assert!(ModelId::MoonshotKimiK20905Preview.is_top_tier());
         assert!(ModelId::MoonshotKimiLatest128k.is_top_tier());
         assert!(ModelId::OllamaQwen3Coder480bCloud.is_top_tier());
+        assert!(ModelId::OllamaGptOss120bCloud.is_top_tier());
+        assert!(ModelId::OllamaDeepseekV31_671bCloud.is_top_tier());
+        assert!(ModelId::OllamaKimiK21tCloud.is_top_tier());
         assert!(ModelId::OllamaGlm46Cloud.is_top_tier());
         assert!(!ModelId::Gemini25FlashPreview.is_top_tier());
         assert!(!ModelId::ClaudeHaiku45.is_top_tier());
@@ -1589,6 +1646,14 @@ mod tests {
         assert_eq!(ModelId::MoonshotKimiLatest8k.generation(), "latest");
         assert_eq!(ModelId::MoonshotKimiLatest32k.generation(), "latest");
         assert_eq!(ModelId::MoonshotKimiLatest128k.generation(), "latest");
+        assert_eq!(ModelId::OllamaGptOss20bCloud.generation(), "oss cloud");
+        assert_eq!(ModelId::OllamaGptOss120bCloud.generation(), "oss cloud");
+        assert_eq!(
+            ModelId::OllamaDeepseekV31_671bCloud.generation(),
+            "v3.1 cloud"
+        );
+        assert_eq!(ModelId::OllamaKimiK21tCloud.generation(), "k2 cloud");
+        assert_eq!(ModelId::OllamaGlm46Cloud.generation(), "4.6 cloud");
 
         macro_rules! assert_openrouter_generation {
             ($(($variant:ident, $const:ident, $display:expr, $description:expr, $efficient:expr, $top:expr, $generation:expr),)*) => {
@@ -1659,8 +1724,12 @@ mod tests {
         assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder30b));
         assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder480b));
         assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder480bCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaGptOss20bCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaGptOss120bCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaDeepseekV31_671bCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaKimiK21tCloud));
         assert!(ollama_models.contains(&ModelId::OllamaGlm46Cloud));
-        assert_eq!(ollama_models.len(), 6);
+        assert_eq!(ollama_models.len(), 10);
     }
 
     #[test]

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -20,9 +20,9 @@ use std::collections::HashSet;
 const MAX_COMPLETION_TOKENS_FIELD: &str = "max_completion_tokens";
 
 use super::{
+    ReasoningBuffer,
     common::{extract_prompt_cache_settings, override_base_url, resolve_model},
     extract_reasoning_trace, gpt5_codex_developer_prompt, split_reasoning_from_text,
-    ReasoningBuffer,
 };
 
 fn find_sse_boundary(buffer: &str) -> Option<(usize, usize)> {

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -18,9 +18,9 @@ use serde_json::{Map, Value, json};
 use std::borrow::Cow;
 
 use super::{
+    ReasoningBuffer,
     common::{extract_prompt_cache_settings, override_base_url, resolve_model},
     extract_reasoning_trace, gpt5_codex_developer_prompt, split_reasoning_from_text,
-    ReasoningBuffer,
 };
 
 #[derive(Default, Clone)]


### PR DESCRIPTION
## Summary
- replace direct reqwest usage with the official ollama-rs client types and extend requests with custom payloads so tool_choice and headers are forwarded correctly
- enrich Ollama request validation and streaming handling to support explicit tool selection, tool-choice parsing, and robust error mapping
- document JSON tool calling usage and add regression tests covering tool_choice serialization and invalid base URL handling

## Testing
- cargo fmt
- cargo clippy --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68f0f8088ba4832387d3faaec9ae0e32