### PR TITLE
Enable streaming reasoning for OpenAI

### DIFF
--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -12,7 +12,7 @@ mod codex_prompt;
 mod reasoning;
 
 pub(crate) use codex_prompt::gpt5_codex_developer_prompt;
-pub(crate) use reasoning::extract_reasoning_trace;
+pub(crate) use reasoning::{ReasoningBuffer, extract_reasoning_trace, split_reasoning_from_text};
 
 pub use anthropic::AnthropicProvider;
 pub use deepseek::DeepSeekProvider;

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -5,19 +5,255 @@ use crate::config::types::ReasoningEffortLevel;
 use crate::llm::client::LLMClient;
 use crate::llm::error_display;
 use crate::llm::provider::{
-    FinishReason, LLMError, LLMProvider, LLMRequest, LLMResponse, Message, MessageRole, ToolCall,
-    ToolChoice, ToolDefinition,
+    FinishReason, LLMError, LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent,
+    Message, MessageRole, ToolCall, ToolChoice, ToolDefinition,
 };
 use crate::llm::rig_adapter::reasoning_parameters_for;
 use crate::llm::types as llm_types;
+use async_stream::try_stream;
 use async_trait::async_trait;
+use futures::StreamExt;
 use reqwest::Client as HttpClient;
 use serde_json::{Value, json};
 use std::collections::HashSet;
 
 const MAX_COMPLETION_TOKENS_FIELD: &str = "max_completion_tokens";
 
