### PR TITLE
Add print mode flag for CLI single prompt queries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,11 @@
 //!
 //! Thin binary entry point that delegates to modular CLI handlers.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use colorchoice::ColorChoice as GlobalColorChoice;
+use std::io::IsTerminal;
+use std::io::{self, Read};
 use vtcode::startup::StartupContext;
 use vtcode_core::cli::args::{Cli, Commands};
 use vtcode_core::config::api_keys::load_dotenv;
@@ -27,6 +29,7 @@ async fn main() -> Result<()> {
     load_dotenv().ok();
 
     let args = Cli::parse();
+    let print_mode = args.print.clone();
     args.color.write_global();
     if args.no_color {
         GlobalColorChoice::Never.write_global();
@@ -39,6 +42,12 @@ async fn main() -> Result<()> {
     let core_cfg = &startup.agent_config;
     let skip_confirmations = startup.skip_confirmations;
     let full_auto_requested = startup.full_auto_requested;
+
+    if let Some(print_value) = print_mode {
+        let prompt = build_print_prompt(print_value)?;
+        cli::handle_ask_single_command(core_cfg, &prompt).await?;
+        return Ok(());
+    }
 
     if let Some(prompt) = startup.automation_prompt.as_ref() {
         cli::handle_auto_task_command(core_cfg, cfg, prompt).await?;
@@ -143,4 +152,51 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn build_print_prompt(print_value: String) -> Result<String> {
+    let piped_input = collect_piped_stdin()?;
+    let inline_prompt = if print_value.trim().is_empty() {
+        None
+    } else {
+        Some(print_value)
+    };
+
+    match (piped_input, inline_prompt) {
+        (Some(piped), Some(prompt)) => {
+            let mut combined = piped;
+            if !combined.ends_with("\n\n") {
+                if combined.ends_with('\n') {
+                    combined.push('\n');
+                } else {
+                    combined.push_str("\n\n");
+                }
+            }
+            combined.push_str(&prompt);
+            Ok(combined)
+        }
+        (Some(piped), None) => Ok(piped),
+        (None, Some(prompt)) => Ok(prompt),
+        (None, None) => Err(anyhow::anyhow!(
+            "No prompt provided. Pass text to -p/--print or pipe input via stdin."
+        )),
+    }
+}
+
+fn collect_piped_stdin() -> Result<Option<String>> {
+    let mut stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(None);
+    }
+
+    let mut buffer = String::new();
+    stdin
+        .read_to_string(&mut buffer)
+        .context("Failed to read prompt from stdin")?;
+
+    if buffer.trim().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(buffer))
+    }
 }

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -193,6 +193,29 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub skip_confirmations: bool,
 
+    /// **Print response without launching the interactive TUI**
+    ///
+    /// Equivalent to `claude -p` style single prompt mode.
+    ///
+    /// Behaviour:
+    ///   • Provide a prompt inline: `vtcode -p "Explain this function"`
+    ///   • Pipe content and add a question: `cat file.rs | vtcode -p "Summarize"`
+    ///   • Pipe content only: `cat plan.md | vtcode -p`
+    ///
+    /// When both piped content and an inline prompt are supplied, the piped
+    /// content is prepended to the inline prompt separated by a blank line.
+    #[arg(
+        short = 'p',
+        long = "print",
+        value_name = "PROMPT",
+        value_hint = ValueHint::Other,
+        num_args = 0..=1,
+        default_missing_value = "",
+        global = true,
+        conflicts_with_all = ["command", "full_auto"]
+    )]
+    pub print: Option<String>,
+
     /// **Enable full-auto mode (no interaction) or run a headless task**
     ///
     /// Use without a value to launch the interactive UI in full-auto mode.
@@ -702,6 +725,7 @@ impl Default for Cli {
             no_color: false,
             theme: None,
             skip_confirmations: false,
+            print: None,
             full_auto: None,
             debug: false,
             command: Some(Commands::Chat),


### PR DESCRIPTION
## Summary
- add a `-p` / `--print` flag to the CLI so users can run single-shot queries without starting the TUI
- build the print-mode prompt by combining optional piped stdin with the inline message before invoking the ask handler
- short-circuit the main entrypoint to execute the ask command when print mode is requested

## Testing
- cargo fmt
- cargo clippy


------
https://chatgpt.com/codex/tasks/task_e_68f1b4f610bc8323ba9925f9e5fd3548