### PR TITLE
Fix exec policy integration compile errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "acp-client"
 version = "0.1.0"
 dependencies = [
@@ -64,6 +74,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocative"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fac2ce611db8b8cee9b2aa886ca03c924e9da5e5295d0dbd0526e5d0b0710f7"
+dependencies = [
+ "allocative_derive",
+ "bumpalo",
+ "ctor",
+ "hashbrown 0.14.5",
+ "num-bigint",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +117,15 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "ansi-to-tui"
@@ -195,6 +238,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,7 +277,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -236,7 +288,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -277,6 +329,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bincode"
@@ -341,6 +399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,7 +443,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -470,7 +534,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -482,7 +546,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -490,6 +554,23 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
+name = "cmp_any"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "colorchoice"
@@ -567,6 +648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,7 +673,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap",
+ "indexmap 2.11.4",
  "log",
  "serde",
  "serde_derive",
@@ -748,6 +835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,8 +874,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn",
+ "strsim 0.11.1",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -791,8 +888,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn",
+ "strsim 0.11.1",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -803,7 +900,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -814,7 +911,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -831,12 +928,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugserver-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf6834a70ed14e8e4e41882df27190bea150f1f6ecf461f1033f8739cd8af4a"
+dependencies = [
+ "schemafy",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -847,7 +967,41 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -859,7 +1013,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -901,6 +1055,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +1077,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "display_container"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a110a75c96bedec8e65823dea00a1d710288b7a369d95fd8a0f5127639466fa"
+dependencies = [
+ "either",
+ "indenter",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,7 +1105,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -945,6 +1130,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dupe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +1160,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -972,10 +1186,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -985,6 +1214,16 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
 ]
 
 [[package]]
@@ -1038,7 +1277,7 @@ checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -1046,6 +1285,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -1063,6 +1313,12 @@ name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1166,7 +1422,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1203,6 +1459,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1273,7 +1538,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -1288,7 +1553,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -1307,9 +1572,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1339,6 +1614,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -1630,6 +1911,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,7 +1967,16 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1769,6 +2076,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools 0.10.5",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax 0.6.29",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +2184,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +2220,25 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -1877,7 +2257,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.106",
  "typify",
 ]
 
@@ -1952,6 +2332,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2358,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2384,17 @@ dependencies = [
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2045,10 +2460,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2150,7 +2584,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2222,16 +2656,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
 name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.11.4",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2250,7 +2721,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2278,7 +2749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap",
+ "indexmap 2.11.4",
  "quick-xml",
  "serde",
  "time",
@@ -2385,6 +2856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,7 +2878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2429,7 +2906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
- "indexmap",
+ "indexmap 2.11.4",
  "nix 0.30.1",
  "tokio",
  "tracing",
@@ -2556,6 +3033,16 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -2703,7 +3190,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2715,7 +3202,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2726,8 +3213,20 @@ checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2892,7 +3391,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2939,7 +3438,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.106",
  "unicode-ident",
 ]
 
@@ -2957,7 +3456,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.106",
  "unicode-ident",
 ]
 
@@ -3066,6 +3565,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustyline"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.26.4",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,6 +3612,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemafy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aea5ba40287dae331f2c48b64dbc8138541f5e97ee8793caa7948c1f31d86d5"
+dependencies = [
+ "Inflector",
+ "schemafy_core",
+ "schemafy_lib",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41781ae092f4fd52c9287efb74456aea0d3b90032d2ecad272bd14dbbcb0511b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3661,18 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
  "serde",
  "serde_json",
 ]
@@ -3124,7 +3700,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3136,7 +3712,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3205,7 +3781,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3216,7 +3792,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3225,12 +3801,23 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3251,7 +3838,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3267,12 +3854,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093cd8c01b25262b84927e0f7151692158fab02d961e04c979d3903eba7ecc5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.11.4",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e6c180db0816026a61afa1cff5344fb7ebded7e4d3062772179f2501481c27"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.4",
  "itoa",
  "ryu",
  "serde",
@@ -3418,6 +4036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,16 +4083,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "starlark"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419b088f6fe8393b8b2525d57f32e240ff07ab49e39f0afe3c8a5372bb94a823"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "bumpalo",
+ "cmp_any",
+ "debugserver-types",
+ "derivative",
+ "derive_more 0.99.20",
+ "display_container",
+ "dupe",
+ "either",
+ "erased-serde",
+ "hashbrown 0.14.5",
+ "inventory",
+ "itertools 0.10.5",
+ "maplit",
+ "memoffset",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "regex",
+ "rustyline",
+ "serde",
+ "serde_json",
+ "starlark_derive",
+ "starlark_map",
+ "starlark_syntax",
+ "static_assertions",
+ "strsim 0.10.0",
+ "textwrap",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starlark_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8407ca86174f600acfc8b7e0576058bb866a19521b92f9590fa2bcf1c8c807"
+dependencies = [
+ "dupe",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "starlark_map"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e03678553f5f0ce473a7a9064fc7bf2c1fa5013eb605c95d09896e3eacbacc5"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "serde",
+]
+
+[[package]]
+name = "starlark_syntax"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae4c126dbc9702fae89fb2460f06b0f562e7de1351ab545591a27e9528afa2f"
+dependencies = [
+ "allocative",
+ "annotate-snippets",
+ "anyhow",
+ "derivative",
+ "derive_more 0.99.20",
+ "dupe",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "lsp-types",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "starlark_map",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -3495,7 +4232,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3503,6 +4240,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3532,7 +4280,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3547,7 +4295,7 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax",
+ "regex-syntax 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3605,6 +4353,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,6 +4380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -3649,7 +4417,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3660,7 +4428,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3717,6 +4485,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3782,7 +4559,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3836,7 +4613,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.4",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -3860,7 +4637,7 @@ version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.4",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -3945,7 +4722,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4007,7 +4784,7 @@ checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
 dependencies = [
  "cc",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.6",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
@@ -4188,7 +4965,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.106",
  "thiserror 2.0.16",
  "unicode-ident",
 ]
@@ -4206,7 +4983,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn",
+ "syn 2.0.106",
  "typify-impl",
 ]
 
@@ -4250,6 +5027,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -4395,7 +5178,7 @@ dependencies = [
  "dialoguer",
  "dotenvy",
  "futures",
- "indexmap",
+ "indexmap 2.11.4",
  "indicatif",
  "is-terminal",
  "itertools 0.14.0",
@@ -4425,6 +5208,7 @@ dependencies = [
 name = "vtcode-core"
 version = "0.23.3"
 dependencies = [
+ "allocative",
  "anstream",
  "anstyle",
  "anstyle-git",
@@ -4443,6 +5227,7 @@ dependencies = [
  "console 0.16.1",
  "crossterm 0.27.0",
  "dashmap",
+ "derive_more 2.0.1",
  "dialoguer",
  "dirs",
  "dotenvy",
@@ -4452,30 +5237,35 @@ dependencies = [
  "humantime",
  "iana-time-zone",
  "ignore",
- "indexmap",
+ "indexmap 2.11.4",
  "is-terminal",
  "itertools 0.14.0",
  "line-clipping",
  "mcp-types",
+ "multimap",
  "nucleo-matcher",
  "once_cell",
  "parking_lot",
+ "path-absolutize",
  "portable-pty 0.9.0",
  "pulldown-cmark 0.9.6",
  "quick_cache",
  "rand 0.8.5",
  "ratatui",
  "regex",
+ "regex-lite",
  "reqwest",
  "rig-core",
  "rmcp",
  "roff",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "sha2",
  "shell-words",
  "similar",
+ "starlark",
  "syntect",
  "tempfile",
  "terminal_size",
@@ -4589,7 +5379,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -4624,7 +5414,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4778,7 +5568,7 @@ checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4789,7 +5579,7 @@ checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5166,7 +5956,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -5187,7 +5977,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5207,7 +5997,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -5247,5 +6037,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -32,8 +32,8 @@ use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
 use vtcode_core::config::mcp::McpTransportConfig;
 use vtcode_core::config::models::Provider;
 use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, UiSurfacePreference};
-use vtcode_core::core::agent::snapshots::{SnapshotConfig, SnapshotManager};
 use vtcode_core::config::{StatusLineConfig, StatusLineMode};
+use vtcode_core::core::agent::snapshots::{SnapshotConfig, SnapshotManager};
 use vtcode_core::core::context_curator::{
     ConversationPhase, CuratedContext, Message as CuratorMessage,
     ToolDefinition as CuratorToolDefinition,
@@ -2119,9 +2119,9 @@ async fn run_status_line_command(
         Ok(status_res) => status_res
             .with_context(|| format!("failed to wait for status line command `{}`", command))?,
         Err(_) => {
-            child
-                .start_kill()
-                .with_context(|| format!("failed to kill timed out status line command `{}`", command))?;
+            child.start_kill().with_context(|| {
+                format!("failed to kill timed out status line command `{}`", command)
+            })?;
             child.wait().await.with_context(|| {
                 format!(
                     "failed to wait for killed status line command `{}` after timeout",
@@ -3052,10 +3052,10 @@ async fn stream_and_render_response(
             reasoning_state
                 .handle_stream_failure(renderer)
                 .map_err(|err| map_render_error(provider_name, err))?;
-        let formatted_error = error_display::format_llm_error(
-            provider_name,
-            "Stream ended without a completion event",
-        );
+            let formatted_error = error_display::format_llm_error(
+                provider_name,
+                "Stream ended without a completion event",
+            );
             return Err(uni::LLMError::Provider(formatted_error));
         }
     };

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -13,7 +13,9 @@ keywords = ["ai", "coding", "agent", "llm", "rust"]
 categories = ["development-tools", "api-bindings"]
 
 [dependencies]
+allocative = "0.3.4"
 anyhow = "1.0"
+derive_more = { version = "2.0", features = ["display"] }
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,6 +39,7 @@ console = "0.16.1"
 dialoguer = "0.11"
 colored = "2.1"
 regex = "1.10"
+regex-lite = "0.1.7"
 shell-words = "1.1"
 tree-sitter = "0.25"
 tree-sitter-rust = "0.23"
@@ -50,6 +53,7 @@ indexmap = { version = "2.2", features = ["serde"] }
 itertools = "0.14.0"
 tempfile = "3.0"
 dashmap = "5.5" # For concurrent hash maps
+multimap = "0.10"
 once_cell = "1.19"
 parking_lot = "0.12"
 sha2 = "0.10"
@@ -69,6 +73,10 @@ dirs = "5.0"
 # YAML support
 serde_yaml = "0.9"
 tracing = "0.1"
+# Execution policy support
+path-absolutize = "3.1.1"
+serde_with = { version = "3.14", features = ["macros"] }
+starlark = "0.12"
 # ANSI styling
 anstyle = "1.0"
 anstyle-query = "1.0"

--- a/vtcode-core/src/exec_policy/arg_matcher.rs
+++ b/vtcode-core/src/exec_policy/arg_matcher.rs
@@ -1,0 +1,117 @@
+#![allow(clippy::needless_lifetimes)]
+
+use allocative::Allocative;
+use derive_more::derive::Display;
+use starlark::any::ProvidesStaticType;
+use starlark::values::AllocValue;
+use starlark::values::Heap;
+use starlark::values::NoSerialize;
+use starlark::values::StarlarkValue;
+use starlark::values::UnpackValue;
+use starlark::values::Value;
+use starlark::values::ValueLike;
+use starlark::values::starlark_value;
+use starlark::values::string::StarlarkStr;
+
+use super::arg_type::ArgType;
+
+/// Patterns that lists of arguments should be compared against.
+#[derive(Clone, Debug, Display, Eq, PartialEq, NoSerialize, ProvidesStaticType, Allocative)]
+#[display("{}", self)]
+pub enum ArgMatcher {
+    /// Literal string value.
+    Literal(String),
+
+    /// We cannot say what type of value this should match, but it is *not* a file path.
+    OpaqueNonFile,
+
+    /// Required readable file.
+    ReadableFile,
+
+    /// Required writeable file.
+    WriteableFile,
+
+    /// Non-empty list of readable files.
+    ReadableFiles,
+
+    /// Non-empty list of readable files, or empty list, implying readable cwd.
+    ReadableFilesOrCwd,
+
+    /// Positive integer, like one that is required for `head -n`.
+    PositiveInteger,
+
+    /// Bespoke matcher for safe sed commands.
+    SedCommand,
+
+    /// Matches an arbitrary number of arguments without attributing any
+    /// particular meaning to them. Caller is responsible for interpreting them.
+    UnverifiedVarargs,
+}
+
+impl ArgMatcher {
+    pub fn cardinality(&self) -> ArgMatcherCardinality {
+        match self {
+            ArgMatcher::Literal(_)
+            | ArgMatcher::OpaqueNonFile
+            | ArgMatcher::ReadableFile
+            | ArgMatcher::WriteableFile
+            | ArgMatcher::PositiveInteger
+            | ArgMatcher::SedCommand => ArgMatcherCardinality::One,
+            ArgMatcher::ReadableFiles => ArgMatcherCardinality::AtLeastOne,
+            ArgMatcher::ReadableFilesOrCwd | ArgMatcher::UnverifiedVarargs => {
+                ArgMatcherCardinality::ZeroOrMore
+            }
+        }
+    }
+
+    pub fn arg_type(&self) -> ArgType {
+        match self {
+            ArgMatcher::Literal(value) => ArgType::Literal(value.clone()),
+            ArgMatcher::OpaqueNonFile => ArgType::OpaqueNonFile,
+            ArgMatcher::ReadableFile => ArgType::ReadableFile,
+            ArgMatcher::WriteableFile => ArgType::WriteableFile,
+            ArgMatcher::ReadableFiles => ArgType::ReadableFile,
+            ArgMatcher::ReadableFilesOrCwd => ArgType::ReadableFile,
+            ArgMatcher::PositiveInteger => ArgType::PositiveInteger,
+            ArgMatcher::SedCommand => ArgType::SedCommand,
+            ArgMatcher::UnverifiedVarargs => ArgType::Unknown,
+        }
+    }
+}
+
+pub enum ArgMatcherCardinality {
+    One,
+    AtLeastOne,
+    ZeroOrMore,
+}
+
+impl ArgMatcherCardinality {
+    pub fn is_exact(&self) -> Option<usize> {
+        match self {
+            ArgMatcherCardinality::One => Some(1),
+            ArgMatcherCardinality::AtLeastOne => None,
+            ArgMatcherCardinality::ZeroOrMore => None,
+        }
+    }
+}
+
+impl<'v> AllocValue<'v> for ArgMatcher {
+    fn alloc_value(self, heap: &'v Heap) -> Value<'v> {
+        heap.alloc_simple(self)
+    }
+}
+
+#[starlark_value(type = "ArgMatcher")]
+impl<'v> StarlarkValue<'v> for ArgMatcher {
+    type Canonical = ArgMatcher;
+}
+
+impl<'v> UnpackValue<'v> for ArgMatcher {
+    fn unpack_value(value: Value<'v>) -> Option<Self> {
+        if let Some(str) = value.downcast_ref::<StarlarkStr>() {
+            Some(ArgMatcher::Literal(str.as_str().to_string()))
+        } else {
+            value.downcast_ref::<ArgMatcher>().cloned()
+        }
+    }
+}

--- a/vtcode-core/src/exec_policy/arg_resolver.rs
+++ b/vtcode-core/src/exec_policy/arg_resolver.rs
@@ -1,0 +1,202 @@
+use serde::Serialize;
+
+use super::arg_matcher::{ArgMatcher, ArgMatcherCardinality};
+use super::error::{Error, Result};
+use super::valid_exec::MatchedArg;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PositionalArg {
+    pub index: usize,
+    pub value: String,
+}
+
+pub fn resolve_observed_args_with_patterns(
+    program: &str,
+    args: Vec<PositionalArg>,
+    arg_patterns: &Vec<ArgMatcher>,
+) -> Result<Vec<MatchedArg>> {
+    // Naive matching implementation. Among `arg_patterns`, there is allowed to
+    // be at most one vararg pattern. Assuming `arg_patterns` is non-empty, we
+    // end up with either:
+    //
+    // - all `arg_patterns` in `prefix_patterns`
+    // - `arg_patterns` split across `prefix_patterns` (which could be empty),
+    //   one `vararg_pattern`, and `suffix_patterns` (which could also empty).
+    //
+    // From there, we start by matching everything in `prefix_patterns`.
+    // Then we calculate how many positional args should be matched by
+    // `suffix_patterns` and use that to determine how many args are left to
+    // be matched by `vararg_pattern` (which could be zero).
+    //
+    // After associating positional args with `vararg_pattern`, we match the
+    // `suffix_patterns` with the remaining args.
+    let ParitionedArgs {
+        num_prefix_args,
+        num_suffix_args,
+        prefix_patterns,
+        suffix_patterns,
+        vararg_pattern,
+    } = partition_args(program, arg_patterns)?;
+
+    let mut matched_args = Vec::<MatchedArg>::new();
+
+    let prefix = get_range_checked(&args, 0..num_prefix_args)?;
+    let mut prefix_arg_index = 0;
+    for pattern in prefix_patterns {
+        let n = pattern
+            .cardinality()
+            .is_exact()
+            .ok_or(Error::InternalInvariantViolation {
+                message: "expected exact cardinality".to_string(),
+            })?;
+        for positional_arg in &prefix[prefix_arg_index..prefix_arg_index + n] {
+            let matched_arg = MatchedArg::new(
+                positional_arg.index,
+                pattern.arg_type(),
+                &positional_arg.value.clone(),
+            )?;
+            matched_args.push(matched_arg);
+        }
+        prefix_arg_index += n;
+    }
+
+    if num_suffix_args > args.len() {
+        return Err(Error::NotEnoughArgs {
+            program: program.to_string(),
+            args,
+            arg_patterns: arg_patterns.clone(),
+        });
+    }
+
+    let initial_suffix_args_index = args.len() - num_suffix_args;
+    if prefix_arg_index > initial_suffix_args_index {
+        return Err(Error::PrefixOverlapsSuffix {});
+    }
+
+    if let Some(pattern) = vararg_pattern {
+        let vararg = get_range_checked(&args, prefix_arg_index..initial_suffix_args_index)?;
+        match pattern.cardinality() {
+            ArgMatcherCardinality::One => {
+                return Err(Error::InternalInvariantViolation {
+                    message: "vararg pattern should not have cardinality of one".to_string(),
+                });
+            }
+            ArgMatcherCardinality::AtLeastOne => {
+                if vararg.is_empty() {
+                    return Err(Error::VarargMatcherDidNotMatchAnything {
+                        program: program.to_string(),
+                        matcher: pattern,
+                    });
+                } else {
+                    for positional_arg in vararg {
+                        let matched_arg = MatchedArg::new(
+                            positional_arg.index,
+                            pattern.arg_type(),
+                            &positional_arg.value.clone(),
+                        )?;
+                        matched_args.push(matched_arg);
+                    }
+                }
+            }
+            ArgMatcherCardinality::ZeroOrMore => {
+                for positional_arg in vararg {
+                    let matched_arg = MatchedArg::new(
+                        positional_arg.index,
+                        pattern.arg_type(),
+                        &positional_arg.value.clone(),
+                    )?;
+                    matched_args.push(matched_arg);
+                }
+            }
+        }
+    }
+
+    let suffix = get_range_checked(&args, initial_suffix_args_index..args.len())?;
+    let mut suffix_arg_index = 0;
+    for pattern in suffix_patterns {
+        let n = pattern
+            .cardinality()
+            .is_exact()
+            .ok_or(Error::InternalInvariantViolation {
+                message: "expected exact cardinality".to_string(),
+            })?;
+        for positional_arg in &suffix[suffix_arg_index..suffix_arg_index + n] {
+            let matched_arg = MatchedArg::new(
+                positional_arg.index,
+                pattern.arg_type(),
+                &positional_arg.value.clone(),
+            )?;
+            matched_args.push(matched_arg);
+        }
+        suffix_arg_index += n;
+    }
+
+    if matched_args.len() < args.len() {
+        let extra_args = get_range_checked(&args, matched_args.len()..args.len())?;
+        Err(Error::UnexpectedArguments {
+            program: program.to_string(),
+            args: extra_args.to_vec(),
+        })
+    } else {
+        Ok(matched_args)
+    }
+}
+
+#[derive(Default)]
+struct ParitionedArgs {
+    num_prefix_args: usize,
+    num_suffix_args: usize,
+    prefix_patterns: Vec<ArgMatcher>,
+    suffix_patterns: Vec<ArgMatcher>,
+    vararg_pattern: Option<ArgMatcher>,
+}
+
+fn partition_args(program: &str, arg_patterns: &Vec<ArgMatcher>) -> Result<ParitionedArgs> {
+    let mut in_prefix = true;
+    let mut partitioned_args = ParitionedArgs::default();
+
+    for pattern in arg_patterns {
+        match pattern.cardinality().is_exact() {
+            Some(n) => {
+                if in_prefix {
+                    partitioned_args.prefix_patterns.push(pattern.clone());
+                    partitioned_args.num_prefix_args += n;
+                } else {
+                    partitioned_args.suffix_patterns.push(pattern.clone());
+                    partitioned_args.num_suffix_args += n;
+                }
+            }
+            None => match partitioned_args.vararg_pattern {
+                None => {
+                    partitioned_args.vararg_pattern = Some(pattern.clone());
+                    in_prefix = false;
+                }
+                Some(existing_pattern) => {
+                    return Err(Error::MultipleVarargPatterns {
+                        program: program.to_string(),
+                        first: existing_pattern,
+                        second: pattern.clone(),
+                    });
+                }
+            },
+        }
+    }
+
+    Ok(partitioned_args)
+}
+
+fn get_range_checked<T>(vec: &[T], range: std::ops::Range<usize>) -> Result<&[T]> {
+    if range.start > range.end {
+        Err(Error::RangeStartExceedsEnd {
+            start: range.start,
+            end: range.end,
+        })
+    } else if range.end > vec.len() {
+        Err(Error::RangeEndOutOfBounds {
+            end: range.end,
+            len: vec.len(),
+        })
+    } else {
+        Ok(&vec[range])
+    }
+}

--- a/vtcode-core/src/exec_policy/arg_type.rs
+++ b/vtcode-core/src/exec_policy/arg_type.rs
@@ -1,0 +1,87 @@
+#![allow(clippy::needless_lifetimes)]
+
+use allocative::Allocative;
+use derive_more::derive::Display;
+use serde::Serialize;
+use starlark::any::ProvidesStaticType;
+use starlark::values::StarlarkValue;
+use starlark::values::starlark_value;
+
+use super::error::{Error, Result};
+use super::sed_command::parse_sed_command;
+
+#[derive(Debug, Clone, Display, Eq, PartialEq, ProvidesStaticType, Allocative, Serialize)]
+#[display("{}", self)]
+pub enum ArgType {
+    Literal(String),
+    /// We cannot say what this argument represents, but it is *not* a file path.
+    OpaqueNonFile,
+    /// A file (or directory) that can be expected to be read as part of this command.
+    ReadableFile,
+    /// A file (or directory) that can be expected to be written as part of this command.
+    WriteableFile,
+    /// Positive integer, like one that is required for `head -n`.
+    PositiveInteger,
+    /// Bespoke arg type for a safe sed command.
+    SedCommand,
+    /// Type is unknown: it may or may not be a file.
+    Unknown,
+}
+
+impl ArgType {
+    pub fn validate(&self, value: &str) -> Result<()> {
+        match self {
+            ArgType::Literal(literal_value) => {
+                if value != *literal_value {
+                    Err(Error::LiteralValueDidNotMatch {
+                        expected: literal_value.clone(),
+                        actual: value.to_string(),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+            ArgType::ReadableFile => {
+                if value.is_empty() {
+                    Err(Error::EmptyFileName {})
+                } else {
+                    Ok(())
+                }
+            }
+            ArgType::WriteableFile => {
+                if value.is_empty() {
+                    Err(Error::EmptyFileName {})
+                } else {
+                    Ok(())
+                }
+            }
+            ArgType::OpaqueNonFile | ArgType::Unknown => Ok(()),
+            ArgType::PositiveInteger => match value.parse::<u64>() {
+                Ok(0) => Err(Error::InvalidPositiveInteger {
+                    value: value.to_string(),
+                }),
+                Ok(_) => Ok(()),
+                Err(_) => Err(Error::InvalidPositiveInteger {
+                    value: value.to_string(),
+                }),
+            },
+            ArgType::SedCommand => parse_sed_command(value),
+        }
+    }
+
+    pub fn might_write_file(&self) -> bool {
+        match self {
+            ArgType::WriteableFile | ArgType::Unknown => true,
+            ArgType::Literal(_)
+            | ArgType::OpaqueNonFile
+            | ArgType::PositiveInteger
+            | ArgType::ReadableFile
+            | ArgType::SedCommand => false,
+        }
+    }
+}
+
+#[starlark_value(type = "ArgType")]
+impl<'v> StarlarkValue<'v> for ArgType {
+    type Canonical = ArgType;
+}

--- a/vtcode-core/src/exec_policy/default.policy
+++ b/vtcode-core/src/exec_policy/default.policy
@@ -1,0 +1,202 @@
+"""
+define_program() supports the following arguments:
+- program: the name of the program
+- system_path: list of absolute paths on the system where program can likely be found
+- option_bundling (PLANNED): whether to allow bundling of options (e.g. `-al` for `-a -l`)
+- combine_format (PLANNED): whether to allow `--option=value` (as opposed to `--option value`)
+- options: the command-line flags/options: use flag() and opt() to define these
+- args: the rules for what arguments are allowed that are not "options"
+- should_match: list of command-line invocations that should be matched by the rule
+- should_not_match: list of command-line invocations that should not be matched by the rule
+"""
+
+define_program(
+    program="ls",
+    system_path=["/bin/ls", "/usr/bin/ls"],
+    options=[
+        flag("-1"),
+        flag("-a"),
+        flag("-l"),
+    ],
+    args=[ARG_RFILES_OR_CWD],
+)
+
+define_program(
+    program="cat",
+    options=[
+        flag("-b"),
+        flag("-n"),
+        flag("-t"),
+    ],
+    system_path=["/bin/cat", "/usr/bin/cat"],
+    args=[ARG_RFILES],
+    should_match=[
+        ["file.txt"],
+        ["-n", "file.txt"],
+        ["-b", "file.txt"],
+    ],
+    should_not_match=[
+        # While cat without args is valid, it will read from stdin, which
+        # does not seem appropriate for our current use case.
+        [],
+        # Let's not auto-approve advisory locking.
+        ["-l", "file.txt"],
+    ]
+)
+
+define_program(
+    program="cp",
+    options=[
+        flag("-r"),
+        flag("-R"),
+        flag("--recursive"),
+    ],
+    args=[ARG_RFILES, ARG_WFILE],
+    system_path=["/bin/cp", "/usr/bin/cp"],
+    should_match=[
+        ["foo", "bar"],
+    ],
+    should_not_match=[
+        ["foo"],
+    ],
+)
+
+define_program(
+    program="head",
+    system_path=["/bin/head", "/usr/bin/head"],
+    options=[
+        opt("-c", ARG_POS_INT),
+        opt("-n", ARG_POS_INT),
+    ],
+    args=[ARG_RFILES],
+)
+
+printenv_system_path = ["/usr/bin/printenv"]
+
+# Print all environment variables.
+define_program(
+    program="printenv",
+    args=[],
+    system_path=printenv_system_path,
+    # This variant of `printenv` only allows zero args.
+    should_match=[[]],
+    should_not_match=[["PATH"]],
+)
+
+# Print a specific environment variable.
+define_program(
+    program="printenv",
+    args=[ARG_OPAQUE_VALUE],
+    system_path=printenv_system_path,
+    # This variant of `printenv` only allows exactly one arg.
+    should_match=[["PATH"]],
+    should_not_match=[[], ["PATH", "HOME"]],
+)
+
+# Note that `pwd` is generally implemented as a shell built-in. It does not
+# accept any arguments.
+define_program(
+    program="pwd",
+    options=[
+        flag("-L"),
+        flag("-P"),
+    ],
+    args=[],
+)
+
+define_program(
+    program="rg",
+    options=[
+        opt("-A", ARG_POS_INT),
+        opt("-B", ARG_POS_INT),
+        opt("-C", ARG_POS_INT),
+        opt("-d", ARG_POS_INT),
+        opt("--max-depth", ARG_POS_INT),
+        opt("-g", ARG_OPAQUE_VALUE),
+        opt("--glob", ARG_OPAQUE_VALUE),
+        opt("-m", ARG_POS_INT),
+        opt("--max-count", ARG_POS_INT),
+
+        flag("-n"),
+        flag("-i"),
+        flag("-l"),
+        flag("--files"),
+        flag("--files-with-matches"),
+        flag("--files-without-match"),
+    ],
+    args=[ARG_OPAQUE_VALUE, ARG_RFILES_OR_CWD],
+    should_match=[
+        ["-n", "init"],
+        ["-n", "init", "."],
+        ["-i", "-n", "init", "src"],
+        ["--files", "--max-depth", "2", "."],
+    ],
+    should_not_match=[
+        ["-m", "-n", "init"],
+        ["--glob", "src"],
+    ],
+    # TODO(mbolin): Perhaps we need a way to indicate that we expect `rg` to be
+    # bundled with the host environment and we should be using that version.
+    system_path=[],
+)
+
+# Unfortunately, `sed` is difficult to secure because GNU sed supports an `e`
+# flag where `s/pattern/replacement/e` would run `replacement` as a shell
+# command every time `pattern` is matched. For example, try the following on
+# Ubuntu (which uses GNU sed, unlike macOS):
+#
+# ```shell
+# $ yes | head -n 4 > /tmp/yes.txt
+# $ sed 's/y/echo hi/e' /tmp/yes.txt
+# hi
+# hi
+# hi
+# hi
+# ```
+#
+# As you can see, `echo hi` got executed four times. In order to support some
+# basic sed functionality, we implement a bespoke `ARG_SED_COMMAND` that matches
+# only "known safe" sed commands.
+common_sed_flags = [
+    # We deliberately do not support -i or -f.
+    flag("-n"),
+    flag("-u"),
+]
+sed_system_path = ["/usr/bin/sed"]
+
+# When -e is not specified, the first argument must be a valid sed command.
+define_program(
+    program="sed",
+    options=common_sed_flags,
+    args=[ARG_SED_COMMAND, ARG_RFILES],
+    system_path=sed_system_path,
+)
+
+# When -e is required, all arguments are assumed to be readable files.
+define_program(
+    program="sed",
+    options=common_sed_flags + [
+        opt("-e", ARG_SED_COMMAND, required=True),
+    ],
+    args=[ARG_RFILES],
+    system_path=sed_system_path,
+)
+
+define_program(
+    program="which",
+    options=[
+        flag("-a"),
+        flag("-s"),
+    ],
+    # Surprisingly, `which` takes more than one argument.
+    args=[ARG_RFILES],
+    should_match=[
+        ["python3"],
+        ["-a", "python3"],
+        ["-a", "python3", "cargo"],
+    ],
+    should_not_match=[
+        [],
+    ],
+    system_path=["/bin/which", "/usr/bin/which"],
+)

--- a/vtcode-core/src/exec_policy/error.rs
+++ b/vtcode-core/src/exec_policy/error.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::Serialize;
+use serde_with::DisplayFromStr;
+use serde_with::serde_as;
+
+use super::arg_matcher::ArgMatcher;
+use super::arg_resolver::PositionalArg;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[serde_as]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(tag = "type")]
+pub enum Error {
+    NoSpecForProgram {
+        program: String,
+    },
+    OptionMissingValue {
+        program: String,
+        option: String,
+    },
+    OptionFollowedByOptionInsteadOfValue {
+        program: String,
+        option: String,
+        value: String,
+    },
+    UnknownOption {
+        program: String,
+        option: String,
+    },
+    UnexpectedArguments {
+        program: String,
+        args: Vec<PositionalArg>,
+    },
+    DoubleDashNotSupportedYet {
+        program: String,
+    },
+    MultipleVarargPatterns {
+        program: String,
+        first: ArgMatcher,
+        second: ArgMatcher,
+    },
+    RangeStartExceedsEnd {
+        start: usize,
+        end: usize,
+    },
+    RangeEndOutOfBounds {
+        end: usize,
+        len: usize,
+    },
+    PrefixOverlapsSuffix {},
+    NotEnoughArgs {
+        program: String,
+        args: Vec<PositionalArg>,
+        arg_patterns: Vec<ArgMatcher>,
+    },
+    InternalInvariantViolation {
+        message: String,
+    },
+    VarargMatcherDidNotMatchAnything {
+        program: String,
+        matcher: ArgMatcher,
+    },
+    EmptyFileName {},
+    LiteralValueDidNotMatch {
+        expected: String,
+        actual: String,
+    },
+    InvalidPositiveInteger {
+        value: String,
+    },
+    MissingRequiredOptions {
+        program: String,
+        options: Vec<String>,
+    },
+    SedCommandNotProvablySafe {
+        command: String,
+    },
+    ReadablePathNotInReadableFolders {
+        file: PathBuf,
+        folders: Vec<PathBuf>,
+    },
+    WriteablePathNotInWriteableFolders {
+        file: PathBuf,
+        folders: Vec<PathBuf>,
+    },
+    CannotCheckRelativePath {
+        file: PathBuf,
+    },
+    CannotCanonicalizePath {
+        file: String,
+        #[serde_as(as = "DisplayFromStr")]
+        error: std::io::ErrorKind,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for Error {}

--- a/vtcode-core/src/exec_policy/exec_call.rs
+++ b/vtcode-core/src/exec_policy/exec_call.rs
@@ -1,0 +1,28 @@
+use std::fmt::Display;
+
+use serde::Serialize;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExecCall {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl ExecCall {
+    pub fn new(program: &str, args: &[&str]) -> Self {
+        Self {
+            program: program.to_string(),
+            args: args.iter().map(|&s| s.into()).collect(),
+        }
+    }
+}
+
+impl Display for ExecCall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.program)?;
+        for arg in &self.args {
+            write!(f, " {arg}")?;
+        }
+        Ok(())
+    }
+}

--- a/vtcode-core/src/exec_policy/execv_checker.rs
+++ b/vtcode-core/src/exec_policy/execv_checker.rs
@@ -1,0 +1,256 @@
+use std::borrow::Cow;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use path_absolutize::*;
+
+use super::Result;
+use super::arg_type::ArgType;
+use super::error::Error::{
+    CannotCanonicalizePath, CannotCheckRelativePath, ReadablePathNotInReadableFolders,
+    WriteablePathNotInWriteableFolders,
+};
+use super::exec_call::ExecCall;
+use super::policy::Policy;
+use super::program::MatchedExec;
+use super::valid_exec::ValidExec;
+
+macro_rules! check_file_in_folders {
+    ($file:expr, $folders:expr, $error:ident) => {
+        if !$folders.iter().any(|folder| $file.starts_with(folder)) {
+            return Err($error {
+                file: $file.clone(),
+                folders: $folders.to_vec(),
+            });
+        }
+    };
+}
+
+#[derive(Clone, Debug)]
+pub struct ExecvChecker {
+    execv_policy: Policy,
+}
+
+impl ExecvChecker {
+    pub fn new(execv_policy: Policy) -> Self {
+        Self { execv_policy }
+    }
+
+    pub fn r#match(&self, exec_call: &ExecCall) -> Result<MatchedExec> {
+        self.execv_policy.check(exec_call)
+    }
+
+    /// The caller is responsible for ensuring readable_folders and
+    /// writeable_folders are in canonical form.
+    pub fn check(
+        &self,
+        valid_exec: ValidExec,
+        cwd: &Option<OsString>,
+        readable_folders: &[PathBuf],
+        writeable_folders: &[PathBuf],
+    ) -> Result<String> {
+        for (arg_type, value) in valid_exec
+            .args
+            .into_iter()
+            .map(|arg| (arg.r#type, arg.value))
+            .chain(
+                valid_exec
+                    .opts
+                    .into_iter()
+                    .map(|opt| (opt.r#type, opt.value)),
+            )
+        {
+            match arg_type {
+                ArgType::ReadableFile => {
+                    let readable_file = ensure_absolute_path(&value, cwd)?;
+                    check_file_in_folders!(
+                        readable_file,
+                        readable_folders,
+                        ReadablePathNotInReadableFolders
+                    );
+                }
+                ArgType::WriteableFile => {
+                    let writeable_file = ensure_absolute_path(&value, cwd)?;
+                    check_file_in_folders!(
+                        writeable_file,
+                        writeable_folders,
+                        WriteablePathNotInWriteableFolders
+                    );
+                }
+                ArgType::OpaqueNonFile
+                | ArgType::Unknown
+                | ArgType::PositiveInteger
+                | ArgType::SedCommand
+                | ArgType::Literal(_) => {
+                    continue;
+                }
+            }
+        }
+
+        let mut program = valid_exec.program.to_string();
+        for system_path in valid_exec.system_path {
+            if is_executable_file(&system_path) {
+                program = system_path;
+                break;
+            }
+        }
+
+        Ok(program)
+    }
+}
+
+fn ensure_absolute_path(path: &str, cwd: &Option<OsString>) -> Result<PathBuf> {
+    let file = PathBuf::from(path);
+    let result = if file.is_relative() {
+        match cwd {
+            Some(cwd) => file.absolutize_from(cwd),
+            None => return Err(CannotCheckRelativePath { file }),
+        }
+    } else {
+        file.absolutize()
+    };
+    result
+        .map(Cow::into_owned)
+        .map_err(|error| CannotCanonicalizePath {
+            file: path.to_string(),
+            error: error.kind(),
+        })
+}
+
+fn is_executable_file(path: &str) -> bool {
+    let file_path = Path::new(path);
+
+    if let Ok(metadata) = std::fs::metadata(file_path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let permissions = metadata.permissions();
+
+            // Check if the file is executable (by checking the executable bit for the owner)
+            return metadata.is_file() && (permissions.mode() & 0o111 != 0);
+        }
+
+        #[cfg(windows)]
+        {
+            // TODO(mbolin): Check against PATHEXT environment variable.
+            return metadata.is_file();
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::super::policy_parser::PolicyParser;
+    use super::*;
+    use anyhow::{Result as AnyhowResult, anyhow};
+
+    fn setup(fake_cp: &Path) -> ExecvChecker {
+        let source = format!(
+            r#"
+define_program(
+program="cp",
+args=[ARG_RFILE, ARG_WFILE],
+system_path=[{fake_cp:?}]
+)
+"#
+        );
+        let parser = PolicyParser::new("#test", &source);
+        let policy = parser.parse().unwrap();
+        ExecvChecker::new(policy)
+    }
+
+    #[test]
+    fn test_check_valid_input_files() -> AnyhowResult<()> {
+        let temp_dir = TempDir::new()?;
+
+        // Create an executable file that can be used with the system_path arg.
+        let fake_cp = temp_dir.path().join("cp");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let fake_cp_file = std::fs::File::create(&fake_cp)?;
+            let mut permissions = fake_cp_file.metadata()?.permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&fake_cp, permissions)?;
+        }
+        #[cfg(windows)]
+        {
+            std::fs::File::create(&fake_cp)?;
+        }
+
+        // Create root_path and reference to files under the root.
+        let root_path = temp_dir.path().to_path_buf();
+        let source_path = root_path.join("source");
+        let dest_path = root_path.join("dest");
+
+        let cp = fake_cp.to_str().unwrap().to_string();
+        let root = root_path.to_str().unwrap().to_string();
+        let source = source_path.to_str().unwrap().to_string();
+        let dest = dest_path.to_str().unwrap().to_string();
+
+        let cwd = Some(root_path.clone().into());
+
+        let checker = setup(&fake_cp);
+        let exec_call = ExecCall {
+            program: "cp".to_string(),
+            args: vec![source.clone(), dest.clone()],
+        };
+        let matched = checker.r#match(&exec_call)?;
+        let exec = match matched {
+            MatchedExec::Match { exec } => exec,
+            MatchedExec::Forbidden { cause, reason } => {
+                return Err(anyhow!(
+                    "expected match, got forbidden: {:?}, reason: {}",
+                    cause,
+                    reason
+                ));
+            }
+        };
+
+        let executable = checker.check(exec, &cwd, &[root_path.clone()], &[root_path.clone()])?;
+        assert_eq!(executable, cp);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_check_rejects_unreadable_path() -> AnyhowResult<()> {
+        let temp_dir = TempDir::new()?;
+        let fake_cp = temp_dir.path().join("cp");
+        std::fs::File::create(&fake_cp)?;
+
+        let checker = setup(&fake_cp);
+        let exec_call = ExecCall {
+            program: "cp".to_string(),
+            args: vec!["/etc/passwd".to_string(), "dest".to_string()],
+        };
+        let matched = checker.r#match(&exec_call)?;
+        let exec = match matched {
+            MatchedExec::Match { exec } => exec,
+            MatchedExec::Forbidden { cause, reason } => {
+                return Err(anyhow!(
+                    "expected match, got forbidden: {:?}, reason: {}",
+                    cause,
+                    reason
+                ));
+            }
+        };
+
+        let result = checker.check(
+            exec,
+            &Some(temp_dir.path().into()),
+            &[temp_dir.path().to_path_buf()],
+            &[temp_dir.path().to_path_buf()],
+        );
+        assert!(matches!(
+            result,
+            Err(ReadablePathNotInReadableFolders { .. })
+        ));
+        Ok(())
+    }
+}

--- a/vtcode-core/src/exec_policy/manager.rs
+++ b/vtcode-core/src/exec_policy/manager.rs
@@ -1,0 +1,194 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use super::default_execv_checker;
+use super::error::Error;
+use super::exec_call::ExecCall;
+use super::execv_checker::ExecvChecker;
+use super::program::{Forbidden, MatchedExec};
+use super::valid_exec::ValidExec;
+
+#[derive(Debug, Clone)]
+pub struct ExecPolicyManager {
+    checker: ExecvChecker,
+    workspace_root: PathBuf,
+    readable_roots: Vec<PathBuf>,
+    writeable_roots: Vec<PathBuf>,
+}
+
+impl ExecPolicyManager {
+    pub fn new(workspace_root: PathBuf) -> Result<Self> {
+        let checker =
+            default_execv_checker().with_context(|| "failed to load default exec policy")?;
+        let canonical_root = workspace_root
+            .canonicalize()
+            .unwrap_or(workspace_root.clone());
+
+        let mut readable_roots = vec![canonical_root.clone()];
+        let mut writeable_roots = vec![canonical_root.clone()];
+
+        let temp_dir = std::env::temp_dir()
+            .canonicalize()
+            .unwrap_or_else(|_| std::env::temp_dir());
+        if !readable_roots.contains(&temp_dir) {
+            readable_roots.push(temp_dir.clone());
+        }
+        if !writeable_roots.contains(&temp_dir) {
+            writeable_roots.push(temp_dir);
+        }
+
+        Ok(Self {
+            checker,
+            workspace_root: canonical_root,
+            readable_roots,
+            writeable_roots,
+        })
+    }
+
+    pub fn assess(&self, command: &[String], working_dir: &Path) -> ExecPolicyReport {
+        if command.is_empty() {
+            return ExecPolicyReport::unverified(Some("command had no program".to_string()), None);
+        }
+
+        let exec_call = ExecCall {
+            program: command[0].clone(),
+            args: command[1..].to_vec(),
+        };
+
+        match self.checker.r#match(&exec_call) {
+            Ok(MatchedExec::Match { exec }) => self.handle_match(exec, working_dir),
+            Ok(MatchedExec::Forbidden { cause, reason }) => {
+                ExecPolicyReport::forbidden(Some(reason), Some(cause), None)
+            }
+            Err(Error::NoSpecForProgram { .. }) => ExecPolicyReport::not_covered(),
+            Err(error) => ExecPolicyReport::unverified(None, Some(error)),
+        }
+    }
+
+    fn handle_match(&self, exec: ValidExec, working_dir: &Path) -> ExecPolicyReport {
+        let cwd = self.resolve_cwd(working_dir);
+        let cwd_os = Some(cwd.clone().into_os_string());
+
+        let mut readable = self.readable_roots.clone();
+        if !readable.iter().any(|path| path == &cwd) {
+            readable.push(cwd.clone());
+        }
+
+        let mut writeable = self.writeable_roots.clone();
+        if !writeable.iter().any(|path| path == &cwd) {
+            writeable.push(cwd.clone());
+        }
+
+        let exec_for_report = exec.clone();
+        match self.checker.check(exec, &cwd_os, &readable, &writeable) {
+            Ok(program) => {
+                if exec_for_report.might_write_files() {
+                    ExecPolicyReport::needs_review(Some(program), exec_for_report)
+                } else {
+                    ExecPolicyReport::safe(Some(program), exec_for_report)
+                }
+            }
+            Err(error) => ExecPolicyReport::forbidden(None, None, Some(error)),
+        }
+    }
+
+    fn resolve_cwd(&self, working_dir: &Path) -> PathBuf {
+        let joined = if working_dir.is_absolute() {
+            working_dir.to_path_buf()
+        } else {
+            self.workspace_root.join(working_dir)
+        };
+        joined.canonicalize().unwrap_or(joined)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecPolicyVerdict {
+    Safe,
+    NeedsReview,
+    Forbidden,
+    Unverified,
+    NotCovered,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecPolicyReport {
+    pub verdict: ExecPolicyVerdict,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_program: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exec: Option<ValidExec>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forbidden_cause: Option<Forbidden>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<Error>,
+}
+
+impl ExecPolicyReport {
+    pub fn safe(canonical_program: Option<String>, exec: ValidExec) -> Self {
+        Self {
+            verdict: ExecPolicyVerdict::Safe,
+            reason: None,
+            canonical_program,
+            exec: Some(exec),
+            forbidden_cause: None,
+            error: None,
+        }
+    }
+
+    pub fn needs_review(canonical_program: Option<String>, exec: ValidExec) -> Self {
+        Self {
+            verdict: ExecPolicyVerdict::NeedsReview,
+            reason: Some("command may write to disk".to_string()),
+            canonical_program,
+            exec: Some(exec),
+            forbidden_cause: None,
+            error: None,
+        }
+    }
+
+    pub fn forbidden(
+        reason: Option<String>,
+        cause: Option<Forbidden>,
+        error: Option<Error>,
+    ) -> Self {
+        Self {
+            verdict: ExecPolicyVerdict::Forbidden,
+            reason,
+            canonical_program: None,
+            exec: match &cause {
+                Some(Forbidden::Exec { exec }) => Some(exec.clone()),
+                _ => None,
+            },
+            forbidden_cause: cause,
+            error,
+        }
+    }
+
+    pub fn unverified(reason: Option<String>, error: Option<Error>) -> Self {
+        Self {
+            verdict: ExecPolicyVerdict::Unverified,
+            reason,
+            canonical_program: None,
+            exec: None,
+            forbidden_cause: None,
+            error,
+        }
+    }
+
+    pub fn not_covered() -> Self {
+        Self {
+            verdict: ExecPolicyVerdict::NotCovered,
+            reason: None,
+            canonical_program: None,
+            exec: None,
+            forbidden_cause: None,
+            error: None,
+        }
+    }
+}

--- a/vtcode-core/src/exec_policy/mod.rs
+++ b/vtcode-core/src/exec_policy/mod.rs
@@ -1,0 +1,45 @@
+#![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
+
+mod arg_matcher;
+mod arg_resolver;
+mod arg_type;
+mod error;
+mod exec_call;
+mod execv_checker;
+mod opt;
+mod policy;
+mod policy_parser;
+mod program;
+mod sed_command;
+mod valid_exec;
+
+pub mod manager;
+
+pub use arg_matcher::ArgMatcher;
+pub use arg_resolver::PositionalArg;
+pub use arg_type::ArgType;
+pub use error::{Error, Result};
+pub use exec_call::ExecCall;
+pub use execv_checker::ExecvChecker;
+pub use manager::{ExecPolicyManager, ExecPolicyReport, ExecPolicyVerdict};
+pub use opt::Opt;
+pub use policy::Policy;
+pub use policy_parser::PolicyParser;
+pub use program::{
+    Forbidden, MatchedExec, NegativeExamplePassedCheck, PositiveExampleFailedCheck, ProgramSpec,
+};
+pub use sed_command::parse_sed_command;
+pub use valid_exec::{MatchedArg, MatchedFlag, MatchedOpt, ValidExec};
+
+const DEFAULT_POLICY: &str = include_str!("default.policy");
+
+pub fn parse_default_policy() -> starlark::Result<Policy> {
+    let parser = PolicyParser::new("#default", DEFAULT_POLICY);
+    parser.parse()
+}
+
+pub fn default_execv_checker() -> anyhow::Result<ExecvChecker> {
+    let policy = parse_default_policy().map_err(|error| anyhow::anyhow!(error))?;
+    Ok(ExecvChecker::new(policy))
+}

--- a/vtcode-core/src/exec_policy/opt.rs
+++ b/vtcode-core/src/exec_policy/opt.rs
@@ -1,0 +1,76 @@
+#![allow(clippy::needless_lifetimes)]
+
+use allocative::Allocative;
+use derive_more::derive::Display;
+use starlark::any::ProvidesStaticType;
+use starlark::values::AllocValue;
+use starlark::values::Heap;
+use starlark::values::NoSerialize;
+use starlark::values::StarlarkValue;
+use starlark::values::UnpackValue;
+use starlark::values::Value;
+use starlark::values::ValueLike;
+use starlark::values::starlark_value;
+
+use super::arg_type::ArgType;
+
+/// Command line option that takes a value.
+#[derive(Clone, Debug, Display, PartialEq, Eq, ProvidesStaticType, NoSerialize, Allocative)]
+#[display("opt({})", opt)]
+pub struct Opt {
+    /// The option as typed on the command line, e.g., `-h` or `--help`. If
+    /// it can be used in the `--name=value` format, then this should be
+    /// `--name` (though this is subject to change).
+    pub opt: String,
+    pub meta: OptMeta,
+    pub required: bool,
+}
+
+/// When defining an Opt, use as specific an OptMeta as possible.
+#[derive(Clone, Debug, Display, PartialEq, Eq, ProvidesStaticType, NoSerialize, Allocative)]
+#[display("{}", self)]
+pub enum OptMeta {
+    /// Option does not take a value.
+    Flag,
+
+    /// Option takes a single value matching the specified type.
+    Value(ArgType),
+}
+
+impl Opt {
+    pub fn new(opt: String, meta: OptMeta, required: bool) -> Self {
+        Self {
+            opt,
+            meta,
+            required,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.opt
+    }
+}
+
+#[starlark_value(type = "Opt")]
+impl<'v> StarlarkValue<'v> for Opt {
+    type Canonical = Opt;
+}
+
+impl<'v> UnpackValue<'v> for Opt {
+    fn unpack_value(value: Value<'v>) -> Option<Self> {
+        // TODO(mbolin): It feels like this should be doable without cloning?
+        // Cannot simply consume the value?
+        value.downcast_ref::<Opt>().cloned()
+    }
+}
+
+impl<'v> AllocValue<'v> for Opt {
+    fn alloc_value(self, heap: &'v Heap) -> Value<'v> {
+        heap.alloc_simple(self)
+    }
+}
+
+#[starlark_value(type = "OptMeta")]
+impl<'v> StarlarkValue<'v> for OptMeta {
+    type Canonical = OptMeta;
+}

--- a/vtcode-core/src/exec_policy/policy.rs
+++ b/vtcode-core/src/exec_policy/policy.rs
@@ -1,0 +1,99 @@
+use multimap::MultiMap;
+use regex_lite::{Error as RegexError, Regex};
+
+use super::error::{Error, Result};
+use super::exec_call::ExecCall;
+use super::policy_parser::ForbiddenProgramRegex;
+use super::program::{Forbidden, MatchedExec, ProgramSpec};
+use super::program::{NegativeExamplePassedCheck, PositiveExampleFailedCheck};
+
+#[derive(Clone, Debug)]
+pub struct Policy {
+    programs: MultiMap<String, ProgramSpec>,
+    forbidden_program_regexes: Vec<ForbiddenProgramRegex>,
+    forbidden_substrings_pattern: Option<Regex>,
+}
+
+impl Policy {
+    pub fn new(
+        programs: MultiMap<String, ProgramSpec>,
+        forbidden_program_regexes: Vec<ForbiddenProgramRegex>,
+        forbidden_substrings: Vec<String>,
+    ) -> std::result::Result<Self, RegexError> {
+        let forbidden_substrings_pattern = if forbidden_substrings.is_empty() {
+            None
+        } else {
+            let escaped_substrings = forbidden_substrings
+                .iter()
+                .map(|s| regex_lite::escape(s))
+                .collect::<Vec<_>>()
+                .join("|");
+            Some(Regex::new(&format!("({escaped_substrings})"))?)
+        };
+        Ok(Self {
+            programs,
+            forbidden_program_regexes,
+            forbidden_substrings_pattern,
+        })
+    }
+
+    pub fn check(&self, exec_call: &ExecCall) -> Result<MatchedExec> {
+        let ExecCall { program, args } = &exec_call;
+        for ForbiddenProgramRegex { regex, reason } in &self.forbidden_program_regexes {
+            if regex.is_match(program) {
+                return Ok(MatchedExec::Forbidden {
+                    cause: Forbidden::Program {
+                        program: program.clone(),
+                        exec_call: exec_call.clone(),
+                    },
+                    reason: reason.clone(),
+                });
+            }
+        }
+
+        for arg in args {
+            if let Some(regex) = &self.forbidden_substrings_pattern
+                && regex.is_match(arg)
+            {
+                return Ok(MatchedExec::Forbidden {
+                    cause: Forbidden::Arg {
+                        arg: arg.clone(),
+                        exec_call: exec_call.clone(),
+                    },
+                    reason: format!("arg `{arg}` contains forbidden substring"),
+                });
+            }
+        }
+
+        let mut last_err = Err(Error::NoSpecForProgram {
+            program: program.clone(),
+        });
+        if let Some(spec_list) = self.programs.get_vec(program) {
+            for spec in spec_list {
+                match spec.check(exec_call) {
+                    Ok(matched_exec) => return Ok(matched_exec),
+                    Err(err) => {
+                        last_err = Err(err);
+                    }
+                }
+            }
+        }
+        last_err
+    }
+
+    pub fn check_each_good_list_individually(&self) -> Vec<PositiveExampleFailedCheck> {
+        let mut violations = Vec::new();
+        for (_program, spec) in self.programs.flat_iter() {
+            violations.extend(spec.verify_should_match_list());
+        }
+        violations
+    }
+
+    pub fn check_each_bad_list_individually(&self) -> Vec<NegativeExamplePassedCheck> {
+        let mut violations = Vec::new();
+        for (_program, spec) in self.programs.flat_iter() {
+            violations.extend(spec.verify_should_not_match_list());
+        }
+        violations
+    }
+}

--- a/vtcode-core/src/exec_policy/policy_parser.rs
+++ b/vtcode-core/src/exec_policy/policy_parser.rs
@@ -1,0 +1,225 @@
+#![allow(clippy::needless_lifetimes)]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use multimap::MultiMap;
+use regex_lite::Regex;
+use starlark::any::ProvidesStaticType;
+use starlark::environment::{GlobalsBuilder, LibraryExtension, Module};
+use starlark::eval::Evaluator;
+use starlark::starlark_module;
+use starlark::syntax::{AstModule, Dialect};
+use starlark::values::Heap;
+use starlark::values::list::UnpackList;
+use starlark::values::none::NoneType;
+use tracing::info;
+
+use super::arg_matcher::ArgMatcher;
+use super::opt::{Opt, OptMeta};
+use super::policy::Policy;
+use super::program::ProgramSpec;
+
+pub struct PolicyParser {
+    policy_source: String,
+    unparsed_policy: String,
+}
+
+impl PolicyParser {
+    pub fn new(policy_source: &str, unparsed_policy: &str) -> Self {
+        Self {
+            policy_source: policy_source.to_string(),
+            unparsed_policy: unparsed_policy.to_string(),
+        }
+    }
+
+    pub fn parse(&self) -> starlark::Result<Policy> {
+        let mut dialect = Dialect::Extended.clone();
+        dialect.enable_f_strings = true;
+        let ast = AstModule::parse(&self.policy_source, self.unparsed_policy.clone(), &dialect)?;
+        let globals = GlobalsBuilder::extended_by(&[LibraryExtension::Typing])
+            .with(policy_builtins)
+            .build();
+        let module = Module::new();
+
+        let heap = Heap::new();
+
+        module.set("ARG_OPAQUE_VALUE", heap.alloc(ArgMatcher::OpaqueNonFile));
+        module.set("ARG_RFILE", heap.alloc(ArgMatcher::ReadableFile));
+        module.set("ARG_WFILE", heap.alloc(ArgMatcher::WriteableFile));
+        module.set("ARG_RFILES", heap.alloc(ArgMatcher::ReadableFiles));
+        module.set(
+            "ARG_RFILES_OR_CWD",
+            heap.alloc(ArgMatcher::ReadableFilesOrCwd),
+        );
+        module.set("ARG_POS_INT", heap.alloc(ArgMatcher::PositiveInteger));
+        module.set("ARG_SED_COMMAND", heap.alloc(ArgMatcher::SedCommand));
+        module.set(
+            "ARG_UNVERIFIED_VARARGS",
+            heap.alloc(ArgMatcher::UnverifiedVarargs),
+        );
+
+        let policy_builder = PolicyBuilder::new();
+        {
+            let mut eval = Evaluator::new(&module);
+            eval.extra = Some(&policy_builder);
+            eval.eval_module(ast, &globals)?;
+        }
+        let policy = policy_builder.build();
+        policy.map_err(starlark::Error::new_other)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ForbiddenProgramRegex {
+    pub regex: regex_lite::Regex,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, ProvidesStaticType)]
+struct PolicyBuilder {
+    programs: RefCell<MultiMap<String, ProgramSpec>>,
+    forbidden_program_regexes: RefCell<Vec<ForbiddenProgramRegex>>,
+    forbidden_substrings: RefCell<Vec<String>>,
+}
+
+impl PolicyBuilder {
+    fn new() -> Self {
+        Self {
+            programs: RefCell::new(MultiMap::new()),
+            forbidden_program_regexes: RefCell::new(Vec::new()),
+            forbidden_substrings: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn build(self) -> Result<Policy, regex_lite::Error> {
+        let programs = self.programs.into_inner();
+        let forbidden_program_regexes = self.forbidden_program_regexes.into_inner();
+        let forbidden_substrings = self.forbidden_substrings.into_inner();
+        Policy::new(programs, forbidden_program_regexes, forbidden_substrings)
+    }
+
+    fn add_program_spec(&self, program_spec: ProgramSpec) {
+        info!("adding program spec: {program_spec:?}");
+        let name = program_spec.program.clone();
+        let mut programs = self.programs.borrow_mut();
+        programs.insert(name, program_spec);
+    }
+
+    fn add_forbidden_substrings(&self, substrings: &[String]) {
+        let mut forbidden_substrings = self.forbidden_substrings.borrow_mut();
+        forbidden_substrings.extend_from_slice(substrings);
+    }
+
+    fn add_forbidden_program_regex(&self, regex: Regex, reason: String) {
+        let mut forbidden_program_regexes = self.forbidden_program_regexes.borrow_mut();
+        forbidden_program_regexes.push(ForbiddenProgramRegex { regex, reason });
+    }
+}
+
+#[starlark_module]
+fn policy_builtins(_builder: &mut GlobalsBuilder) {
+    fn define_program<'v>(
+        program: String,
+        system_path: Option<UnpackList<String>>,
+        option_bundling: Option<bool>,
+        combined_format: Option<bool>,
+        options: Option<UnpackList<Opt>>,
+        args: Option<UnpackList<ArgMatcher>>,
+        forbidden: Option<String>,
+        should_match: Option<UnpackList<UnpackList<String>>>,
+        should_not_match: Option<UnpackList<UnpackList<String>>>,
+        eval: &mut Evaluator,
+    ) -> anyhow::Result<NoneType> {
+        let option_bundling = option_bundling.unwrap_or(false);
+        let system_path = system_path.map_or_else(Vec::new, |v| v.items.to_vec());
+        let combined_format = combined_format.unwrap_or(false);
+        let options = options.map_or_else(Vec::new, |v| v.items.to_vec());
+        let args = args.map_or_else(Vec::new, |v| v.items.to_vec());
+
+        let mut allowed_options = HashMap::<String, Opt>::new();
+        for opt in options {
+            let name = opt.name().to_string();
+            if allowed_options
+                .insert(opt.name().to_string(), opt)
+                .is_some()
+            {
+                return Err(anyhow::format_err!("duplicate flag: {name}"));
+            }
+        }
+
+        let program_spec = ProgramSpec::new(
+            program,
+            system_path,
+            option_bundling,
+            combined_format,
+            allowed_options,
+            args,
+            forbidden,
+            should_match
+                .map_or_else(Vec::new, |v| v.items.to_vec())
+                .into_iter()
+                .map(|v| v.items.to_vec())
+                .collect(),
+            should_not_match
+                .map_or_else(Vec::new, |v| v.items.to_vec())
+                .into_iter()
+                .map(|v| v.items.to_vec())
+                .collect(),
+        );
+
+        #[expect(clippy::unwrap_used)]
+        let policy_builder = eval
+            .extra
+            .as_ref()
+            .unwrap()
+            .downcast_ref::<PolicyBuilder>()
+            .unwrap();
+        policy_builder.add_program_spec(program_spec);
+        Ok(NoneType)
+    }
+
+    fn forbid_substrings(
+        strings: UnpackList<String>,
+        eval: &mut Evaluator,
+    ) -> anyhow::Result<NoneType> {
+        #[expect(clippy::unwrap_used)]
+        let policy_builder = eval
+            .extra
+            .as_ref()
+            .unwrap()
+            .downcast_ref::<PolicyBuilder>()
+            .unwrap();
+        policy_builder.add_forbidden_substrings(&strings.items.to_vec());
+        Ok(NoneType)
+    }
+
+    fn forbid_program_regex(
+        regex: String,
+        reason: String,
+        eval: &mut Evaluator,
+    ) -> anyhow::Result<NoneType> {
+        #[expect(clippy::unwrap_used)]
+        let policy_builder = eval
+            .extra
+            .as_ref()
+            .unwrap()
+            .downcast_ref::<PolicyBuilder>()
+            .unwrap();
+        let compiled_regex = regex_lite::Regex::new(&regex)?;
+        policy_builder.add_forbidden_program_regex(compiled_regex, reason);
+        Ok(NoneType)
+    }
+
+    fn opt(name: String, r#type: ArgMatcher, required: Option<bool>) -> anyhow::Result<Opt> {
+        Ok(Opt::new(
+            name,
+            OptMeta::Value(r#type.arg_type()),
+            required.unwrap_or(false),
+        ))
+    }
+
+    fn flag(name: String) -> anyhow::Result<Opt> {
+        Ok(Opt::new(name, OptMeta::Flag, false))
+    }
+}

--- a/vtcode-core/src/exec_policy/program.rs
+++ b/vtcode-core/src/exec_policy/program.rs
@@ -1,0 +1,235 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::Serialize;
+
+use super::arg_matcher::ArgMatcher;
+use super::arg_resolver::{PositionalArg, resolve_observed_args_with_patterns};
+use super::arg_type::ArgType;
+use super::error::{Error, Result};
+use super::exec_call::ExecCall;
+use super::opt::{Opt, OptMeta};
+use super::valid_exec::{MatchedFlag, MatchedOpt, ValidExec};
+
+#[derive(Clone, Debug)]
+pub struct ProgramSpec {
+    pub program: String,
+    pub system_path: Vec<String>,
+    pub option_bundling: bool,
+    pub combined_format: bool,
+    pub allowed_options: HashMap<String, Opt>,
+    pub arg_patterns: Vec<ArgMatcher>,
+    forbidden: Option<String>,
+    required_options: HashSet<String>,
+    should_match: Vec<Vec<String>>,
+    should_not_match: Vec<Vec<String>>,
+}
+
+impl ProgramSpec {
+    pub fn new(
+        program: String,
+        system_path: Vec<String>,
+        option_bundling: bool,
+        combined_format: bool,
+        allowed_options: HashMap<String, Opt>,
+        arg_patterns: Vec<ArgMatcher>,
+        forbidden: Option<String>,
+        should_match: Vec<Vec<String>>,
+        should_not_match: Vec<Vec<String>>,
+    ) -> Self {
+        let required_options = allowed_options
+            .iter()
+            .filter_map(|(name, opt)| {
+                if opt.required {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Self {
+            program,
+            system_path,
+            option_bundling,
+            combined_format,
+            allowed_options,
+            arg_patterns,
+            forbidden,
+            required_options,
+            should_match,
+            should_not_match,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub enum MatchedExec {
+    Match { exec: ValidExec },
+    Forbidden { cause: Forbidden, reason: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub enum Forbidden {
+    Program {
+        program: String,
+        exec_call: ExecCall,
+    },
+    Arg {
+        arg: String,
+        exec_call: ExecCall,
+    },
+    Exec {
+        exec: ValidExec,
+    },
+}
+
+impl ProgramSpec {
+    pub fn check(&self, exec_call: &ExecCall) -> Result<MatchedExec> {
+        let mut expecting_option_value: Option<(String, ArgType)> = None;
+        let mut args = Vec::<PositionalArg>::new();
+        let mut matched_flags = Vec::<MatchedFlag>::new();
+        let mut matched_opts = Vec::<MatchedOpt>::new();
+
+        for (index, arg) in exec_call.args.iter().enumerate() {
+            if let Some(expected) = expecting_option_value {
+                let (name, arg_type) = expected;
+                if arg.starts_with("-") {
+                    return Err(Error::OptionFollowedByOptionInsteadOfValue {
+                        program: self.program.clone(),
+                        option: name,
+                        value: arg.clone(),
+                    });
+                }
+
+                matched_opts.push(MatchedOpt::new(&name, arg, arg_type)?);
+                expecting_option_value = None;
+            } else if arg == "--" {
+                return Err(Error::DoubleDashNotSupportedYet {
+                    program: self.program.clone(),
+                });
+            } else if arg.starts_with("-") {
+                match self.allowed_options.get(arg) {
+                    Some(opt) => match &opt.meta {
+                        OptMeta::Flag => {
+                            matched_flags.push(MatchedFlag { name: arg.clone() });
+                            continue;
+                        }
+                        OptMeta::Value(arg_type) => {
+                            expecting_option_value = Some((arg.clone(), arg_type.clone()));
+                            continue;
+                        }
+                    },
+                    None => {}
+                }
+
+                return Err(Error::UnknownOption {
+                    program: self.program.clone(),
+                    option: arg.clone(),
+                });
+            } else {
+                args.push(PositionalArg {
+                    index,
+                    value: arg.clone(),
+                });
+            }
+        }
+
+        if let Some(expected) = expecting_option_value {
+            let (name, _arg_type) = expected;
+            return Err(Error::OptionMissingValue {
+                program: self.program.clone(),
+                option: name,
+            });
+        }
+
+        let matched_args =
+            resolve_observed_args_with_patterns(&self.program, args, &self.arg_patterns)?;
+
+        let matched_opt_names: HashSet<String> = matched_opts
+            .iter()
+            .map(|opt| opt.name().to_string())
+            .collect();
+        if !matched_opt_names.is_superset(&self.required_options) {
+            let mut options = self
+                .required_options
+                .difference(&matched_opt_names)
+                .map(String::from)
+                .collect::<Vec<_>>();
+            options.sort();
+            return Err(Error::MissingRequiredOptions {
+                program: self.program.clone(),
+                options,
+            });
+        }
+
+        let exec = ValidExec {
+            program: self.program.clone(),
+            flags: matched_flags,
+            opts: matched_opts,
+            args: matched_args,
+            system_path: self.system_path.clone(),
+        };
+        match &self.forbidden {
+            Some(reason) => Ok(MatchedExec::Forbidden {
+                cause: Forbidden::Exec { exec },
+                reason: reason.clone(),
+            }),
+            None => Ok(MatchedExec::Match { exec }),
+        }
+    }
+
+    pub fn verify_should_match_list(&self) -> Vec<PositiveExampleFailedCheck> {
+        let mut violations = Vec::new();
+        for good in &self.should_match {
+            let exec_call = ExecCall {
+                program: self.program.clone(),
+                args: good.clone(),
+            };
+            match self.check(&exec_call) {
+                Ok(MatchedExec::Match { .. }) => {}
+                Ok(MatchedExec::Forbidden { reason, .. }) => violations
+                    .push(PositiveExampleFailedCheck::MatchedForbiddenRule { exec_call, reason }),
+                Err(error) => violations
+                    .push(PositiveExampleFailedCheck::RejectedExecCall { exec_call, error }),
+            }
+        }
+        violations
+    }
+
+    pub fn verify_should_not_match_list(&self) -> Vec<NegativeExamplePassedCheck> {
+        let mut violations = Vec::new();
+        for bad in &self.should_not_match {
+            let exec_call = ExecCall {
+                program: self.program.clone(),
+                args: bad.clone(),
+            };
+            match self.check(&exec_call) {
+                Ok(MatchedExec::Match { exec }) => {
+                    violations.push(NegativeExamplePassedCheck::Match { exec_call, exec })
+                }
+                Ok(MatchedExec::Forbidden { .. }) => {}
+                Err(error) => {
+                    violations.push(NegativeExamplePassedCheck::Error { exec_call, error })
+                }
+            }
+        }
+        violations
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub enum PositiveExampleFailedCheck {
+    MatchedForbiddenRule { exec_call: ExecCall, reason: String },
+    RejectedExecCall { exec_call: ExecCall, error: Error },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub enum NegativeExamplePassedCheck {
+    Match {
+        exec_call: ExecCall,
+        exec: ValidExec,
+    },
+    Error {
+        exec_call: ExecCall,
+        error: Error,
+    },
+}

--- a/vtcode-core/src/exec_policy/sed_command.rs
+++ b/vtcode-core/src/exec_policy/sed_command.rs
@@ -1,0 +1,15 @@
+use super::error::{Error, Result};
+
+pub fn parse_sed_command(sed_command: &str) -> Result<()> {
+    if let Some(stripped) = sed_command.strip_suffix("p")
+        && let Some((first, rest)) = stripped.split_once(",")
+        && first.parse::<u64>().is_ok()
+        && rest.parse::<u64>().is_ok()
+    {
+        return Ok(());
+    }
+
+    Err(Error::SedCommandNotProvablySafe {
+        command: sed_command.to_string(),
+    })
+}

--- a/vtcode-core/src/exec_policy/valid_exec.rs
+++ b/vtcode-core/src/exec_policy/valid_exec.rs
@@ -1,0 +1,83 @@
+use serde::Serialize;
+
+use super::arg_type::ArgType;
+use super::error::Result;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct ValidExec {
+    pub program: String,
+    pub flags: Vec<MatchedFlag>,
+    pub opts: Vec<MatchedOpt>,
+    pub args: Vec<MatchedArg>,
+    pub system_path: Vec<String>,
+}
+
+impl ValidExec {
+    pub fn new(program: &str, args: Vec<MatchedArg>, system_path: &[&str]) -> Self {
+        Self {
+            program: program.to_string(),
+            flags: vec![],
+            opts: vec![],
+            args,
+            system_path: system_path.iter().map(|&s| s.to_string()).collect(),
+        }
+    }
+
+    pub fn might_write_files(&self) -> bool {
+        self.opts.iter().any(|opt| opt.r#type.might_write_file())
+            || self.args.iter().any(|opt| opt.r#type.might_write_file())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MatchedArg {
+    pub index: usize,
+    pub r#type: ArgType,
+    pub value: String,
+}
+
+impl MatchedArg {
+    pub fn new(index: usize, r#type: ArgType, value: &str) -> Result<Self> {
+        r#type.validate(value)?;
+        Ok(Self {
+            index,
+            r#type,
+            value: value.to_string(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MatchedOpt {
+    pub name: String,
+    pub value: String,
+    pub r#type: ArgType,
+}
+
+impl MatchedOpt {
+    pub fn new(name: &str, value: &str, r#type: ArgType) -> Result<Self> {
+        r#type.validate(value)?;
+        Ok(Self {
+            name: name.to_string(),
+            value: value.to_string(),
+            r#type,
+        })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MatchedFlag {
+    pub name: String,
+}
+
+impl MatchedFlag {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+        }
+    }
+}

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -130,6 +130,7 @@ pub mod config;
 pub mod constants;
 pub mod core;
 pub mod exec;
+pub mod exec_policy;
 pub mod gemini;
 pub mod instructions;
 pub mod llm;


### PR DESCRIPTION
## Summary
- update exec policy modules to the latest Starlark APIs and derive the required traits
- wire the default execv checker through anyhow-aware error handling
- keep the new exec policy assets together with the command tool integration

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f3074be0908323a922a88f776421df