### PR TITLE
Add OpenRouter free model entries

### DIFF
--- a/docs/models.json
+++ b/docs/models.json
@@ -577,6 +577,26 @@
           "output": 1.9e-06
         }
       },
+      "moonshotai/kimi-k2:free": {
+        "id": "moonshotai/kimi-k2:free",
+        "name": "MoonshotAI: Kimi K2 (free)",
+        "reasoning": false,
+        "tool_call": false,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 262144,
+        "max_output_tokens": null,
+        "cost": {
+          "input": 0.0,
+          "output": 0.0
+        }
+      },
       "qwen/qwen3-max": {
         "id": "qwen/qwen3-max",
         "name": "Qwen: Qwen3 Max",
@@ -1076,6 +1096,7 @@
           "input": 4e-07,
           "output": 2e-06
         }
+      },
       "deepseek/deepseek-chat-v3.1:free": {
         "id": "deepseek/deepseek-chat-v3.1:free",
         "name": "DeepSeek: DeepSeek V3.1 (free)",
@@ -1090,6 +1111,26 @@
           ]
         },
         "context": 163840,
+        "max_output_tokens": null,
+        "cost": {
+          "input": 0.0,
+          "output": 0.0
+        }
+      },
+      "nvidia/nemotron-nano-9b-v2:free": {
+        "id": "nvidia/nemotron-nano-9b-v2:free",
+        "name": "NVIDIA: Nemotron Nano 9B v2 (free)",
+        "reasoning": false,
+        "tool_call": false,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072,
         "max_output_tokens": null,
         "cost": {
           "input": 0.0,

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -104,6 +104,7 @@ pub mod models {
         pub const Z_AI_GLM_4_5_AIR_FREE: &str = "z-ai/glm-4.5-air:free";
         pub const Z_AI_GLM_4_6: &str = "z-ai/glm-4.6";
         pub const MOONSHOTAI_KIMI_K2_0905: &str = "moonshotai/kimi-k2-0905";
+        pub const MOONSHOTAI_KIMI_K2_FREE: &str = "moonshotai/kimi-k2:free";
         pub const QWEN3_MAX: &str = "qwen/qwen3-max";
         pub const QWEN3_235B_A22B: &str = "qwen/qwen3-235b-a22b";
         pub const QWEN3_235B_A22B_FREE: &str = "qwen/qwen3-235b-a22b:free";
@@ -130,6 +131,7 @@ pub mod models {
         pub const DEEPSEEK_DEEPSEEK_CHAT_V3_1: &str = "deepseek/deepseek-chat-v3.1";
         pub const DEEPSEEK_DEEPSEEK_CHAT_V3_1_FREE: &str = "deepseek/deepseek-chat-v3.1:free";
         pub const DEEPSEEK_DEEPSEEK_R1: &str = "deepseek/deepseek-r1";
+        pub const NVIDIA_NEMOTRON_NANO_9B_V2_FREE: &str = "nvidia/nemotron-nano-9b-v2:free";
         pub const OPENAI_GPT_OSS_120B: &str = "openai/gpt-oss-120b";
         pub const OPENAI_GPT_OSS_20B: &str = "openai/gpt-oss-20b";
         pub const OPENAI_GPT_OSS_20B_FREE: &str = "openai/gpt-oss-20b:free";
@@ -151,6 +153,7 @@ pub mod models {
             Z_AI_GLM_4_5_AIR_FREE,
             Z_AI_GLM_4_6,
             MOONSHOTAI_KIMI_K2_0905,
+            MOONSHOTAI_KIMI_K2_FREE,
             QWEN3_MAX,
             QWEN3_235B_A22B,
             QWEN3_235B_A22B_FREE,
@@ -173,6 +176,7 @@ pub mod models {
             DEEPSEEK_DEEPSEEK_CHAT_V3_1,
             DEEPSEEK_DEEPSEEK_CHAT_V3_1_FREE,
             DEEPSEEK_DEEPSEEK_R1,
+            NVIDIA_NEMOTRON_NANO_9B_V2_FREE,
             OPENAI_GPT_OSS_120B,
             OPENAI_GPT_OSS_20B,
             OPENAI_GPT_5,
@@ -221,6 +225,8 @@ pub mod models {
             OPENAI_GPT_4O_SEARCH_PREVIEW,
             OPENAI_GPT_4O_MINI_SEARCH_PREVIEW,
             OPENAI_CHATGPT_4O_LATEST,
+            MOONSHOTAI_KIMI_K2_FREE,
+            NVIDIA_NEMOTRON_NANO_9B_V2_FREE,
         ];
     }
 
@@ -306,6 +312,7 @@ pub mod models {
     pub const OPENROUTER_Z_AI_GLM_4_5_AIR_FREE: &str = openrouter::Z_AI_GLM_4_5_AIR_FREE;
     pub const OPENROUTER_Z_AI_GLM_4_6: &str = openrouter::Z_AI_GLM_4_6;
     pub const OPENROUTER_MOONSHOTAI_KIMI_K2_0905: &str = openrouter::MOONSHOTAI_KIMI_K2_0905;
+    pub const OPENROUTER_MOONSHOTAI_KIMI_K2_FREE: &str = openrouter::MOONSHOTAI_KIMI_K2_FREE;
     pub const OPENROUTER_QWEN3_MAX: &str = openrouter::QWEN3_MAX;
     pub const OPENROUTER_QWEN3_235B_A22B: &str = openrouter::QWEN3_235B_A22B;
     pub const OPENROUTER_QWEN3_235B_A22B_FREE: &str = openrouter::QWEN3_235B_A22B_FREE;
@@ -339,6 +346,8 @@ pub mod models {
     pub const OPENROUTER_DEEPSEEK_CHAT_V3_1_FREE: &str =
         openrouter::DEEPSEEK_DEEPSEEK_CHAT_V3_1_FREE;
     pub const OPENROUTER_DEEPSEEK_R1: &str = openrouter::DEEPSEEK_DEEPSEEK_R1;
+    pub const OPENROUTER_NVIDIA_NEMOTRON_NANO_9B_V2_FREE: &str =
+        openrouter::NVIDIA_NEMOTRON_NANO_9B_V2_FREE;
     pub const OPENROUTER_OPENAI_GPT_OSS_120B: &str = openrouter::OPENAI_GPT_OSS_120B;
     pub const OPENROUTER_OPENAI_GPT_OSS_20B: &str = openrouter::OPENAI_GPT_OSS_20B;
     pub const OPENROUTER_OPENAI_GPT_OSS_20B_FREE: &str = openrouter::OPENAI_GPT_OSS_20B_FREE;

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -27,6 +27,7 @@ macro_rules! each_openrouter_variant {
             (OpenRouterZaiGlm45AirFree, OPENROUTER_Z_AI_GLM_4_5_AIR_FREE, "GLM 4.5 Air (free)", "Community tier for Z.AI GLM 4.5 Air", false, false, "GLM-4.5"),
             (OpenRouterZaiGlm46, OPENROUTER_Z_AI_GLM_4_6, "GLM 4.6", "Z.AI GLM 4.6 long-context reasoning model", false, true, "GLM-4.6"),
             (OpenRouterMoonshotaiKimiK20905, OPENROUTER_MOONSHOTAI_KIMI_K2_0905, "Kimi K2 0905", "MoonshotAI Kimi K2 0905 MoE release optimised for coding agents", false, true, "K2-0905"),
+            (OpenRouterMoonshotaiKimiK2Free, OPENROUTER_MOONSHOTAI_KIMI_K2_FREE, "Kimi K2 (free)", "Community tier for MoonshotAI Kimi K2", false, false, "K2"),
             (OpenRouterQwen3Max, OPENROUTER_QWEN3_MAX, "Qwen3 Max", "Flagship Qwen3 mixture for general reasoning", false, true, "Qwen3"),
             (OpenRouterQwen3235bA22b, OPENROUTER_QWEN3_235B_A22B, "Qwen3 235B A22B", "Mixture-of-experts Qwen3 235B general model", false, true, "Qwen3"),
             (OpenRouterQwen3235bA22bFree, OPENROUTER_QWEN3_235B_A22B_FREE, "Qwen3 235B A22B (free)", "Community tier for Qwen3 235B A22B", false, true, "Qwen3"),
@@ -51,7 +52,9 @@ macro_rules! each_openrouter_variant {
             (OpenRouterQwen3Coder30bA3bInstruct, OPENROUTER_QWEN3_CODER_30B_A3B_INSTRUCT, "Qwen3 Coder 30B A3B Instruct", "Large Mixture-of-Experts coding deployment", false, true, "Qwen3-Coder"),
             (OpenRouterDeepSeekV32Exp, OPENROUTER_DEEPSEEK_V3_2_EXP, "DeepSeek V3.2 Exp", "Experimental DeepSeek V3.2 listing", false, true, "V3.2-Exp"),
             (OpenRouterDeepSeekChatV31, OPENROUTER_DEEPSEEK_CHAT_V3_1, "DeepSeek Chat v3.1", "Advanced DeepSeek model via OpenRouter", false, true, "2025-08-21"),
+            (OpenRouterDeepSeekChatV31Free, OPENROUTER_DEEPSEEK_CHAT_V3_1_FREE, "DeepSeek Chat v3.1 (free)", "Community tier for DeepSeek Chat v3.1", false, false, "2025-08-21"),
             (OpenRouterDeepSeekR1, OPENROUTER_DEEPSEEK_R1, "DeepSeek R1", "DeepSeek R1 reasoning model with chain-of-thought", false, true, "2025-01-20"),
+            (OpenRouterNvidiaNemotronNano9bV2Free, OPENROUTER_NVIDIA_NEMOTRON_NANO_9B_V2_FREE, "Nemotron Nano 9B v2 (free)", "NVIDIA Nemotron Nano 9B v2 community tier", true, false, "Nemotron-9B"),
             (OpenRouterOpenAIGptOss120b, OPENROUTER_OPENAI_GPT_OSS_120B, "OpenAI gpt-oss-120b", "Open-weight 120B reasoning model via OpenRouter", false, true, "OSS-120B"),
             (OpenRouterOpenAIGptOss20b, OPENROUTER_OPENAI_GPT_OSS_20B, "OpenAI gpt-oss-20b", "Open-weight 20B deployment via OpenRouter", false, false, "OSS-20B"),
             (OpenRouterOpenAIGptOss20bFree, OPENROUTER_OPENAI_GPT_OSS_20B_FREE, "OpenAI gpt-oss-20b (free)", "Community tier for OpenAI gpt-oss-20b", false, false, "OSS-20B"),
@@ -294,6 +297,8 @@ pub enum ModelId {
     OpenRouterZaiGlm46,
     /// MoonshotAI Kimi K2 0905 - Latest MoE update via OpenRouter
     OpenRouterMoonshotaiKimiK20905,
+    /// MoonshotAI Kimi K2 (free tier) - Community access listing
+    OpenRouterMoonshotaiKimiK2Free,
     /// Qwen3 Max - Flagship Qwen3 deployment via OpenRouter
     OpenRouterQwen3Max,
     /// Qwen3 235B A22B - General Qwen3 expert mixture
@@ -342,8 +347,12 @@ pub enum ModelId {
     OpenRouterDeepSeekV32Exp,
     /// DeepSeek Chat v3.1 - Advanced DeepSeek model via OpenRouter
     OpenRouterDeepSeekChatV31,
+    /// DeepSeek Chat v3.1 (free tier) - Community access listing
+    OpenRouterDeepSeekChatV31Free,
     /// DeepSeek R1 - Reasoning model via OpenRouter
     OpenRouterDeepSeekR1,
+    /// NVIDIA Nemotron Nano 9B v2 (free tier) via OpenRouter
+    OpenRouterNvidiaNemotronNano9bV2Free,
     /// OpenAI gpt-oss-120b via OpenRouter
     OpenRouterOpenAIGptOss120b,
     /// OpenAI gpt-oss-20b via OpenRouter


### PR DESCRIPTION
## Summary
- add new OpenRouter free models to the shared constants and model metadata
- document the new OpenRouter listings in `docs/models.json` so they surface in the model picker

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f3697a09408323a2689c4d03623594