### PR TITLE
Add inline session banner inspired by Codex TUI

### DIFF
--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -32,8 +32,8 @@ use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
 use vtcode_core::config::mcp::McpTransportConfig;
 use vtcode_core::config::models::Provider;
 use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, UiSurfacePreference};
-use vtcode_core::core::agent::snapshots::{SnapshotConfig, SnapshotManager};
 use vtcode_core::config::{StatusLineConfig, StatusLineMode};
+use vtcode_core::core::agent::snapshots::{SnapshotConfig, SnapshotManager};
 use vtcode_core::core::context_curator::{
     ConversationPhase, CuratedContext, Message as CuratorMessage,
     ToolDefinition as CuratorToolDefinition,
@@ -2119,9 +2119,9 @@ async fn run_status_line_command(
         Ok(status_res) => status_res
             .with_context(|| format!("failed to wait for status line command `{}`", command))?,
         Err(_) => {
-            child
-                .start_kill()
-                .with_context(|| format!("failed to kill timed out status line command `{}`", command))?;
+            child.start_kill().with_context(|| {
+                format!("failed to kill timed out status line command `{}`", command)
+            })?;
             child.wait().await.with_context(|| {
                 format!(
                     "failed to wait for killed status line command `{}` after timeout",
@@ -3052,10 +3052,10 @@ async fn stream_and_render_response(
             reasoning_state
                 .handle_stream_failure(renderer)
                 .map_err(|err| map_render_error(provider_name, err))?;
-        let formatted_error = error_display::format_llm_error(
-            provider_name,
-            "Stream ended without a completion event",
-        );
+            let formatted_error = error_display::format_llm_error(
+                provider_name,
+                "Stream ended without a completion event",
+            );
             return Err(uni::LLMError::Provider(formatted_error));
         }
     };
@@ -3362,13 +3362,6 @@ pub(crate) async fn run_single_agent_loop_unified(
         .map(|cfg| cfg.agent.reasoning_effort.as_str().to_string())
         .unwrap_or_else(|| config.reasoning_effort.as_str().to_string());
 
-    render_session_banner(
-        &mut renderer,
-        &config,
-        &session_bootstrap,
-        &config.model,
-        &reasoning_label,
-    )?;
     let mode_label = resolve_mode_label(config.ui_surface, full_auto);
     let header_context = build_inline_header_context(
         &config,
@@ -3378,6 +3371,7 @@ pub(crate) async fn run_single_agent_loop_unified(
         mode_label,
         reasoning_label.clone(),
     )?;
+    render_session_banner(&mut renderer, &config, &header_context)?;
     handle.set_header_context(header_context);
     // MCP events are now rendered as message blocks in the conversation history
 


### PR DESCRIPTION
## Summary
- port the Codex inline session banner styling to VT Code's renderer
- populate the banner with provider, model, workspace, and onboarding highlights using the existing header context
- initialize the banner after computing the header context so the inline UI and ANSI renderer share the same metadata

## Testing
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68f2fe4ded3c8323829a31136732e685