### PR TITLE
Add interactive mode reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,8 @@ Configuration validation: On load, checks TOML against schema (e.g., model in `d
 # Interactive mode (TUI)
 vtcode
 
+**Interactive reference:** See [docs/user-guide/interactive-mode.md](docs/user-guide/interactive-mode.md) for keyboard shortcuts, quick commands, and background execution tips.
+
 # Single query mode
 vtcode ask "your question here"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ See [CHANGELOG](../CHANGELOG.md) for complete details on these improvements.
 New to VT Code? Start with installation and basic usage:
 
 -   **[Getting Started](./user-guide/getting-started.md)** - Installation, configuration, and first steps
+-   **[Interactive Mode Reference](./user-guide/interactive-mode.md)** - Keyboard shortcuts and terminal workflows
 -   [Decision Ledger](./context/DECISION_LEDGER.md) - How decisions are tracked and injected
 -   **[Configuration Guide](./CONFIGURATION.md)** - Comprehensive configuration options
 

--- a/docs/user-guide/interactive-mode.md
+++ b/docs/user-guide/interactive-mode.md
@@ -1,0 +1,138 @@
+# Interactive Mode Reference
+
+The VT Code terminal UI includes an interactive mode that combines keyboard-first navigation with quick commands for agent control. This page consolidates the shortcuts, input modes, and background execution behaviors available while you are connected to a session.
+
+## Keyboard Shortcuts
+
+> Keyboard shortcuts may vary slightly by platform and terminal emulator. Press `?` while VT Code is running to see the bindings detected for your environment.
+
+### General Controls
+
+| Shortcut | Description | Context |
+| :-- | :-- | :-- |
+| `Ctrl+C` | Cancel the current generation or command. Press twice to terminate the session. | Works during prompts, tool execution, and streaming replies. |
+| `Ctrl+D` | Exit VT Code interactive mode. | Sends EOF to the shell integration. |
+| `Ctrl+L` | Clear the terminal screen while keeping the conversation history. | Useful for refreshing when output is cluttered. |
+| `Ctrl+O` | Toggle verbose tool output and diagnostics. | Reveals detailed tool invocation logs. |
+| `Ctrl+R` | Reverse search the command history. | Matches previous prompts and bash commands. |
+| `Ctrl+V` (macOS/Linux) or `Alt+V` (Windows) | Paste an image from the clipboard. | Works with image-enabled sessions. |
+| `Up/Down arrows` | Navigate through command history. | Recall previous prompts or commands. |
+| `Esc` + `Esc` | Rewind the conversation and code to the previous checkpoint. | Restores an earlier snapshot. |
+| `Tab` | Toggle extended thinking (analysis) mode on and off. | Switch between shorter and more verbose reasoning. |
+| `Shift+Tab` or `Alt+M` | Cycle permission modes. | Switches Auto-Accept Mode, Plan Mode, and normal mode. |
+
+### Multiline Input
+
+| Method | Shortcut | Context |
+| :-- | :-- | :-- |
+| Quick escape | `\` + `Enter` | Works across supported terminals. |
+| macOS default | `Option+Enter` | Default multiline binding on macOS terminals. |
+| Terminal setup | `Shift+Enter` | Available after running `/terminal-setup`. |
+| Control sequence | `Ctrl+J` | Inserts a line feed for multiline editing. |
+| Paste mode | Paste directly | Ideal for code blocks or long transcripts. |
+
+> Tip: Configure the preferred line break behavior in your terminal. Run `/terminal-setup` to install the `Shift+Enter` binding for iTerm2 and VS Code terminals.
+
+### Quick Commands
+
+| Shortcut | Description | Notes |
+| :-- | :-- | :-- |
+| `#` at start of input | Memory shortcut – append text to `CLAUDE.md`. | Prompts for file selection before saving. |
+| `/` at start of input | Issue a slash command. | Run `/help` or `/slash-commands` in a session to list everything available. |
+| `!` at start of input | Enter Bash mode. | Runs shell commands directly and streams their output. |
+| `@` within input | Mention a file path. | Triggers file path autocomplete. |
+
+## Vim Editor Mode
+
+Enable Vim-style editing by running `/vim` or enabling it via `/config`.
+
+### Mode Switching
+
+| Command | Action | From mode |
+| :-- | :-- | :-- |
+| `Esc` | Enter NORMAL mode. | INSERT |
+| `i` | Insert before the cursor. | NORMAL |
+| `I` | Insert at the beginning of the line. | NORMAL |
+| `a` | Insert after the cursor. | NORMAL |
+| `A` | Insert at the end of the line. | NORMAL |
+| `o` | Open a line below. | NORMAL |
+| `O` | Open a line above. | NORMAL |
+
+### Navigation (NORMAL mode)
+
+| Command | Action |
+| :-- | :-- |
+| `h`/`j`/`k`/`l` | Move left/down/up/right. |
+| `w` | Jump to the next word. |
+| `e` | Jump to the end of the current word. |
+| `b` | Jump to the previous word. |
+| `0` | Move to the beginning of the line. |
+| `$` | Move to the end of the line. |
+| `^` | Jump to the first non-blank character. |
+| `gg` | Go to the beginning of the input. |
+| `G` | Go to the end of the input. |
+
+### Editing (NORMAL mode)
+
+| Command | Action |
+| :-- | :-- |
+| `x` | Delete the character under the cursor. |
+| `dd` | Delete the current line. |
+| `D` | Delete to the end of the line. |
+| `dw` / `de` / `db` | Delete word / to end of word / backward word. |
+| `cc` | Change the current line. |
+| `C` | Change to the end of the line. |
+| `cw` / `ce` / `cb` | Change word / to end of word / backward word. |
+| `.` | Repeat the last change. |
+
+## Command History
+
+VT Code keeps a command history scoped to the working directory. The history resets when you clear it manually or start a new directory session.
+
+* Cleared with the `/clear` command.
+* Use the arrow keys to navigate between entries.
+* History expansion via `!` is disabled by default to prevent accidental execution.
+
+### Reverse Search with `Ctrl+R`
+
+1. Press `Ctrl+R` to start the reverse history search.
+2. Type a query to highlight matching entries.
+3. Press `Ctrl+R` again to cycle through older matches.
+4. Accept the current match with `Tab`, `Esc`, or `Enter` to execute immediately.
+5. Cancel the search with `Ctrl+C` or `Backspace` on an empty query.
+
+## Background Bash Commands
+
+The Bash integration can run long commands asynchronously while you continue working with the agent.
+
+### Running in the Background
+
+* Ask VT Code to run a command in the background, or
+* Press `Ctrl+B` while a command runs to move it to the background (press twice if your terminal uses tmux with the same prefix).
+
+Background tasks return immediately with an ID. VT Code keeps streaming updates via the BashOutput tool, and tasks are automatically cleaned up when the session ends.
+
+Common backgrounded commands include:
+
+* Build systems (e.g., webpack, vite, make)
+* Package managers (npm, yarn, pnpm)
+* Test runners (jest, pytest)
+* Development servers and other long-running processes
+
+### Bash Mode with `!`
+
+Prefix input with `!` to run commands directly without agent interpretation:
+
+```bash
+! npm test
+! git status
+! ls -la
+```
+
+Bash mode streams the command and its output into the chat, supports backgrounding via `Ctrl+B`, and is ideal for quick shell operations while keeping a shared context with the agent.
+
+## Additional Resources
+
+* [User guide overview](../README.md)
+* [Getting started walkthrough](../user-guide/getting-started.md)
+* [Advanced features](../ADVANCED_FEATURES_IMPLEMENTATION.md)


### PR DESCRIPTION
## Summary
- add a comprehensive interactive mode reference under docs/user-guide
- link the new guide from the README and documentation hub for visibility

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f1b4eadd64832399716b812f6e2d75