### PR TITLE
Add execution policy enforcement for command tool

### DIFF
--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -831,14 +831,9 @@ fn render_terminal_command_panel(
         .and_then(|value| value.as_bool())
         .unwrap_or(false);
     let exit_code = payload.get("exit_code").and_then(|value| value.as_i64());
-    let shell_label = if payload
-        .get("used_shell")
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false)
-    {
-        "Shell"
-    } else {
-        "Command"
+    let shell_label = match payload.get("mode").and_then(|value| value.as_str()) {
+        Some("pty") => "PTY",
+        _ => "Command",
     };
 
     let mut summary = format!(

--- a/src/agent/runloop/unified/shell.rs
+++ b/src/agent/runloop/unified/shell.rs
@@ -96,12 +96,13 @@ pub(crate) fn derive_recent_tool_output(history: &[uni::Message]) -> Option<Stri
         }
     }
 
-    if let Some(used_shell) = value.get("used_shell").and_then(|v| v.as_bool()) {
-        if used_shell {
-            if let Some(command) = value.get("command").and_then(|v| v.as_str()) {
-                output_parts.push(format!("Command executed: {}", command));
-            }
-        }
+    if let Some(command) = value
+        .get("command")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+    {
+        output_parts.push(format!("Command executed: {}", command));
     }
 
     if output_parts.is_empty() {

--- a/vtcode-core/src/execpolicy/mod.rs
+++ b/vtcode-core/src/execpolicy/mod.rs
@@ -1,0 +1,539 @@
+use std::env;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+
+/// Validate whether a command is allowed to run under the execution policy.
+///
+/// The policy is inspired by the Codex execution policy and limits commands to
+/// a curated allow-list with argument validation to prevent workspace
+/// breakout or destructive actions.
+pub fn validate_command(
+    command: &[String],
+    workspace_root: &Path,
+    working_dir: &Path,
+) -> Result<()> {
+    if command.is_empty() {
+        return Err(anyhow!("command cannot be empty"));
+    }
+
+    let program = command[0].as_str();
+    let args = &command[1..];
+
+    match program {
+        "ls" => validate_ls(args, workspace_root, working_dir),
+        "cat" => validate_cat(args, workspace_root, working_dir),
+        "cp" => validate_cp(args, workspace_root, working_dir),
+        "head" => validate_head(args, workspace_root, working_dir),
+        "printenv" => validate_printenv(args),
+        "pwd" => validate_pwd(args),
+        "rg" => validate_rg(args, workspace_root, working_dir),
+        "sed" => validate_sed(args, workspace_root, working_dir),
+        "which" => validate_which(args),
+        other => Err(anyhow!(
+            "command '{}' is not permitted by the execution policy",
+            other
+        )),
+    }
+}
+
+/// Normalize a working directory relative to the workspace root.
+pub fn sanitize_working_dir(workspace_root: &Path, working_dir: Option<&str>) -> Result<PathBuf> {
+    let normalized_root = normalize_workspace_root(workspace_root)?;
+    if let Some(dir) = working_dir {
+        if dir.trim().is_empty() {
+            return Ok(normalized_root);
+        }
+        let candidate = normalize_path(&normalized_root.join(dir));
+        if !candidate.starts_with(&normalized_root) {
+            return Err(anyhow!(
+                "working directory '{}' escapes the workspace root",
+                dir
+            ));
+        }
+        Ok(candidate)
+    } else {
+        Ok(normalized_root)
+    }
+}
+
+fn validate_ls(args: &[String], workspace_root: &Path, working_dir: &Path) -> Result<()> {
+    for arg in args {
+        match arg.as_str() {
+            "-1" | "-a" | "-l" => continue,
+            value if value.starts_with('-') => {
+                return Err(anyhow!("unsupported ls flag '{}'", value));
+            }
+            value => {
+                let path = resolve_path(workspace_root, working_dir, value)?;
+                ensure_path_exists(&path)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_cat(args: &[String], workspace_root: &Path, working_dir: &Path) -> Result<()> {
+    let mut files = Vec::new();
+    for arg in args {
+        match arg.as_str() {
+            "-b" | "-n" | "-t" => continue,
+            value if value.starts_with('-') => {
+                return Err(anyhow!("unsupported cat flag '{}'", value));
+            }
+            value => {
+                let path = resolve_path(workspace_root, working_dir, value)?;
+                ensure_is_file(&path)?;
+                files.push(path);
+            }
+        }
+    }
+
+    if files.is_empty() {
+        return Err(anyhow!("cat requires at least one readable file"));
+    }
+
+    Ok(())
+}
+
+fn validate_cp(args: &[String], workspace_root: &Path, working_dir: &Path) -> Result<()> {
+    let mut positional = Vec::new();
+    let mut allow_recursive = false;
+
+    for arg in args {
+        match arg.as_str() {
+            "-r" | "-R" | "--recursive" => {
+                allow_recursive = true;
+            }
+            value if value.starts_with('-') => {
+                return Err(anyhow!("unsupported cp flag '{}'", value));
+            }
+            value => positional.push(value.to_string()),
+        }
+    }
+
+    if positional.len() < 2 {
+        return Err(anyhow!("cp requires a source and destination"));
+    }
+
+    let dest_raw = positional.last().unwrap();
+    let sources = &positional[..positional.len() - 1];
+
+    for source in sources {
+        let path = resolve_path(workspace_root, working_dir, source)?;
+        let metadata = fs::metadata(&path)
+            .with_context(|| format!("failed to inspect source '{}'", source))?;
+        if metadata.is_dir() && !allow_recursive {
+            return Err(anyhow!(
+                "copying directories requires the recursive flag for '{}'",
+                source
+            ));
+        }
+        if !metadata.is_file() && !metadata.is_dir() {
+            return Err(anyhow!("unsupported source type for '{}'", source));
+        }
+    }
+
+    let dest_path = resolve_path_allow_new(workspace_root, working_dir, dest_raw)?;
+    if let Some(parent) = dest_path.parent() {
+        if !parent.exists() {
+            return Err(anyhow!(
+                "destination parent '{}' must exist",
+                parent.display()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_head(args: &[String], workspace_root: &Path, working_dir: &Path) -> Result<()> {
+    let mut positional = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let current = &args[index];
+        match current.as_str() {
+            "-c" | "-n" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| anyhow!("option '{}' requires a value", current))?;
+                parse_positive_int(value)
+                    .with_context(|| format!("invalid value '{}' for '{}'", value, current))?;
+                index += 2;
+            }
+            value if value.starts_with('-') => {
+                return Err(anyhow!("unsupported head flag '{}'", value));
+            }
+            value => {
+                positional.push(value);
+                index += 1;
+            }
+        }
+    }
+
+    if positional.is_empty() {
+        return Err(anyhow!("head requires at least one file"));
+    }
+
+    for file in positional {
+        let path = resolve_path(workspace_root, working_dir, file)?;
+        ensure_is_file(&path)?;
+    }
+
+    Ok(())
+}
+
+fn validate_printenv(args: &[String]) -> Result<()> {
+    match args.len() {
+        0 => Ok(()),
+        1 => {
+            let name = &args[0];
+            if name.is_empty()
+                || !name
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+            {
+                return Err(anyhow!("invalid environment variable name '{}'", name));
+            }
+            Ok(())
+        }
+        _ => Err(anyhow!("printenv accepts zero or one argument")),
+    }
+}
+
+fn validate_pwd(args: &[String]) -> Result<()> {
+    if args.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!("pwd does not accept arguments"))
+    }
+}
+
+fn validate_rg(args: &[String], workspace_root: &Path, working_dir: &Path) -> Result<()> {
+    let mut index = 0;
+    let mut allow_no_pattern = false;
+
+    while index < args.len() {
+        let current = &args[index];
+        if current == "--" {
+            index += 1;
+            break;
+        }
+
+        match current.as_str() {
+            "-A" | "-B" | "-C" | "-d" | "--max-depth" | "-m" | "--max-count" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| anyhow!("option '{}' requires a value", current))?;
+                parse_positive_int(value)
+                    .with_context(|| format!("invalid value '{}' for '{}'", value, current))?;
+                index += 2;
+            }
+            "-g" | "--glob" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| anyhow!("option '{}' requires a value", current))?;
+                if value.is_empty() {
+                    return Err(anyhow!("glob value for '{}' cannot be empty", current));
+                }
+                index += 2;
+            }
+            "-n" | "-i" | "-l" | "--files" | "--files-with-matches" | "--files-without-match" => {
+                if matches!(
+                    current.as_str(),
+                    "--files" | "--files-with-matches" | "--files-without-match"
+                ) {
+                    allow_no_pattern = true;
+                }
+                index += 1;
+            }
+            value if value.starts_with('-') => {
+                return Err(anyhow!("unsupported ripgrep flag '{}'", value));
+            }
+            _ => break,
+        }
+    }
+
+    let remaining = &args[index..];
+    if remaining.is_empty() && !allow_no_pattern {
+        return Err(anyhow!(
+            "ripgrep requires a pattern unless file listing flags are used"
+        ));
+    }
+
+    let mut rem_index = 0;
+    if !remaining.is_empty() {
+        let pattern = &remaining[0];
+        if pattern.is_empty() {
+            return Err(anyhow!("ripgrep pattern cannot be empty"));
+        }
+        rem_index = 1;
+    }
+
+    if remaining.len() > rem_index {
+        let search_root = &remaining[rem_index];
+        let path = resolve_path_allow_dir(workspace_root, working_dir, search_root)?;
+        if !path.exists() {
+            return Err(anyhow!("search path '{}' does not exist", search_root));
+        }
+        if remaining.len() > rem_index + 1 {
+            return Err(anyhow!("ripgrep accepts at most one search path"));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_sed(args: &[String], workspace_root: &Path, working_dir: &Path) -> Result<()> {
+    let mut commands = Vec::new();
+    let mut files = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let current = &args[index];
+        match current.as_str() {
+            "-n" | "-u" => {
+                index += 1;
+            }
+            "-e" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| anyhow!("-e requires a sed command"))?;
+                ensure_safe_sed_command(value)?;
+                commands.push(value.clone());
+                index += 2;
+            }
+            value if value.starts_with('-') => {
+                return Err(anyhow!("unsupported sed flag '{}'", value));
+            }
+            value => {
+                if commands.is_empty() {
+                    ensure_safe_sed_command(value)?;
+                    commands.push(value.to_string());
+                    index += 1;
+                } else {
+                    let path = resolve_path(workspace_root, working_dir, value)?;
+                    ensure_is_file(&path)?;
+                    files.push(path);
+                    index += 1;
+                }
+            }
+        }
+    }
+
+    if commands.is_empty() {
+        return Err(anyhow!("sed requires at least one command"));
+    }
+
+    if files.is_empty() {
+        return Err(anyhow!("sed requires at least one readable file"));
+    }
+
+    Ok(())
+}
+
+fn validate_which(args: &[String]) -> Result<()> {
+    if args.is_empty() {
+        return Err(anyhow!("which requires at least one program name"));
+    }
+
+    for arg in args {
+        match arg.as_str() {
+            "-a" | "-s" => continue,
+            value if value.starts_with('-') => {
+                return Err(anyhow!("unsupported which flag '{}'", value));
+            }
+            value => {
+                if value.is_empty()
+                    || value.contains('/')
+                    || value.chars().any(|ch| ch.is_whitespace())
+                {
+                    return Err(anyhow!(
+                        "program name '{}' contains unsupported characters",
+                        value
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_path(workspace_root: &Path, working_dir: &Path, value: &str) -> Result<PathBuf> {
+    let base = build_candidate_path(workspace_root, working_dir, value)?;
+    if !base.exists() {
+        return Err(anyhow!("path '{}' does not exist", value));
+    }
+    if !base.starts_with(workspace_root) {
+        return Err(anyhow!("path '{}' is outside the workspace root", value));
+    }
+    Ok(base)
+}
+
+fn resolve_path_allow_new(
+    workspace_root: &Path,
+    working_dir: &Path,
+    value: &str,
+) -> Result<PathBuf> {
+    let candidate = build_candidate_path(workspace_root, working_dir, value)?;
+    if !candidate.starts_with(workspace_root) {
+        return Err(anyhow!("path '{}' is outside the workspace root", value));
+    }
+    Ok(candidate)
+}
+
+fn resolve_path_allow_dir(
+    workspace_root: &Path,
+    working_dir: &Path,
+    value: &str,
+) -> Result<PathBuf> {
+    let candidate = build_candidate_path(workspace_root, working_dir, value)?;
+    if !candidate.starts_with(workspace_root) {
+        return Err(anyhow!("path '{}' is outside the workspace root", value));
+    }
+    Ok(candidate)
+}
+
+fn build_candidate_path(workspace_root: &Path, working_dir: &Path, value: &str) -> Result<PathBuf> {
+    let normalized_root = normalize_workspace_root(workspace_root)?;
+    let normalized_working = normalize_path(working_dir);
+    let raw_path = Path::new(value);
+    let candidate = if raw_path.is_absolute() {
+        normalize_path(raw_path)
+    } else {
+        normalize_path(&normalized_working.join(raw_path))
+    };
+
+    if !candidate.starts_with(&normalized_root) {
+        return Err(anyhow!("path '{}' escapes the workspace root", value));
+    }
+    Ok(candidate)
+}
+
+fn normalize_workspace_root(workspace_root: &Path) -> Result<PathBuf> {
+    if workspace_root.is_absolute() {
+        return Ok(normalize_path(workspace_root));
+    }
+
+    let cwd = env::current_dir().context("failed to resolve current working directory")?;
+    Ok(normalize_path(&cwd.join(workspace_root)))
+}
+
+fn ensure_path_exists(path: &Path) -> Result<()> {
+    if path.exists() {
+        Ok(())
+    } else {
+        Err(anyhow!("path '{}' does not exist", path.display()))
+    }
+}
+
+fn ensure_is_file(path: &Path) -> Result<()> {
+    let metadata =
+        fs::metadata(path).with_context(|| format!("failed to inspect '{}'", path.display()))?;
+    if metadata.is_file() {
+        Ok(())
+    } else {
+        Err(anyhow!("'{}' is not a file", path.display()))
+    }
+}
+
+fn parse_positive_int(value: &str) -> Result<u64> {
+    let parsed: u64 = value.parse()?;
+    if parsed == 0 {
+        return Err(anyhow!("value must be greater than zero"));
+    }
+    Ok(parsed)
+}
+
+fn ensure_safe_sed_command(value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(anyhow!("sed command cannot be empty"));
+    }
+    if value.contains([';', '|', '&', '`']) {
+        return Err(anyhow!(
+            "sed command contains unsupported control characters"
+        ));
+    }
+
+    let mut chars = value.chars();
+    if chars.next() != Some('s') {
+        return Err(anyhow!("only sed substitution commands are supported"));
+    }
+    let delimiter = chars
+        .next()
+        .ok_or_else(|| anyhow!("sed substitution is missing a delimiter"))?;
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_ascii_whitespace() {
+        return Err(anyhow!("invalid sed delimiter"));
+    }
+
+    let mut pattern = String::new();
+    let mut replacement = String::new();
+    let mut flags = String::new();
+
+    parse_sed_section(&mut chars, delimiter, &mut pattern)?;
+    parse_sed_section(&mut chars, delimiter, &mut replacement)?;
+    collect_sed_flags(chars, &mut flags)?;
+
+    if flags.chars().any(|ch| matches!(ch, 'e' | 'E' | 'F' | 'f')) {
+        return Err(anyhow!(
+            "sed execution flags are not permitted in substitution"
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_sed_section(
+    chars: &mut std::str::Chars<'_>,
+    delimiter: char,
+    target: &mut String,
+) -> Result<()> {
+    let mut escaped = false;
+    while let Some(ch) = chars.next() {
+        if escaped {
+            target.push(ch);
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => {
+                escaped = true;
+            }
+            value if value == delimiter => {
+                return Ok(());
+            }
+            other => target.push(other),
+        }
+    }
+    Err(anyhow!("sed command is missing a closing delimiter"))
+}
+
+fn collect_sed_flags(chars: std::str::Chars<'_>, target: &mut String) -> Result<()> {
+    for ch in chars {
+        if ch.is_ascii_alphabetic() {
+            target.push(ch);
+        } else {
+            return Err(anyhow!("sed flags contain unsupported characters"));
+        }
+    }
+    Ok(())
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -130,6 +130,7 @@ pub mod config;
 pub mod constants;
 pub mod core;
 pub mod exec;
+pub mod execpolicy;
 pub mod gemini;
 pub mod instructions;
 pub mod llm;

--- a/vtcode-core/src/tools/command.rs
+++ b/vtcode-core/src/tools/command.rs
@@ -3,19 +3,14 @@
 use super::traits::{ModeTool, Tool};
 use super::types::*;
 use crate::config::constants::tools;
+use crate::execpolicy::{sanitize_working_dir, validate_command};
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use serde_json::{Value, json};
-use shell_words::split;
-use std::{
-    env,
-    path::{Path, PathBuf},
-    process::Stdio,
-    time::Duration,
-};
+use std::{path::PathBuf, process::Stdio, time::Duration};
 use tokio::{process::Command, time::timeout};
 
-/// Command execution tool for non-PTY process handling with shell-aware quoting
+/// Command execution tool for non-PTY process handling with policy enforcement
 #[derive(Clone)]
 pub struct CommandTool {
     workspace_root: PathBuf,
@@ -23,7 +18,11 @@ pub struct CommandTool {
 
 impl CommandTool {
     pub fn new(workspace_root: PathBuf) -> Self {
-        Self { workspace_root }
+        let normalized_root =
+            sanitize_working_dir(&workspace_root, None).unwrap_or(workspace_root.clone());
+        Self {
+            workspace_root: normalized_root,
+        }
     }
 
     async fn execute_terminal_command(
@@ -34,11 +33,7 @@ impl CommandTool {
         let mut cmd = Command::new(&invocation.program);
         cmd.args(&invocation.args);
 
-        let work_dir = if let Some(ref working_dir) = input.working_dir {
-            self.workspace_root.join(working_dir)
-        } else {
-            self.workspace_root.clone()
-        };
+        let work_dir = sanitize_working_dir(&self.workspace_root, input.working_dir.as_deref())?;
 
         cmd.current_dir(work_dir);
         cmd.stdout(Stdio::piped());
@@ -66,7 +61,6 @@ impl CommandTool {
             "mode": "terminal",
             "pty_enabled": false,
             "command": invocation.display,
-            "used_shell": invocation.used_shell
         }))
     }
 
@@ -80,32 +74,21 @@ impl CommandTool {
 
         self.validate_command_segments(&input.command)?;
 
-        if let Some(invocation) = detect_explicit_shell(&input.command, &input.raw_command) {
-            self.validate_script(&invocation.display)?;
-            return Ok(invocation);
-        }
+        let working_dir = sanitize_working_dir(&self.workspace_root, input.working_dir.as_deref())?;
 
-        let shell = input
-            .shell
+        validate_command(&input.command, &self.workspace_root, &working_dir)?;
+
+        let program = input.command[0].clone();
+        let args = input.command[1..].to_vec();
+        let display = input
+            .raw_command
             .clone()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(default_shell);
-        let login = input.login.unwrap_or(true);
-        let script = if let Some(raw) = &input.raw_command {
-            raw.clone()
-        } else {
-            join_command_for_shell(&input.command, Some(shell.as_str()))
-        };
-
-        self.validate_script(&script)?;
-
-        let args = build_shell_arguments(&shell, login, &script);
+            .unwrap_or_else(|| format_command(&input.command));
 
         Ok(CommandInvocation {
-            program: shell,
+            program,
             args,
-            display: script,
-            used_shell: true,
+            display,
         })
     }
 
@@ -114,45 +97,22 @@ impl CommandTool {
             return Err(anyhow!("Command cannot be empty"));
         }
 
-        let raw_program = &command[0];
-        let canonical_program = if raw_program.chars().any(char::is_whitespace) {
-            match split(raw_program) {
-                Ok(parts) => parts
-                    .into_iter()
-                    .next()
-                    .unwrap_or_else(|| raw_program.clone()),
-                Err(_) => raw_program.clone(),
-            }
-        } else {
-            raw_program.clone()
-        };
+        let program = &command[0];
+        if program.chars().any(char::is_whitespace) {
+            return Err(anyhow!(
+                "Program name cannot contain whitespace: {}",
+                program
+            ));
+        }
 
         let dangerous_commands = ["rm", "rmdir", "del", "format", "fdisk", "mkfs", "dd"];
-        if dangerous_commands.contains(&canonical_program.as_str()) {
-            return Err(anyhow!(
-                "Dangerous command not allowed: {}",
-                canonical_program
-            ));
+        if dangerous_commands.contains(&program.as_str()) {
+            return Err(anyhow!("Dangerous command not allowed: {}", program));
         }
 
         let full_command = command.join(" ");
         if full_command.contains("rm -rf /") || full_command.contains("sudo rm") {
             return Err(anyhow!("Potentially dangerous command pattern detected"));
-        }
-
-        Ok(())
-    }
-
-    fn validate_script(&self, script: &str) -> Result<()> {
-        if script.contains("rm -rf /")
-            || script.contains("sudo rm")
-            || script.contains("format")
-            || script.contains("fdisk")
-            || script.contains("mkfs")
-        {
-            return Err(anyhow!(
-                "Potentially dangerous command pattern detected in shell command"
-            ));
         }
 
         Ok(())
@@ -202,53 +162,14 @@ pub(crate) struct CommandInvocation {
     pub(crate) program: String,
     pub(crate) args: Vec<String>,
     pub(crate) display: String,
-    pub(crate) used_shell: bool,
 }
 
-fn detect_explicit_shell(
-    command: &[String],
-    raw_command: &Option<String>,
-) -> Option<CommandInvocation> {
-    if command.is_empty() {
-        return None;
-    }
-
-    let program = &command[0];
-    if !is_shell_program(program) {
-        return None;
-    }
-
-    let args = command[1..].to_vec();
-    let display = raw_command
-        .clone()
-        .or_else(|| extract_shell_script(program, &args))
-        .unwrap_or_else(|| join_command_for_shell(command, Some(program.as_str())));
-
-    Some(CommandInvocation {
-        program: program.clone(),
-        args,
-        display,
-        used_shell: true,
-    })
-}
-
-fn join_command_for_shell(command: &[String], shell: Option<&str>) -> String {
-    let quoting = shell
-        .map(shell_quoting_style)
-        .unwrap_or(ShellQuotingStyle::Posix);
+fn format_command(command: &[String]) -> String {
     command
         .iter()
-        .map(|part| quote_argument(part, quoting))
+        .map(|part| quote_argument_posix(part))
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn quote_argument(arg: &str, style: ShellQuotingStyle) -> String {
-    match style {
-        ShellQuotingStyle::Cmd => quote_argument_cmd(arg),
-        ShellQuotingStyle::PowerShell => quote_argument_powershell(arg),
-        ShellQuotingStyle::Posix => quote_argument_posix(arg),
-    }
 }
 
 fn quote_argument_posix(arg: &str) -> String {
@@ -275,311 +196,70 @@ fn quote_argument_posix(arg: &str) -> String {
     quoted
 }
 
-fn quote_argument_powershell(arg: &str) -> String {
-    if arg.is_empty() {
-        return "''".to_string();
-    }
-
-    if arg
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || "-_./:@".contains(ch))
-    {
-        return arg.to_string();
-    }
-
-    let escaped = arg.replace('\'', "''");
-    format!("'{}'", escaped)
-}
-
-fn quote_argument_cmd(arg: &str) -> String {
-    if arg.is_empty() {
-        return String::from("\"\"");
-    }
-
-    let mut escaped = String::new();
-    let mut needs_quotes = false;
-
-    for ch in arg.chars() {
-        match ch {
-            '"' => {
-                needs_quotes = true;
-                escaped.push('\\');
-                escaped.push('"');
-            }
-            '^' => {
-                needs_quotes = true;
-                escaped.push('^');
-                escaped.push('^');
-            }
-            '&' | '|' | '<' | '>' | '(' | ')' => {
-                needs_quotes = true;
-                escaped.push('^');
-                escaped.push(ch);
-            }
-            '%' => {
-                needs_quotes = true;
-                escaped.push('%');
-                escaped.push('%');
-            }
-            ' ' | '\t' => {
-                needs_quotes = true;
-                escaped.push(ch);
-            }
-            _ => escaped.push(ch),
-        }
-    }
-
-    if needs_quotes {
-        let trailing_backslashes = escaped.chars().rev().take_while(|&ch| ch == '\\').count();
-        let mut quoted = escaped;
-        for _ in 0..trailing_backslashes {
-            quoted.push('\\');
-        }
-        format!("\"{}\"", quoted)
-    } else {
-        escaped
-    }
-}
-
-fn shell_quoting_style(shell: &str) -> ShellQuotingStyle {
-    match shell_program_name(shell).as_str() {
-        "cmd" | "cmd.exe" => ShellQuotingStyle::Cmd,
-        "pwsh" | "powershell" | "powershell.exe" => ShellQuotingStyle::PowerShell,
-        _ => ShellQuotingStyle::Posix,
-    }
-}
-
-#[derive(Copy, Clone)]
-enum ShellQuotingStyle {
-    Posix,
-    Cmd,
-    PowerShell,
-}
-
-fn extract_shell_script(program: &str, args: &[String]) -> Option<String> {
-    let name = shell_program_name(program);
-    match name.as_str() {
-        "sh" | "bash" | "zsh" | "ksh" | "dash" | "fish" => {
-            if args.len() >= 2 && matches!(args[0].as_str(), "-c" | "-lc") {
-                Some(args[1].clone())
-            } else {
-                None
-            }
-        }
-        "pwsh" | "powershell" | "powershell.exe" => {
-            let mut iter = args.iter();
-            while let Some(arg) = iter.next() {
-                if arg.eq_ignore_ascii_case("-command") || arg.eq_ignore_ascii_case("-c") {
-                    return iter.next().cloned();
-                }
-            }
-            None
-        }
-        "cmd" | "cmd.exe" => {
-            let mut iter = args.iter();
-            while let Some(arg) = iter.next() {
-                if arg.eq_ignore_ascii_case("/c") {
-                    return iter.next().cloned();
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-fn build_shell_arguments(shell: &str, login: bool, script: &str) -> Vec<String> {
-    let name = shell_program_name(shell);
-    match name.as_str() {
-        "cmd" | "cmd.exe" => vec!["/C".to_string(), script.to_string()],
-        "pwsh" | "powershell" | "powershell.exe" => {
-            let mut args = Vec::new();
-            if login {
-                args.push("-NoProfile".to_string());
-            }
-            args.push("-Command".to_string());
-            args.push(script.to_string());
-            args
-        }
-        _ => {
-            let flag = if login { "-lc" } else { "-c" };
-            vec![flag.to_string(), script.to_string()]
-        }
-    }
-}
-
-fn is_shell_program(program: &str) -> bool {
-    matches!(
-        shell_program_name(program).as_str(),
-        "sh" | "bash"
-            | "zsh"
-            | "dash"
-            | "ksh"
-            | "fish"
-            | "pwsh"
-            | "powershell"
-            | "powershell.exe"
-            | "cmd"
-            | "cmd.exe"
-    )
-}
-
-fn shell_program_name(program: &str) -> String {
-    Path::new(program)
-        .file_name()
-        .and_then(|value| value.to_str())
-        .unwrap_or(program)
-        .to_ascii_lowercase()
-}
-
-fn default_shell() -> String {
-    if let Ok(shell) = env::var("SHELL") {
-        if !shell.trim().is_empty() {
-            return shell;
-        }
-    }
-
-    if let Ok(comspec) = env::var("COMSPEC") {
-        if !comspec.trim().is_empty() {
-            return comspec;
-        }
-    }
-
-    if cfg!(windows) {
-        return "cmd.exe".to_string();
-    }
-
-    let fallback_shells = ["/bin/bash", "/usr/bin/bash", "/bin/sh"];
-    for candidate in fallback_shells {
-        if Path::new(candidate).exists() {
-            return candidate.to_string();
-        }
-    }
-
-    "sh".to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn make_tool() -> CommandTool {
-        CommandTool::new(PathBuf::from("."))
+        let cwd = std::env::current_dir().expect("current dir");
+        CommandTool::new(cwd)
     }
 
-    #[test]
-    fn quotes_arguments_for_posix_shell() {
-        assert_eq!(quote_argument_posix("simple"), "simple");
-        assert_eq!(quote_argument_posix("needs space"), "'needs space'");
-        assert_eq!(quote_argument_posix("quote'inner"), r#"'quote'"'"'inner'"#);
-    }
-
-    #[test]
-    fn quotes_arguments_for_powershell_shell() {
-        assert_eq!(quote_argument_powershell("simple"), "simple");
-        assert_eq!(
-            quote_argument_powershell("value with space"),
-            "'value with space'"
-        );
-        assert_eq!(quote_argument_powershell("O'Reilly"), "'O''Reilly'");
-    }
-
-    #[test]
-    fn quotes_arguments_for_cmd_shell() {
-        assert_eq!(quote_argument_cmd("simple"), "simple");
-        assert_eq!(quote_argument_cmd("needs space"), r#""needs space""#);
-        assert_eq!(
-            quote_argument_cmd("x & del important"),
-            r#""x ^& del important""#
-        );
-        assert_eq!(quote_argument_cmd("%TEMP%"), "%TEMP%");
-        assert_eq!(
-            quote_argument_cmd(r"C:\\Program Files\\"),
-            "\"C:\\Program Files\\\\\""
-        );
-    }
-
-    #[test]
-    fn joins_command_for_posix_shell_execution() {
-        let parts = vec!["echo".to_string(), "hello world".to_string()];
-        assert_eq!(
-            join_command_for_shell(&parts, Some("/bin/bash")),
-            "echo 'hello world'"
-        );
-    }
-
-    #[test]
-    fn joins_command_for_cmd_shell_execution() {
-        let parts = vec!["echo".to_string(), "x & del important".to_string()];
-        assert_eq!(
-            join_command_for_shell(&parts, Some("cmd.exe")),
-            r#"echo "x ^& del important""#
-        );
-    }
-
-    #[test]
-    fn joins_command_for_cmd_preserves_trailing_backslash() {
-        let parts = vec!["dir".to_string(), r"C:\\Program Files\\".to_string()];
-        assert_eq!(
-            join_command_for_shell(&parts, Some("cmd.exe")),
-            "dir \"C:\\Program Files\\\\\""
-        );
-    }
-
-    #[test]
-    fn joins_command_for_powershell_execution() {
-        let parts = vec!["Write-Output".to_string(), "O'Reilly".to_string()];
-        assert_eq!(
-            join_command_for_shell(&parts, Some("pwsh")),
-            "Write-Output 'O''Reilly'"
-        );
-    }
-
-    #[test]
-    fn detects_explicit_bash_script() {
-        let args = vec!["bash".to_string(), "-lc".to_string(), "ls".to_string()];
-        let invocation = detect_explicit_shell(&args, &None).expect("shell invocation");
-        assert_eq!(invocation.program, "bash");
-        assert_eq!(invocation.args, vec!["-lc".to_string(), "ls".to_string()]);
-        assert_eq!(invocation.display, "ls");
-    }
-
-    #[test]
-    fn prepare_invocation_wraps_non_shell_commands() {
-        let tool = make_tool();
-        let input = EnhancedTerminalInput {
-            command: vec!["cargo".into(), "test".into()],
+    fn make_input(command: Vec<&str>) -> EnhancedTerminalInput {
+        EnhancedTerminalInput {
+            command: command.into_iter().map(String::from).collect(),
             working_dir: None,
             timeout_secs: None,
             mode: None,
             response_format: None,
             raw_command: None,
-            shell: Some("/bin/bash".into()),
-            login: Some(true),
-        };
-        let invocation = tool.prepare_invocation(&input).expect("invocation");
-        assert_eq!(invocation.program, "/bin/bash");
-        assert_eq!(invocation.args[0], "-lc");
-        assert_eq!(invocation.display, "cargo test");
+            shell: None,
+            login: None,
+        }
     }
 
     #[test]
-    fn rejects_dangerous_command_even_with_whitespace_program() {
-        let tool = make_tool();
-        let input = EnhancedTerminalInput {
-            command: vec!["rm -rf".into()],
-            working_dir: None,
-            timeout_secs: None,
-            mode: None,
-            response_format: None,
-            raw_command: Some("rm -rf /".into()),
-            shell: Some("/bin/bash".into()),
-            login: Some(true),
-        };
+    fn formats_command_for_display() {
+        let parts = vec!["echo".to_string(), "hello world".to_string()];
+        assert_eq!(format_command(&parts), "echo 'hello world'");
+    }
 
+    #[test]
+    fn prepare_invocation_allows_policy_command() {
+        let tool = make_tool();
+        let input = make_input(vec!["ls"]);
+        let invocation = tool.prepare_invocation(&input).expect("invocation");
+        assert_eq!(invocation.program, "ls");
+        assert!(invocation.args.is_empty());
+        assert_eq!(invocation.display, "ls");
+    }
+
+    #[test]
+    fn prepare_invocation_rejects_disallowed_command() {
+        let tool = make_tool();
+        let input = make_input(vec!["cargo", "test"]);
         let error = tool
             .prepare_invocation(&input)
-            .expect_err("dangerous command should be rejected");
-        assert!(error.to_string().contains("Dangerous command"));
+            .expect_err("cargo should be blocked");
+        assert!(
+            error
+                .to_string()
+                .contains("is not permitted by the execution policy")
+        );
+    }
+
+    #[test]
+    fn working_dir_escape_is_rejected() {
+        let tool = make_tool();
+        let mut input = make_input(vec!["ls"]);
+        input.working_dir = Some("../".into());
+        let error = tool
+            .prepare_invocation(&input)
+            .expect_err("working dir escape should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("working directory '../' escapes the workspace root")
+        );
     }
 }

--- a/vtcode-core/src/tools/registry/executors.rs
+++ b/vtcode-core/src/tools/registry/executors.rs
@@ -335,7 +335,6 @@ impl ToolRegistry {
             "mode": mode,
             "pty_enabled": true,
             "command": invocation.display,
-            "used_shell": invocation.used_shell,
             "working_directory": working_directory,
             "timeout_secs": timeout_secs,
             "duration_ms": result.duration.as_millis(),


### PR DESCRIPTION
## Summary
- add an exec policy module to allowlist safe commands and validate arguments using Codex-style checks
- update the terminal command tool to enforce the policy, sanitize working directories, and adjust tests
- remove shell-specific metadata from command outputs and update renderers accordingly

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f3218af9dc8323b32bc3915d7c2dd8