### PR TITLE
Prevent repeated tool loops and streamline reasoning render

### DIFF
--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -489,6 +489,7 @@ pub mod defaults {
     pub const DEFAULT_THEME: &str = "ciapre-dark";
     pub const DEFAULT_FULL_AUTO_MAX_TURNS: usize = 30;
     pub const DEFAULT_MAX_TOOL_LOOPS: usize = 100;
+    pub const DEFAULT_MAX_REPEATED_TOOL_CALLS: usize = 3;
     pub const ANTHROPIC_DEFAULT_MAX_TOKENS: u32 = 4_096;
     pub const DEFAULT_PTY_STDOUT_TAIL_LINES: usize = 20;
     pub const DEFAULT_PTY_SCROLLBACK_LINES: usize = 400;

--- a/vtcode-core/src/config/core/tools.rs
+++ b/vtcode-core/src/config/core/tools.rs
@@ -22,6 +22,11 @@ pub struct ToolsConfig {
     ///
     #[serde(default = "default_max_tool_loops")]
     pub max_tool_loops: usize,
+
+    /// Maximum number of times the same tool invocation can be retried with the
+    /// identical arguments within a single turn.
+    #[serde(default = "default_max_repeated_tool_calls")]
+    pub max_repeated_tool_calls: usize,
 }
 
 impl Default for ToolsConfig {
@@ -51,6 +56,7 @@ impl Default for ToolsConfig {
             default_policy: default_tool_policy(),
             policies,
             max_tool_loops: default_max_tool_loops(),
+            max_repeated_tool_calls: default_max_repeated_tool_calls(),
         }
     }
 }
@@ -73,4 +79,8 @@ fn default_tool_policy() -> ToolPolicy {
 
 fn default_max_tool_loops() -> usize {
     defaults::DEFAULT_MAX_TOOL_LOOPS
+}
+
+fn default_max_repeated_tool_calls() -> usize {
+    defaults::DEFAULT_MAX_REPEATED_TOOL_CALLS
 }


### PR DESCRIPTION
## Summary
- rate-limit inline reasoning updates so large reasoning traces no longer hang the inline TUI renderer
- add a safeguard that stops repeated tool invocations after a configurable number of identical attempts and informs the user
- expose the new `tools.max_repeated_tool_calls` setting with a sensible default in the shared configuration constants

## Testing
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f37022b7e08323bbe9888f43072cf4