-use super::{extract_reasoning_trace, gpt5_codex_developer_prompt};
+use super::{
+    ReasoningBuffer, extract_reasoning_trace, gpt5_codex_developer_prompt,
+    split_reasoning_from_text,
+};
+
+fn find_sse_boundary(buffer: &str) -> Option<(usize, usize)> {
+    let newline_boundary = buffer.find("\n\n").map(|idx| (idx, 2));
+    let carriage_boundary = buffer.find("\r\n\r\n").map(|idx| (idx, 4));
+
+    match (newline_boundary, carriage_boundary) {
+        (Some((n_idx, n_len)), Some((c_idx, c_len))) => {
+            if n_idx <= c_idx {
+                Some((n_idx, n_len))
+            } else {
+                Some((c_idx, c_len))
+            }
+        }
+        (Some(boundary), None) => Some(boundary),
+        (None, Some(boundary)) => Some(boundary),
+        (None, None) => None,
+    }
+}
+
+fn extract_data_payload(event: &str) -> Option<String> {
+    let mut data_lines = Vec::new();
+
+    for line in event.lines() {
+        let trimmed = line.trim_end_matches('\r');
+        if let Some(rest) = trimmed.strip_prefix("data:") {
+            data_lines.push(rest.trim_start());
+        }
+    }
+
+    if data_lines.is_empty() {
+        None
+    } else {
+        Some(data_lines.join("\n"))
+    }
+}
+
+fn append_reasoning_segments(reasoning: &mut ReasoningBuffer, text: &str) -> Vec<String> {
+    let mut emitted = Vec::new();
+    let (mut segments, cleaned) = split_reasoning_from_text(text);
+
+    if !segments.is_empty() {
+        for segment in segments.drain(..) {
+            if let Some(delta) = reasoning.push(&segment) {
+                emitted.push(delta);
+            }
+        }
+
+        if let Some(cleaned_text) = cleaned {
+            let trimmed = cleaned_text.trim();
+            if !trimmed.is_empty() {
+                if let Some(delta) = reasoning.push(trimmed) {
+                    emitted.push(delta);
+                }
+            }
+        }
+    } else if let Some(delta) = reasoning.push(text) {
+        emitted.push(delta);
+    }
+
+    emitted
+}
+
+fn parse_responses_payload(
+    response_json: Value,
+    include_cached_prompt_metrics: bool,
+) -> Result<LLMResponse, LLMError> {
+    let output = response_json
+        .get("output")
+        .or_else(|| response_json.get("choices"))
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| {
+            let formatted_error = error_display::format_llm_error(
+                "OpenAI",
+                "Invalid response format: missing output",
+            );
+            LLMError::Provider(formatted_error)
+        })?;
+
+    if output.is_empty() {
+        let formatted_error = error_display::format_llm_error("OpenAI", "No output in response");
+        return Err(LLMError::Provider(formatted_error));
+    }
+
+    let mut content_fragments = Vec::new();
+    let mut reasoning_fragments = Vec::new();
+    let mut tool_calls_vec = Vec::new();
+
+    for item in output {
+        let item_type = item
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if item_type != "message" {
+            continue;
+        }
+
+        if let Some(content_array) = item.get("content").and_then(|value| value.as_array()) {
+            for entry in content_array {
+                let entry_type = entry
+                    .get("type")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                match entry_type {
+                    "output_text" | "text" => {
+                        if let Some(text) = entry.get("text").and_then(|value| value.as_str()) {
+                            if !text.is_empty() {
+                                content_fragments.push(text.to_string());
+                            }
+                        }
+                    }
+                    "reasoning" => {
+                        if let Some(text) = entry.get("text").and_then(|value| value.as_str()) {
+                            if !text.is_empty() {
+                                reasoning_fragments.push(text.to_string());
+                            }
+                        }
+                    }
+                    "tool_call" => {
+                        let (name_value, arguments_value) = if let Some(function) =
+                            entry.get("function").and_then(|value| value.as_object())
+                        {
+                            let name = function.get("name").and_then(|value| value.as_str());
+                            let arguments = function.get("arguments");
+                            (name, arguments)
+                        } else {
+                            let name = entry.get("name").and_then(|value| value.as_str());
+                            let arguments = entry.get("arguments");
+                            (name, arguments)
+                        };
+
+                        if let Some(name) = name_value {
+                            let id = entry
+                                .get("id")
+                                .and_then(|value| value.as_str())
+                                .unwrap_or_else(|| "");
+                            let serialized = arguments_value.map_or("{}".to_string(), |value| {
+                                if value.is_string() {
+                                    value.as_str().unwrap_or("").to_string()
+                                } else {
+                                    value.to_string()
+                                }
+                            });
+                            tool_calls_vec.push(ToolCall::function(
+                                id.to_string(),
+                                name.to_string(),
+                                serialized,
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let content = if content_fragments.is_empty() {
+        None
+    } else {
+        Some(content_fragments.join(""))
+    };
+
+    let reasoning = if reasoning_fragments.is_empty() {
+        None
+    } else {
+        Some(reasoning_fragments.join(""))
+    };
+
+    let tool_calls = if tool_calls_vec.is_empty() {
+        None
+    } else {
+        Some(tool_calls_vec)
+    };
+
+    let usage = response_json.get("usage").map(|usage_value| {
+        let cached_prompt_tokens = if include_cached_prompt_metrics {
+            usage_value
+                .get("prompt_tokens_details")
+                .and_then(|details| details.get("cached_tokens"))
+                .or_else(|| usage_value.get("prompt_cache_hit_tokens"))
+                .and_then(|value| value.as_u64())
+                .map(|value| value as u32)
+        } else {
+            None
+        };
+
+        crate::llm::provider::Usage {
+            prompt_tokens: usage_value
+                .get("input_tokens")
+                .or_else(|| usage_value.get("prompt_tokens"))
+                .and_then(|pt| pt.as_u64())
+                .unwrap_or(0) as u32,
+            completion_tokens: usage_value
+                .get("output_tokens")
+                .or_else(|| usage_value.get("completion_tokens"))
+                .and_then(|ct| ct.as_u64())
+                .unwrap_or(0) as u32,
+            total_tokens: usage_value
+                .get("total_tokens")
+                .and_then(|tt| tt.as_u64())
+                .unwrap_or(0) as u32,
+            cached_prompt_tokens,
+            cache_creation_tokens: None,
+            cache_read_tokens: None,
+        }
+    });
+
+    let stop_reason = response_json
+        .get("stop_reason")
+        .and_then(|value| value.as_str())
+        .or_else(|| {
+            output
+                .iter()
+                .find_map(|item| item.get("stop_reason").and_then(|value| value.as_str()))
+        })
+        .unwrap_or("stop");
+
+    let finish_reason = match stop_reason {
+        "stop" => FinishReason::Stop,
+        "max_output_tokens" | "length" => FinishReason::Length,
+        "tool_use" | "tool_calls" => FinishReason::ToolCalls,
+        other => FinishReason::Error(other.to_string()),
+    };
+
+    Ok(LLMResponse {
+        content,
+        tool_calls,
+        usage,
+        finish_reason,
+        reasoning,
+    })
+}
 
 pub struct OpenAIProvider {
     api_key: String,
@@ -702,173 +938,9 @@ impl OpenAIProvider {
         &self,
         response_json: Value,
     ) -> Result<LLMResponse, LLMError> {
-        let output = response_json
-            .get("output")
-            .or_else(|| response_json.get("choices"))
-            .and_then(|value| value.as_array())
-            .ok_or_else(|| {
-                let formatted_error = error_display::format_llm_error(
-                    "OpenAI",
-                    "Invalid response format: missing output",
-                );
-                LLMError::Provider(formatted_error)
-            })?;
-
-        if output.is_empty() {
-            let formatted_error =
-                error_display::format_llm_error("OpenAI", "No output in response");
-            return Err(LLMError::Provider(formatted_error));
-        }
-
-        let mut content_fragments = Vec::new();
-        let mut reasoning_fragments = Vec::new();
-        let mut tool_calls_vec = Vec::new();
-
-        for item in output {
-            let item_type = item
-                .get("type")
-                .and_then(|value| value.as_str())
-                .unwrap_or("");
-            if item_type != "message" {
-                continue;
-            }
-
-            if let Some(content_array) = item.get("content").and_then(|value| value.as_array()) {
-                for entry in content_array {
-                    let entry_type = entry
-                        .get("type")
-                        .and_then(|value| value.as_str())
-                        .unwrap_or("");
-                    match entry_type {
-                        "output_text" | "text" => {
-                            if let Some(text) = entry.get("text").and_then(|value| value.as_str()) {
-                                if !text.is_empty() {
-                                    content_fragments.push(text.to_string());
-                                }
-                            }
-                        }
-                        "reasoning" => {
-                            if let Some(text) = entry.get("text").and_then(|value| value.as_str()) {
-                                if !text.is_empty() {
-                                    reasoning_fragments.push(text.to_string());
-                                }
-                            }
-                        }
-                        "tool_call" => {
-                            let (name_value, arguments_value) = if let Some(function) =
-                                entry.get("function").and_then(|value| value.as_object())
-                            {
-                                let name = function.get("name").and_then(|value| value.as_str());
-                                let arguments = function.get("arguments");
-                                (name, arguments)
-                            } else {
-                                let name = entry.get("name").and_then(|value| value.as_str());
-                                let arguments = entry.get("arguments");
-                                (name, arguments)
-                            };
-
-                            if let Some(name) = name_value {
-                                let id = entry
-                                    .get("id")
-                                    .and_then(|value| value.as_str())
-                                    .unwrap_or_else(|| "");
-                                let serialized =
-                                    arguments_value.map_or("{}".to_string(), |value| {
-                                        if value.is_string() {
-                                            value.as_str().unwrap_or("").to_string()
-                                        } else {
-                                            value.to_string()
-                                        }
-                                    });
-                                tool_calls_vec.push(ToolCall::function(
-                                    id.to_string(),
-                                    name.to_string(),
-                                    serialized,
-                                ));
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-
-        let content = if content_fragments.is_empty() {
-            None
-        } else {
-            Some(content_fragments.join(""))
-        };
-
-        let reasoning = if reasoning_fragments.is_empty() {
-            None
-        } else {
-            Some(reasoning_fragments.join(""))
-        };
-
-        let tool_calls = if tool_calls_vec.is_empty() {
-            None
-        } else {
-            Some(tool_calls_vec)
-        };
-
-        let usage = response_json.get("usage").map(|usage_value| {
-            let cached_prompt_tokens =
-                if self.prompt_cache_enabled && self.prompt_cache_settings.surface_metrics {
-                    usage_value
-                        .get("prompt_tokens_details")
-                        .and_then(|details| details.get("cached_tokens"))
-                        .or_else(|| usage_value.get("prompt_cache_hit_tokens"))
-                        .and_then(|value| value.as_u64())
-                        .map(|value| value as u32)
-                } else {
-                    None
-                };
-
-            crate::llm::provider::Usage {
-                prompt_tokens: usage_value
-                    .get("input_tokens")
-                    .or_else(|| usage_value.get("prompt_tokens"))
-                    .and_then(|pt| pt.as_u64())
-                    .unwrap_or(0) as u32,
-                completion_tokens: usage_value
-                    .get("output_tokens")
-                    .or_else(|| usage_value.get("completion_tokens"))
-                    .and_then(|ct| ct.as_u64())
-                    .unwrap_or(0) as u32,
-                total_tokens: usage_value
-                    .get("total_tokens")
-                    .and_then(|tt| tt.as_u64())
-                    .unwrap_or(0) as u32,
-                cached_prompt_tokens,
-                cache_creation_tokens: None,
-                cache_read_tokens: None,
-            }
-        });
-
-        let stop_reason = response_json
-            .get("stop_reason")
-            .and_then(|value| value.as_str())
-            .or_else(|| {
-                output
-                    .iter()
-                    .find_map(|item| item.get("stop_reason").and_then(|value| value.as_str()))
-            })
-            .unwrap_or("stop");
-
-        let finish_reason = match stop_reason {
-            "stop" => FinishReason::Stop,
-            "max_output_tokens" | "length" => FinishReason::Length,
-            "tool_use" | "tool_calls" => FinishReason::ToolCalls,
-            other => FinishReason::Error(other.to_string()),
-        };
-
-        Ok(LLMResponse {
-            content,
-            tool_calls,
-            usage,
-            finish_reason,
-            reasoning,
-        })
+        let include_metrics =
+            self.prompt_cache_enabled && self.prompt_cache_settings.surface_metrics;
+        parse_responses_payload(response_json, include_metrics)
     }
 }
 
@@ -1312,8 +1384,20 @@ impl LLMProvider for OpenAIProvider {
         "openai"
     }
 
-    fn supports_reasoning(&self, _model: &str) -> bool {
-        false
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+
+        models::openai::REASONING_MODELS
+            .iter()
+            .any(|candidate| *candidate == requested)
     }
 
     fn supports_reasoning_effort(&self, model: &str) -> bool {
@@ -1337,6 +1421,205 @@ impl LLMProvider for OpenAIProvider {
         !models::openai::TOOL_UNAVAILABLE_MODELS
             .iter()
             .any(|candidate| *candidate == requested)
+    }
+
+    async fn stream(&self, mut request: LLMRequest) -> Result<LLMStream, LLMError> {
+        if request.model.trim().is_empty() {
+            request.model = self.model.clone();
+        }
+
+        if !Self::uses_responses_api(&request.model) {
+            request.stream = false;
+            let response = self.generate(request).await?;
+            let stream = try_stream! {
+                yield LLMStreamEvent::Completed { response };
+            };
+            return Ok(Box::pin(stream));
+        }
+
+        let include_metrics =
+            self.prompt_cache_enabled && self.prompt_cache_settings.surface_metrics;
+
+        let mut openai_request = self.convert_to_openai_responses_format(&request)?;
+        openai_request["stream"] = Value::Bool(true);
+
+        let url = format!("{}/responses", self.base_url);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&openai_request)
+            .send()
+            .await
+            .map_err(|e| {
+                let formatted_error =
+                    error_display::format_llm_error("OpenAI", &format!("Network error: {}", e));
+                LLMError::Network(formatted_error)
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+
+            if status.as_u16() == 429
+                || error_text.contains("insufficient_quota")
+                || error_text.contains("quota")
+                || error_text.contains("rate limit")
+            {
+                return Err(LLMError::RateLimit);
+            }
+
+            let formatted_error = error_display::format_llm_error(
+                "OpenAI",
+                &format!("HTTP {}: {}", status, error_text),
+            );
+            return Err(LLMError::Provider(formatted_error));
+        }
+
+        let stream = try_stream! {
+            let mut body_stream = response.bytes_stream();
+            let mut buffer = String::new();
+            let mut aggregated_content = String::new();
+            let mut reasoning_buffer = ReasoningBuffer::default();
+            let mut final_response: Option<Value> = None;
+            let mut done = false;
+
+            while let Some(chunk_result) = body_stream.next().await {
+                let chunk = chunk_result.map_err(|err| {
+                    let formatted_error = error_display::format_llm_error(
+                        "OpenAI",
+                        &format!("Streaming error: {}", err),
+                    );
+                    LLMError::Network(formatted_error)
+                })?;
+
+                buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                while let Some((split_idx, delimiter_len)) = find_sse_boundary(&buffer) {
+                    let event = buffer[..split_idx].to_string();
+                    buffer.drain(..split_idx + delimiter_len);
+
+                    if let Some(data_payload) = extract_data_payload(&event) {
+                        let trimmed_payload = data_payload.trim();
+                        if trimmed_payload.is_empty() {
+                            continue;
+                        }
+
+                        if trimmed_payload == "[DONE]" {
+                            done = true;
+                            break;
+                        }
+
+                        let payload: Value = serde_json::from_str(trimmed_payload).map_err(|err| {
+                            let formatted_error = error_display::format_llm_error(
+                                "OpenAI",
+                                &format!("Failed to parse stream payload: {}", err),
+                            );
+                            LLMError::Provider(formatted_error)
+                        })?;
+
+                        if let Some(event_type) = payload.get("type").and_then(|value| value.as_str()) {
+                            match event_type {
+                                "response.output_text.delta" => {
+                                    if let Some(delta) = payload.get("delta").and_then(|value| value.as_str()) {
+                                        aggregated_content.push_str(delta);
+                                        yield LLMStreamEvent::Token { delta: delta.to_string() };
+                                    }
+                                }
+                                "response.reasoning_text.delta" | "response.reasoning_summary_text.delta" => {
+                                    if let Some(delta) = payload.get("delta").and_then(|value| value.as_str()) {
+                                        for fragment in append_reasoning_segments(&mut reasoning_buffer, delta) {
+                                            yield LLMStreamEvent::Reasoning { delta: fragment };
+                                        }
+                                    }
+                                }
+                                "response.completed" => {
+                                    if let Some(response_value) = payload.get("response") {
+                                        final_response = Some(response_value.clone());
+                                    }
+                                    done = true;
+                                }
+                                "response.failed" | "response.incomplete" => {
+                                    let message = payload
+                                        .get("response")
+                                        .and_then(|value| value.get("error"))
+                                        .and_then(|error| error.get("message"))
+                                        .and_then(|value| value.as_str())
+                                        .unwrap_or("Streaming response failed");
+                                    let formatted_error = error_display::format_llm_error("OpenAI", message);
+                                    Err(LLMError::Provider(formatted_error))?;
+                                }
+                                "error" => {
+                                    let message = payload
+                                        .get("message")
+                                        .and_then(|value| value.as_str())
+                                        .unwrap_or("Streaming request failed");
+                                    let formatted_error = error_display::format_llm_error("OpenAI", message);
+                                    Err(LLMError::Provider(formatted_error))?;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+
+                if done {
+                    break;
+                }
+            }
+
+            if !done && !buffer.trim().is_empty() {
+                if let Some(data_payload) = extract_data_payload(&buffer) {
+                    let trimmed_payload = data_payload.trim();
+                    if trimmed_payload != "[DONE]" && !trimmed_payload.is_empty() {
+                        let payload: Value = serde_json::from_str(trimmed_payload).map_err(|err| {
+                            let formatted_error = error_display::format_llm_error(
+                                "OpenAI",
+                                &format!("Failed to parse stream payload: {}", err),
+                            );
+                            LLMError::Provider(formatted_error)
+                        })?;
+
+                        if payload
+                            .get("type")
+                            .and_then(|value| value.as_str())
+                            .map(|event_type| event_type == "response.completed")
+                            .unwrap_or(false)
+                        {
+                            if let Some(response_value) = payload.get("response") {
+                                final_response = Some(response_value.clone());
+                            }
+                        }
+                    }
+                }
+            }
+
+            let response_value = match final_response {
+                Some(value) => value,
+                None => {
+                    let formatted_error = error_display::format_llm_error(
+                        "OpenAI",
+                        "Stream ended without a completion event",
+                    );
+                    Err(LLMError::Provider(formatted_error))?
+                }
+            };
+
+            let mut response = parse_responses_payload(response_value, include_metrics)?;
+
+            if response.content.is_none() && !aggregated_content.is_empty() {
+                response.content = Some(aggregated_content.clone());
+            }
+
+            if let Some(reasoning_text) = reasoning_buffer.finalize() {
+                response.reasoning = Some(reasoning_text);
+            }
+
+            yield LLMStreamEvent::Completed { response };
+        };
+
+        Ok(Box::pin(stream))
     }
 
     async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -17,7 +17,10 @@ use reqwest::{Client as HttpClient, Response, StatusCode};
 use serde_json::{Map, Value, json};
 use std::borrow::Cow;
 
-use super::{extract_reasoning_trace, gpt5_codex_developer_prompt};
+use super::{
+    ReasoningBuffer, extract_reasoning_trace, gpt5_codex_developer_prompt,
+    split_reasoning_from_text,
+};
 
 #[derive(Default, Clone)]
 struct ToolCallBuilder {
@@ -131,89 +134,50 @@ impl StreamDelta {
     }
 }
 
-#[derive(Default, Clone)]
-struct ReasoningBuffer {
-    text: String,
-    last_chunk: Option<String>,
+fn append_text_with_reasoning(
+    text: &str,
+    aggregated_content: &mut String,
+    reasoning: &mut ReasoningBuffer,
+    deltas: &mut StreamDelta,
+) {
+    let (segments, cleaned) = split_reasoning_from_text(text);
+
+    if segments.is_empty() && cleaned.is_none() {
+        if !text.is_empty() {
+            aggregated_content.push_str(text);
+            deltas.push_content(text);
+        }
+        return;
+    }
+
+    for segment in segments {
+        if let Some(delta) = reasoning.push(&segment) {
+            deltas.push_reasoning(&delta);
+        }
+    }
+
+    if let Some(cleaned_text) = cleaned {
+        if !cleaned_text.is_empty() {
+            aggregated_content.push_str(&cleaned_text);
+            deltas.push_content(&cleaned_text);
+        }
+    }
 }
 
-impl ReasoningBuffer {
-    fn push(&mut self, chunk: &str) -> Option<String> {
-        if chunk.trim().is_empty() {
-            return None;
-        }
-
-        let normalized = Self::normalize_chunk(chunk);
-
-        if normalized.is_empty() {
-            return None;
-        }
-
-        if self.last_chunk.as_deref() == Some(&normalized) {
-            return None;
-        }
-
-        let last_has_spacing = self.text.ends_with(' ') || self.text.ends_with('\n');
-        let chunk_starts_with_space = chunk
-            .chars()
-            .next()
-            .map(|value| value.is_whitespace())
-            .unwrap_or(false);
-        let leading_punctuation = Self::is_leading_punctuation(chunk);
-        let trailing_connector = Self::ends_with_connector(&self.text);
-
-        let mut delta = String::new();
-
-        if !self.text.is_empty()
-            && !last_has_spacing
-            && !chunk_starts_with_space
-            && !leading_punctuation
-            && !trailing_connector
-        {
-            delta.push(' ');
-        }
-
-        delta.push_str(&normalized);
-        self.text.push_str(&delta);
-        self.last_chunk = Some(normalized);
-
-        Some(delta)
-    }
-
-    fn finalize(self) -> Option<String> {
-        let trimmed = self.text.trim();
+fn append_reasoning_segment(segments: &mut Vec<String>, text: &str) {
+    for line in text.split('\n') {
+        let trimmed = line.trim();
         if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
+            continue;
         }
-    }
-
-    fn normalize_chunk(chunk: &str) -> String {
-        let mut normalized = String::new();
-        for part in chunk.split_whitespace() {
-            if !normalized.is_empty() {
-                normalized.push(' ');
-            }
-            normalized.push_str(part);
+        if segments
+            .last()
+            .map(|last| last.as_str() == trimmed)
+            .unwrap_or(false)
+        {
+            continue;
         }
-        normalized
-    }
-
-    fn is_leading_punctuation(chunk: &str) -> bool {
-        chunk
-            .chars()
-            .find(|ch| !ch.is_whitespace())
-            .map(|ch| matches!(ch, ',' | '.' | '!' | '?' | ':' | ';' | ')' | ']' | '}'))
-            .unwrap_or(false)
-    }
-
-    fn ends_with_connector(text: &str) -> bool {
-        text.chars()
-            .rev()
-            .find(|ch| !ch.is_whitespace())
-            .map(|ch| matches!(ch, '(' | '[' | '{' | '/' | '-'))
-            .unwrap_or(false)
+        segments.push(trimmed.to_string());
     }
 }
 
@@ -304,18 +268,12 @@ fn process_content_object(
     }
 
     if let Some(text_value) = map.get("text").and_then(|value| value.as_str()) {
-        if !text_value.is_empty() {
-            aggregated_content.push_str(text_value);
-            deltas.push_content(text_value);
-        }
+        append_text_with_reasoning(text_value, aggregated_content, reasoning, deltas);
         return;
     }
 
     if let Some(text_value) = map.get("output_text").and_then(|value| value.as_str()) {
-        if !text_value.is_empty() {
-            aggregated_content.push_str(text_value);
-            deltas.push_content(text_value);
-        }
+        append_text_with_reasoning(text_value, aggregated_content, reasoning, deltas);
         return;
     }
 
@@ -323,10 +281,7 @@ fn process_content_object(
         .get("output_text_delta")
         .and_then(|value| value.as_str())
     {
-        if !text_value.is_empty() {
-            aggregated_content.push_str(text_value);
-            deltas.push_content(text_value);
-        }
+        append_text_with_reasoning(text_value, aggregated_content, reasoning, deltas);
         return;
     }
 
@@ -351,10 +306,7 @@ fn process_content_part(
     deltas: &mut StreamDelta,
 ) {
     if let Some(text) = part.as_str() {
-        if !text.is_empty() {
-            aggregated_content.push_str(text);
-            deltas.push_content(text);
-        }
+        append_text_with_reasoning(text, aggregated_content, reasoning, deltas);
         return;
     }
 
@@ -389,10 +341,7 @@ fn process_content_value(
 ) {
     match value {
         Value::String(text) => {
-            if !text.is_empty() {
-                aggregated_content.push_str(text);
-                deltas.push_content(text);
-            }
+            append_text_with_reasoning(text, aggregated_content, reasoning, deltas);
         }
         Value::Array(parts) => {
             for part in parts {
@@ -488,6 +437,21 @@ fn extract_reasoning_from_message_content(message: &Value) -> Option<String> {
     let parts = message.get("content")?.as_array()?;
     let mut segments: Vec<String> = Vec::new();
 
+    fn push_segment(segments: &mut Vec<String>, value: &str) {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        if segments
+            .last()
+            .map(|last| last.as_str() == trimmed)
+            .unwrap_or(false)
+        {
+            return;
+        }
+        segments.push(trimmed.to_string());
+    }
+
     for part in parts {
         match part {
             Value::Object(map) => {
@@ -507,15 +471,22 @@ fn extract_reasoning_from_message_content(message: &Value) -> Option<String> {
                     if let Some(text) = map.get("text").and_then(|value| value.as_str()) {
                         let trimmed = text.trim();
                         if !trimmed.is_empty() {
-                            segments.push(trimmed.to_string());
+                            push_segment(&mut segments, trimmed);
                         }
                     }
                 }
             }
             Value::String(text) => {
-                let trimmed = text.trim();
-                if !trimmed.is_empty() {
-                    segments.push(trimmed.to_string());
+                let (mut markup_segments, cleaned) = split_reasoning_from_text(text);
+                if !markup_segments.is_empty() {
+                    for segment in markup_segments.drain(..) {
+                        push_segment(&mut segments, &segment);
+                    }
+                    if let Some(cleaned_text) = cleaned {
+                        push_segment(&mut segments, &cleaned_text);
+                    }
+                } else {
+                    push_segment(&mut segments, text);
                 }
             }
             _ => {}
@@ -1685,7 +1656,7 @@ impl OpenRouterProvider {
                 LLMError::Provider(formatted_error)
             })?;
 
-            let content = match message.get("content") {
+            let mut content = match message.get("content") {
                 Some(Value::String(text)) => Some(text.to_string()),
                 Some(Value::Array(parts)) => {
                     let text = parts
@@ -1726,14 +1697,46 @@ impl OpenRouterProvider {
                 })
                 .filter(|calls| !calls.is_empty());
 
-            let mut reasoning = message
+            let mut reasoning_segments: Vec<String> = Vec::new();
+
+            if let Some(initial) = message
                 .get("reasoning")
                 .and_then(extract_reasoning_trace)
-                .or_else(|| choice.get("reasoning").and_then(extract_reasoning_trace));
-
-            if reasoning.is_none() {
-                reasoning = extract_reasoning_from_message_content(message);
+                .or_else(|| choice.get("reasoning").and_then(extract_reasoning_trace))
+            {
+                append_reasoning_segment(&mut reasoning_segments, &initial);
             }
+
+            if reasoning_segments.is_empty() {
+                if let Some(from_content) = extract_reasoning_from_message_content(message) {
+                    append_reasoning_segment(&mut reasoning_segments, &from_content);
+                }
+            } else if let Some(extra) = extract_reasoning_from_message_content(message) {
+                append_reasoning_segment(&mut reasoning_segments, &extra);
+            }
+
+            if let Some(original_content) = content.take() {
+                let (markup_segments, cleaned) = split_reasoning_from_text(&original_content);
+                for segment in markup_segments {
+                    append_reasoning_segment(&mut reasoning_segments, &segment);
+                }
+                content = match cleaned {
+                    Some(cleaned_text) => {
+                        if cleaned_text.is_empty() {
+                            None
+                        } else {
+                            Some(cleaned_text)
+                        }
+                    }
+                    None => Some(original_content),
+                };
+            }
+
+            let reasoning = if reasoning_segments.is_empty() {
+                None
+            } else {
+                Some(reasoning_segments.join("\n"))
+            };
 
             let finish_reason = choice
                 .get("finish_reason")
@@ -1815,20 +1818,54 @@ impl OpenRouterProvider {
             tool_calls = extract_tool_calls_from_content(message);
         }
 
-        let mut reasoning = reasoning_buffer.finalize();
-        if reasoning.is_none() {
-            reasoning = extract_reasoning_from_message_content(message)
-                .or_else(|| message.get("reasoning").and_then(extract_reasoning_trace))
-                .or_else(|| payload.get("reasoning").and_then(extract_reasoning_trace));
+        let mut reasoning_segments: Vec<String> = Vec::new();
+
+        if let Some(buffer_reasoning) = reasoning_buffer.finalize() {
+            append_reasoning_segment(&mut reasoning_segments, &buffer_reasoning);
         }
 
-        let content = if aggregated_content.is_empty() {
+        let fallback_reasoning = extract_reasoning_from_message_content(message)
+            .or_else(|| message.get("reasoning").and_then(extract_reasoning_trace))
+            .or_else(|| payload.get("reasoning").and_then(extract_reasoning_trace));
+
+        if reasoning_segments.is_empty() {
+            if let Some(extra) = fallback_reasoning {
+                append_reasoning_segment(&mut reasoning_segments, &extra);
+            }
+        } else if let Some(extra) = fallback_reasoning {
+            append_reasoning_segment(&mut reasoning_segments, &extra);
+        }
+
+        let mut content = if aggregated_content.is_empty() {
             message
                 .get("output_text")
                 .and_then(|value| value.as_str())
                 .map(|value| value.to_string())
         } else {
             Some(aggregated_content)
+        };
+
+        if let Some(original_content) = content.take() {
+            let (markup_segments, cleaned) = split_reasoning_from_text(&original_content);
+            for segment in markup_segments {
+                append_reasoning_segment(&mut reasoning_segments, &segment);
+            }
+            content = match cleaned {
+                Some(cleaned_text) => {
+                    if cleaned_text.is_empty() {
+                        None
+                    } else {
+                        Some(cleaned_text)
+                    }
+                }
+                None => Some(original_content),
+            };
+        }
+
+        let reasoning = if reasoning_segments.is_empty() {
+            None
+        } else {
+            Some(reasoning_segments.join("\n"))
         };
 
         let mut usage = payload.get("usage").map(parse_usage_value);

--- a/vtcode-core/src/llm/providers/reasoning.rs
+++ b/vtcode-core/src/llm/providers/reasoning.rs
@@ -1,5 +1,91 @@
 use serde_json::Value;
 
+#[derive(Default, Clone)]
+pub(crate) struct ReasoningBuffer {
+    text: String,
+    last_chunk: Option<String>,
+}
+
+impl ReasoningBuffer {
+    pub(crate) fn push(&mut self, chunk: &str) -> Option<String> {
+        if chunk.trim().is_empty() {
+            return None;
+        }
+
+        let normalized = Self::normalize_chunk(chunk);
+
+        if normalized.is_empty() {
+            return None;
+        }
+
+        if self.last_chunk.as_deref() == Some(&normalized) {
+            return None;
+        }
+
+        let last_has_spacing = self.text.ends_with(' ') || self.text.ends_with('\n');
+        let chunk_starts_with_space = chunk
+            .chars()
+            .next()
+            .map(|value| value.is_whitespace())
+            .unwrap_or(false);
+        let leading_punctuation = Self::is_leading_punctuation(chunk);
+        let trailing_connector = Self::ends_with_connector(&self.text);
+
+        let mut delta = String::new();
+
+        if !self.text.is_empty()
+            && !last_has_spacing
+            && !chunk_starts_with_space
+            && !leading_punctuation
+            && !trailing_connector
+        {
+            delta.push(' ');
+        }
+
+        delta.push_str(&normalized);
+        self.text.push_str(&delta);
+        self.last_chunk = Some(normalized);
+
+        Some(delta)
+    }
+
+    pub(crate) fn finalize(self) -> Option<String> {
+        let trimmed = self.text.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    fn normalize_chunk(chunk: &str) -> String {
+        let mut normalized = String::new();
+        for part in chunk.split_whitespace() {
+            if !normalized.is_empty() {
+                normalized.push(' ');
+            }
+            normalized.push_str(part);
+        }
+        normalized
+    }
+
+    fn is_leading_punctuation(chunk: &str) -> bool {
+        chunk
+            .chars()
+            .find(|ch| !ch.is_whitespace())
+            .map(|ch| matches!(ch, ',' | '.' | '!' | '?' | ':' | ';' | ')' | ']' | '}'))
+            .unwrap_or(false)
+    }
+
+    fn ends_with_connector(text: &str) -> bool {
+        text.chars()
+            .rev()
+            .find(|ch| !ch.is_whitespace())
+            .map(|ch| matches!(ch, '(' | '[' | '{' | '/' | '-'))
+            .unwrap_or(false)
+    }
+}
+
 const PRIMARY_TEXT_KEYS: &[&str] = &[
     "text",
     "content",
@@ -12,6 +98,21 @@ const SECONDARY_COLLECTION_KEYS: &[&str] = &[
     "messages", "parts", "items", "entries", "steps", "segments", "records", "output", "outputs",
     "logs",
 ];
+
+const REASONING_TAGS: &[&str] = &["think", "thinking", "reasoning", "analysis", "thought"];
+const ANSWER_TAGS: &[&str] = &["answer", "final"];
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TagCategory {
+    Reasoning,
+    Answer,
+}
+
+struct ParsedTag<'a> {
+    name: &'a str,
+    end_index: usize,
+    category: TagCategory,
+}
 
 pub(crate) fn extract_reasoning_trace(value: &Value) -> Option<String> {
     let mut segments = Vec::new();
@@ -30,18 +131,27 @@ fn collect_reasoning_segments(value: &Value, segments: &mut Vec<String>) {
         Value::Null => {}
         Value::Bool(_) | Value::Number(_) => {}
         Value::String(text) => {
+            let (mut tagged_segments, cleaned) = split_reasoning_from_text(text);
+
+            if !tagged_segments.is_empty() {
+                for segment in tagged_segments.drain(..) {
+                    push_unique_segment(segments, &segment);
+                }
+                if let Some(cleaned_text) = cleaned {
+                    let trimmed = cleaned_text.trim();
+                    if !trimmed.is_empty() {
+                        push_unique_segment(segments, trimmed);
+                    }
+                }
+                return;
+            }
+
             let trimmed = text.trim();
             if trimmed.is_empty() {
                 return;
             }
-            if segments
-                .last()
-                .map(|last| last.as_str() == trimmed)
-                .unwrap_or(false)
-            {
-                return;
-            }
-            segments.push(trimmed.to_string());
+
+            push_unique_segment(segments, trimmed);
         }
         Value::Array(items) => {
             for item in items {
@@ -75,6 +185,165 @@ fn collect_reasoning_segments(value: &Value, segments: &mut Vec<String>) {
             }
         }
     }
+}
+
+fn push_unique_segment(segments: &mut Vec<String>, segment: &str) {
+    if segment.trim().is_empty() {
+        return;
+    }
+
+    if segments
+        .last()
+        .map(|last| last.as_str() == segment)
+        .unwrap_or(false)
+    {
+        return;
+    }
+
+    segments.push(segment.to_string());
+}
+
+fn parse_start_tag<'a>(lower: &'a str, start: usize) -> Option<ParsedTag<'a>> {
+    let bytes = lower.as_bytes();
+    let mut index = start + 1;
+
+    if index >= lower.len() {
+        return None;
+    }
+
+    match bytes[index] {
+        b'/' | b'!' | b'?' => return None,
+        _ => {}
+    }
+
+    while index < lower.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+
+    if index >= lower.len() {
+        return None;
+    }
+
+    let name_start = index;
+    while index < lower.len() {
+        let ch = bytes[index];
+        if ch == b'>' || ch.is_ascii_whitespace() {
+            break;
+        }
+        index += 1;
+    }
+
+    if index == name_start {
+        return None;
+    }
+
+    let mut end_index = index;
+    while end_index < lower.len() && bytes[end_index] != b'>' {
+        end_index += 1;
+    }
+
+    if end_index >= lower.len() {
+        return None;
+    }
+
+    let name = &lower[name_start..index];
+    let category = if REASONING_TAGS.iter().any(|candidate| *candidate == name) {
+        TagCategory::Reasoning
+    } else if ANSWER_TAGS.iter().any(|candidate| *candidate == name) {
+        TagCategory::Answer
+    } else {
+        return None;
+    };
+
+    Some(ParsedTag {
+        name,
+        end_index,
+        category,
+    })
+}
+
+pub(crate) fn split_reasoning_from_text(text: &str) -> (Vec<String>, Option<String>) {
+    if text.trim().is_empty() {
+        return (Vec::new(), None);
+    }
+
+    let lower = text.to_ascii_lowercase();
+    let mut segments: Vec<String> = Vec::new();
+    let mut cleaned = String::new();
+    let mut modified = false;
+    let mut index = 0usize;
+
+    while index < text.len() {
+        let Some(relative) = lower[index..].find('<') else {
+            cleaned.push_str(&text[index..]);
+            break;
+        };
+
+        let open_index = index + relative;
+        cleaned.push_str(&text[index..open_index]);
+
+        if let Some(tag) = parse_start_tag(&lower, open_index) {
+            let content_start = tag.end_index + 1;
+            let close_sequence = format!("</{}>", tag.name);
+
+            if let Some(relative_close) = lower[content_start..].find(&close_sequence) {
+                let content_end = content_start + relative_close;
+                let inner = &text[content_start..content_end];
+
+                match tag.category {
+                    TagCategory::Reasoning => {
+                        modified = true;
+                        let (nested_segments, nested_cleaned) = split_reasoning_from_text(inner);
+
+                        if nested_segments.is_empty() {
+                            let trimmed = inner.trim();
+                            if !trimmed.is_empty() {
+                                push_unique_segment(&mut segments, trimmed);
+                            }
+                        } else {
+                            for segment in nested_segments {
+                                push_unique_segment(&mut segments, &segment);
+                            }
+                            if let Some(cleaned_inner) = nested_cleaned {
+                                let trimmed = cleaned_inner.trim();
+                                if !trimmed.is_empty() {
+                                    push_unique_segment(&mut segments, trimmed);
+                                }
+                            }
+                        }
+                    }
+                    TagCategory::Answer => {
+                        modified = true;
+                        let (nested_segments, nested_cleaned) = split_reasoning_from_text(inner);
+                        for segment in nested_segments {
+                            push_unique_segment(&mut segments, &segment);
+                        }
+                        if let Some(cleaned_inner) = nested_cleaned {
+                            cleaned.push_str(&cleaned_inner);
+                        }
+                    }
+                }
+
+                index = content_end + close_sequence.len();
+                continue;
+            }
+        }
+
+        cleaned.push('<');
+        index = open_index + 1;
+    }
+
+    if !modified {
+        return (segments, None);
+    }
+
+    let output = if cleaned.trim().is_empty() {
+        None
+    } else {
+        Some(cleaned)
+    };
+
+    (segments, output)
 }
 
 #[cfg(test)]
@@ -123,5 +392,24 @@ mod tests {
         ]);
         let extracted = extract_reasoning_trace(&value);
         assert_eq!(extracted, Some("repeat\nunique".to_string()));
+    }
+
+    #[test]
+    fn extracts_reasoning_from_think_markup() {
+        let source = "<think>first step</think>\n<answer>final output</answer>";
+        let (segments, cleaned) = split_reasoning_from_text(source);
+        assert_eq!(segments, vec!["first step".to_string()]);
+        assert_eq!(cleaned, Some("\nfinal output".to_string()));
+    }
+
+    #[test]
+    fn handles_nested_reasoning_markup() {
+        let source = "<think><analysis>deep dive</analysis> summary</think>";
+        let (segments, cleaned) = split_reasoning_from_text(source);
+        assert_eq!(
+            segments,
+            vec!["deep dive".to_string(), "summary".to_string()]
+        );
+        assert!(cleaned.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- move the streaming reasoning buffer into the shared reasoning helpers so providers can reuse it
- implement streaming support for OpenAI responses, emitting reasoning deltas and parsing completed responses through the shared helpers

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f0d9e0ce7083239bc1f37649fa3aca