### PR TITLE
Add process hardening to the CLI startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4399,6 +4399,7 @@ dependencies = [
  "indicatif",
  "is-terminal",
  "itertools 0.14.0",
+ "libc",
  "once_cell",
  "path-clean",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ itertools = "0.14.0"
 update-informer = "1.3.0"
 tempfile = "3.0"
 once_cell = "1.19"
+libc = "0.2"
 chrono = { version = "0.4", features = [
     "serde",
 ] } # For timestamp handling in CLI

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ mod workspace_trust;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Load .env (non-fatal if missing)
+    load_dotenv().ok();
+
     process_hardening::apply_process_hardening()
         .context("failed to apply process hardening safeguards")?;
 
@@ -28,9 +31,6 @@ async fn main() -> Result<()> {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .init();
     }
-
-    // Load .env (non-fatal if missing)
-    load_dotenv().ok();
 
     let args = Cli::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,14 @@ use vtcode_core::config::api_keys::load_dotenv;
 mod acp;
 mod agent;
 mod cli; // local CLI handlers in src/cli // agent runloops (single-agent only)
+mod process_hardening;
 mod workspace_trust;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    process_hardening::apply_process_hardening()
+        .context("failed to apply process hardening safeguards")?;
+
     // Initialize tracing
     if std::env::var("RUST_LOG").is_ok() {
         tracing_subscriber::fmt()

--- a/src/process_hardening.rs
+++ b/src/process_hardening.rs
@@ -1,0 +1,110 @@
+use anyhow::{Context, Result};
+
+/// Apply process hardening safeguards to the current process.
+///
+/// These measures are inspired by the Codex process hardening sequence and are
+/// intended to run as early as possible in the binary entry point.
+pub fn apply_process_hardening() -> Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        harden_linux().context("failed to apply Linux process hardening")?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        harden_macos().context("failed to apply macOS process hardening")?;
+    }
+
+    #[cfg(windows)]
+    {
+        harden_windows().context("failed to apply Windows process hardening")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const PRCTL_FAILED_EXIT_CODE: i32 = 5;
+
+#[cfg(target_os = "macos")]
+const PTRACE_DENY_ATTACH_FAILED_EXIT_CODE: i32 = 6;
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+const SET_RLIMIT_CORE_FAILED_EXIT_CODE: i32 = 7;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn harden_linux() -> Result<()> {
+    // Disable ptrace attach / mark process non-dumpable.
+    let ret_code = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
+    if ret_code != 0 {
+        let err = std::io::Error::last_os_error();
+        tracing::error!("prctl(PR_SET_DUMPABLE, 0) failed: {err}");
+        std::process::exit(PRCTL_FAILED_EXIT_CODE);
+    }
+
+    set_core_file_size_limit_to_zero()
+        .context("setrlimit(RLIMIT_CORE) failed while hardening Linux process")?;
+
+    remove_env_vars_with_prefix("LD_");
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn harden_macos() -> Result<()> {
+    let ret_code = unsafe { libc::ptrace(libc::PT_DENY_ATTACH, 0, std::ptr::null_mut(), 0) };
+    if ret_code == -1 {
+        let err = std::io::Error::last_os_error();
+        tracing::error!("ptrace(PT_DENY_ATTACH) failed: {err}");
+        std::process::exit(PTRACE_DENY_ATTACH_FAILED_EXIT_CODE);
+    }
+
+    set_core_file_size_limit_to_zero()
+        .context("setrlimit(RLIMIT_CORE) failed while hardening macOS process")?;
+
+    remove_env_vars_with_prefix("DYLD_");
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn harden_windows() -> Result<()> {
+    // TODO: Evaluate process mitigations for Windows builds.
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_core_file_size_limit_to_zero() -> Result<()> {
+    let rlim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+
+    let ret_code = unsafe { libc::setrlimit(libc::RLIMIT_CORE, &rlim) };
+    if ret_code != 0 {
+        let err = std::io::Error::last_os_error();
+        tracing::error!("setrlimit(RLIMIT_CORE) failed: {err}");
+        std::process::exit(SET_RLIMIT_CORE_FAILED_EXIT_CODE);
+    }
+
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+fn remove_env_vars_with_prefix(prefix: &str) {
+    let keys: Vec<String> = std::env::vars()
+        .filter_map(|(key, _)| {
+            if key.starts_with(prefix) {
+                Some(key)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for key in keys {
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a process hardening module that mirrors Codex safeguards for disabling ptrace attach, core dumps, and dangerous env vars
- invoke the hardening routine at the very start of the CLI entry point
- pull in the libc dependency needed for the platform-specific syscalls

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f2fe8076548323a1b584078a1d536b