### PR TITLE
Fix OpenAI GPT-5 reasoning configuration

### DIFF
--- a/docs/models.json
+++ b/docs/models.json
@@ -82,7 +82,7 @@
       "gpt-5": {
         "id": "gpt-5",
         "name": "GPT-5",
-        "reasoning": false,
+        "reasoning": true,
         "tool_call": true,
         "modalities": {
           "input": [

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -1353,8 +1353,16 @@ impl LLMProvider for OpenAIProvider {
         "openai"
     }
 
-    fn supports_reasoning(&self, _model: &str) -> bool {
-        false
+    fn supports_reasoning(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+
+        models::openai::REASONING_MODELS
+            .iter()
+            .any(|candidate| *candidate == requested)
     }
 
     fn supports_reasoning_effort(&self, model: &str) -> bool {


### PR DESCRIPTION
## Summary
- ensure the OpenAI provider reports reasoning support for GPT-5 models by checking the configured model identifier
- mark GPT-5 as reasoning-capable in the shared model metadata catalog

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f24ff5852083239133b355ab66ae0b