### PR TITLE
Restore OpenAI defaults after merging main

### DIFF
--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -20,9 +20,9 @@ use std::collections::HashSet;
 const MAX_COMPLETION_TOKENS_FIELD: &str = "max_completion_tokens";
 
 use super::{
+    ReasoningBuffer,
     common::{extract_prompt_cache_settings, override_base_url, resolve_model},
     extract_reasoning_trace, gpt5_codex_developer_prompt, split_reasoning_from_text,
-    ReasoningBuffer,
 };
 
 fn find_sse_boundary(buffer: &str) -> Option<(usize, usize)> {

--- a/vtcode-core/src/llm/providers/openrouter.rs
+++ b/vtcode-core/src/llm/providers/openrouter.rs
@@ -18,9 +18,9 @@ use serde_json::{Map, Value, json};
 use std::borrow::Cow;
 
 use super::{
+    ReasoningBuffer,
     common::{extract_prompt_cache_settings, override_base_url, resolve_model},
     extract_reasoning_trace, gpt5_codex_developer_prompt, split_reasoning_from_text,
-    ReasoningBuffer,
 };
 
 #[derive(Default, Clone)]

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -1,7 +1,7 @@
 [agent]
-provider = "openrouter"
-api_key_env = "OPENROUTER_API_KEY"
-default_model = "qwen/qwen3-4b:free"
+provider = "openai"
+api_key_env = "OPENAI_API_KEY"
+default_model = "gpt-5-codex"
 theme = "ciapre-dark"
 todo_planning_mode = true
 ui_surface = "auto"
@@ -151,11 +151,11 @@ heuristic_classification = true
 llm_router_model = ""
 
 [router.models]
-simple = "qwen/qwen3-4b:free"
-standard = "qwen/qwen3-4b:free"
-complex = "qwen/qwen3-4b:free"
-codegen_heavy = "qwen/qwen3-4b:free"
-retrieval_heavy = "qwen/qwen3-4b:free"
+simple = "gpt-5-codex"
+standard = "gpt-5-codex"
+complex = "gpt-5-codex"
+codegen_heavy = "gpt-5-codex"
+retrieval_heavy = "gpt-5-codex"
 
 [router.budgets]
 


### PR DESCRIPTION
## Summary
- restore the OpenAI provider defaults in `vtcode.toml` after merging main
- realign the OpenAI and OpenRouter provider imports with main so `ReasoningBuffer` remains grouped with the new reasoning utilities

## Testing
- `cargo fmt`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68f2763f18b48323af070cdf83d1d38e