### PR TITLE
Add crate category hashtags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![crates.io](https://img.shields.io/crates/v/vtcode.svg?style=for-the-badge&label=crates.io&logo=rust)](https://crates.io/crates/vtcode) [![docs.rs](https://img.shields.io/docsrs/vtcode.svg?style=for-the-badge&label=docs.rs&logo=docsdotrs)](https://docs.rs/vtcode) [![npm](https://img.shields.io/npm/v/vtcode.svg?style=for-the-badge&label=npm&logo=npm)](https://www.npmjs.com/package/vtcode)
 
-[#development-tools](https://crates.io/categories/development-tools) [#command-line-utilities](https://crates.io/categories/command-line-utilities)
-
 ---
 
 `cargo install vtcode`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![crates.io](https://img.shields.io/crates/v/vtcode.svg?style=for-the-badge&label=crates.io&logo=rust)](https://crates.io/crates/vtcode) [![docs.rs](https://img.shields.io/docsrs/vtcode.svg?style=for-the-badge&label=docs.rs&logo=docsdotrs)](https://docs.rs/vtcode) [![npm](https://img.shields.io/npm/v/vtcode.svg?style=for-the-badge&label=npm&logo=npm)](https://www.npmjs.com/package/vtcode)
 
+[#development-tools](https://crates.io/categories/development-tools) [#command-line-utilities](https://crates.io/categories/command-line-utilities)
+
 ---
 
 `cargo install vtcode`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,14 @@
 //! - **Homebrew**: `brew install vinhnx/tap/vtcode`
 //! - **GitHub Releases**: pre-built binaries for macOS, Linux, and Windows
 //!
+//! ## crates.io Categories
+//!
+//! This crate is listed under the following crates.io categories to improve
+//! discoverability for terminal-focused developer tooling:
+//!
+//! - [`#development-tools`](https://crates.io/categories/development-tools)
+//! - [`#command-line-utilities`](https://crates.io/categories/command-line-utilities)
+//!
 //! ## Library Usage Examples
 //!
 //! ### Starting an Agent Programmatically


### PR DESCRIPTION
## Summary
- add linked hashtags to the README pointing to the crate's development tools and command-line utilities categories on crates.io

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f37d47612483238fcc8ea9179efef0