### PR TITLE
Integrate ansi-to-tui for inline ANSI rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,6 +4425,7 @@ dependencies = [
 name = "vtcode-core"
 version = "0.23.3"
 dependencies = [
+ "ansi-to-tui",
  "anstream",
  "anstyle",
  "anstyle-git",

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -103,6 +103,7 @@ similar = "2.4"
 rig = { package = "rig-core", version = "0.21", default-features = false, features = ["reqwest-rustls"] }
 tui-term = { version = "0.2.0", features = ["unstable"] }
 portable-pty = "0.9.0"
+ansi-to-tui = "7.0.0"
 
 # MCP (Model Context Protocol) support
 rmcp = { version = "0.7.0", features = [


### PR DESCRIPTION
## Summary
- add the ansi-to-tui dependency to vtcode-core
- convert ANSI rich strings into inline UI segments with ansi-to-tui so colors/styles are preserved
- add regression tests covering ANSI color handling and newline preservation

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets *(fails with pre-existing warnings throughout the workspace)*
- cargo check
- cargo test -p vtcode-core convert_plain_lines *(fails: vtcode-core tests rely on missing anyhow! macro and outdated MCP types)*

------
https://chatgpt.com/codex/tasks/task_e_68f307e6ff7083238db1069befd84e40