### PR TITLE
Enhance HITL prompt with modal list UI

### DIFF
--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -226,7 +226,8 @@ impl ModelPickerState {
                 }
                 InlineListSelection::Theme(_)
                 | InlineListSelection::Session(_)
-                | InlineListSelection::SlashCommand(_) => Ok(ModelPickerProgress::InProgress),
+                | InlineListSelection::SlashCommand(_)
+                | InlineListSelection::HitlAction(_) => Ok(ModelPickerProgress::InProgress),
             },
             PickerStep::AwaitReasoning => match choice {
                 InlineListSelection::Reasoning(level) => {
@@ -242,7 +243,8 @@ impl ModelPickerState {
                 }
                 InlineListSelection::Theme(_)
                 | InlineListSelection::Session(_)
-                | InlineListSelection::SlashCommand(_) => Ok(ModelPickerProgress::InProgress),
+                | InlineListSelection::SlashCommand(_)
+                | InlineListSelection::HitlAction(_) => Ok(ModelPickerProgress::InProgress),
             },
             PickerStep::AwaitApiKey => {
                 renderer.line(

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -2209,11 +2209,7 @@ async fn run_status_line_command(
 
     let timeout_ms = std::cmp::max(config.command_timeout_ms, 1);
     let timeout_duration = Duration::from_millis(timeout_ms);
-    let wait_result = {
-        let mut wait = child.wait();
-        tokio::pin!(wait);
-        tokio::time::timeout(timeout_duration, &mut wait).await
-    };
+    let wait_result = tokio::time::timeout(timeout_duration, child.wait()).await;
 
     let status = match wait_result {
         Ok(status_res) => status_res

--- a/vtcode-core/src/ui/tui.rs
+++ b/vtcode-core/src/ui/tui.rs
@@ -10,9 +10,10 @@ mod types;
 
 pub use style::{convert_style, theme_from_styles};
 pub use types::{
-    InlineCommand, InlineEvent, InlineHandle, InlineHeaderContext, InlineHeaderHighlight,
-    InlineListItem, InlineListSearchConfig, InlineListSelection, InlineMessageKind, InlineSegment,
-    InlineSession, InlineTextStyle, InlineTheme, SecurePromptConfig,
+    HitlListAction, InlineCommand, InlineEvent, InlineHandle, InlineHeaderContext,
+    InlineHeaderHighlight, InlineListItem, InlineListSearchConfig, InlineListSelection,
+    InlineMessageKind, InlineSegment, InlineSession, InlineTextStyle, InlineTheme,
+    SecurePromptConfig,
 };
 
 use tui::run_tui;

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -123,6 +123,13 @@ pub enum InlineListSelection {
     Theme(String),
     Session(String),
     SlashCommand(String),
+    HitlAction(HitlListAction),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HitlListAction {
+    Approve,
+    Deny,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary
- render human-in-the-loop tool approval prompts with an ANSI block layout and ratatui list modal
- add a dedicated `HitlListAction` selection variant and re-export it for the TUI layer
- update the prompt flow to finalize decisions through the modal and ignore the new selection in other pickers

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f2f36cc0bc83239772ba4cff9f4f92