### PR TITLE
Enhance slash palette search ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,7 +2420,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/docs/project_analysis.md
+++ b/docs/project_analysis.md
@@ -69,9 +69,13 @@
 
 ## Refactoring TODO Checklist
 - [ ] Establish interface layer in `vtcode-core` for turn driving, UI sessions, and ACP adapters, ensuring responsibilities are documented and enforced by module boundaries.【F:vtcode-core/src/core/agent/runner.rs†L1-L170】【F:src/agent/runloop/unified/turn.rs†L1-L200】
-- [ ] Capture regression tests for existing UI behaviors (fuzzy search, modal transitions) prior to moving code to new modules.【F:vtcode-core/src/ui/tui/session.rs†L1-L160】
-- [ ] Extract modal and list management into `ui/tui/modal.rs` and related helpers, leaving `session.rs` as a coordinator over composed components.【F:vtcode-core/src/ui/tui/session.rs†L37-L140】
-- [ ] Introduce a command palette/search module with isolated filtering/highlighting logic and dedicated unit tests.
+- [x] Capture regression tests for existing UI behaviors (fuzzy search, modal transitions) prior to moving code to new modules.【F:vtcode-core/src/ui/tui/session.rs†L1-L160】
+- [x] Extract modal and list management into `ui/tui/modal.rs` and related helpers, leaving `session.rs` as a coordinator over composed components.【F:vtcode-core/src/ui/tui/session.rs†L37-L140】
+- [x] Introduce a command palette/search module with isolated filtering/highlighting logic and dedicated unit tests.
+    - Implemented the slash palette state machine with prefix-aware highlighting and wraparound navigation tests, letting the session delegate rendering and suggestion updates to the shared helper.
+    - Centralized slash command prefix and range parsing inside the palette helper so the session reuses the shared utilities, backed by unit tests for cursor edge cases.
+    - Extended the shared slash palette to drive paging and home/end navigation shortcuts, ensuring the session defers all keyboard handling to the helper with dedicated coverage.
+    - Introduced shared fuzzy search utilities and richer slash command ranking so palette suggestions stay relevant for substring and keyword matches beyond simple prefixes.
 - [ ] Split unified turn loop into state management, UI interaction, and tool routing submodules with clear API boundaries.【F:src/agent/runloop/unified/turn.rs†L1-L200】
 - [ ] Relocate context pruning and summarization workflows into an `agent/runloop/context_manager.rs` service and integrate asynchronous pipelines for tool execution results.【F:src/agent/runloop/unified/turn.rs†L54-L75】
 - [ ] Decompose `src/acp/zed.rs` into reusable configuration gating, permission handling, and workspace trust components with mockable interfaces for testing.【F:src/acp/zed.rs†L40-L121】

--- a/vtcode-core/src/core/token_budget.rs
+++ b/vtcode-core/src/core/token_budget.rs
@@ -480,8 +480,7 @@ fn load_tokenizer_from_spec(spec: &TokenizerSpec) -> Result<Tokenizer> {
             if let Some(rev) = revision {
                 warn!(
                     "Tokenizer revision override '{}' is not supported; using default revision for '{}'",
-                    rev,
-                    id
+                    rev, id
                 );
             }
             Tokenizer::from_pretrained(id, None)

--- a/vtcode-core/src/ui/mod.rs
+++ b/vtcode-core/src/ui/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod diff_renderer;
 pub mod markdown;
+pub mod search;
 pub mod slash;
 pub mod styled;
 pub mod terminal;
@@ -13,6 +14,7 @@ pub mod tui;
 pub mod user_confirmation;
 
 pub use markdown::*;
+pub use search::*;
 pub use slash::*;
 pub use styled::*;
 pub use terminal::*;

--- a/vtcode-core/src/ui/search.rs
+++ b/vtcode-core/src/ui/search.rs
@@ -1,0 +1,90 @@
+/// Normalizes a user-provided query by trimming whitespace, collapsing internal
+/// spaces, and converting everything to lowercase ASCII.
+pub fn normalize_query(query: &str) -> String {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut last_was_space = false;
+    for ch in trimmed.chars() {
+        if ch.is_whitespace() {
+            if !last_was_space && !normalized.is_empty() {
+                normalized.push(' ');
+            }
+            last_was_space = true;
+        } else {
+            normalized.extend(ch.to_lowercase());
+            last_was_space = false;
+        }
+    }
+
+    normalized.trim_end().to_string()
+}
+
+/// Returns true when every term in the query appears as an ordered subsequence
+/// within the candidate text.
+pub fn fuzzy_match(query: &str, candidate: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+
+    query
+        .split_whitespace()
+        .filter(|segment| !segment.is_empty())
+        .all(|segment| fuzzy_subsequence(segment, candidate))
+}
+
+/// Returns true when the characters from `needle` can be found in order within
+/// `haystack`.
+pub fn fuzzy_subsequence(needle: &str, haystack: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+
+    let mut needle_chars = needle.chars();
+    let mut current = match needle_chars.next() {
+        Some(value) => value,
+        None => return true,
+    };
+
+    for ch in haystack.chars() {
+        if ch == current {
+            match needle_chars.next() {
+                Some(next) => current = next,
+                None => return true,
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_query_trims_and_lowercases() {
+        let normalized = normalize_query("   Foo   Bar   BAZ  ");
+        assert_eq!(normalized, "foo bar baz");
+    }
+
+    #[test]
+    fn normalize_query_handles_whitespace_only() {
+        assert!(normalize_query("   ").is_empty());
+    }
+
+    #[test]
+    fn fuzzy_subsequence_requires_in_order_match() {
+        assert!(fuzzy_subsequence("abc", "a_b_c"));
+        assert!(!fuzzy_subsequence("abc", "acb"));
+    }
+
+    #[test]
+    fn fuzzy_match_supports_multiple_terms() {
+        assert!(fuzzy_match("run cmd", "run command"));
+        assert!(!fuzzy_match("missing", "run command"));
+    }
+}

--- a/vtcode-core/src/ui/tui/session/modal.rs
+++ b/vtcode-core/src/ui/tui/session/modal.rs
@@ -1,7 +1,9 @@
 use crate::config::constants::ui;
+use crate::ui::search::{fuzzy_match, normalize_query};
 use crate::ui::tui::types::{
-    InlineListItem, InlineListSearchConfig, InlineListSelection, SecurePromptConfig,
+    InlineEvent, InlineListItem, InlineListSearchConfig, InlineListSelection, SecurePromptConfig,
 };
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
@@ -29,6 +31,22 @@ pub struct ModalState {
     pub search: Option<ModalSearchState>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ModalKeyModifiers {
+    pub control: bool,
+    pub alt: bool,
+    pub command: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum ModalListKeyResult {
+    NotHandled,
+    HandledNoRedraw,
+    Redraw,
+    Submit(InlineEvent),
+    Cancel(InlineEvent),
+}
+
 #[derive(Clone)]
 pub struct ModalListState {
     pub items: Vec<ModalListItem>,
@@ -37,6 +55,7 @@ pub struct ModalListState {
     pub total_selectable: usize,
     pub filter_terms: Vec<String>,
     pub filter_query: Option<String>,
+    pub viewport_rows: Option<u16>,
 }
 
 #[derive(Clone)]
@@ -97,6 +116,112 @@ impl ModalSearchState {
     }
 }
 
+impl ModalState {
+    pub fn handle_list_key_event(
+        &mut self,
+        key: &KeyEvent,
+        modifiers: ModalKeyModifiers,
+    ) -> ModalListKeyResult {
+        let Some(list) = self.list.as_mut() else {
+            return ModalListKeyResult::NotHandled;
+        };
+
+        if let Some(search) = self.search.as_mut() {
+            match key.code {
+                KeyCode::Char(ch) if !modifiers.control && !modifiers.alt && !modifiers.command => {
+                    search.push_char(ch);
+                    list.apply_search(&search.query);
+                    return ModalListKeyResult::Redraw;
+                }
+                KeyCode::Backspace => {
+                    if search.backspace() {
+                        list.apply_search(&search.query);
+                        return ModalListKeyResult::Redraw;
+                    }
+                    return ModalListKeyResult::HandledNoRedraw;
+                }
+                KeyCode::Delete => {
+                    if search.clear() {
+                        list.apply_search(&search.query);
+                        return ModalListKeyResult::Redraw;
+                    }
+                    return ModalListKeyResult::HandledNoRedraw;
+                }
+                KeyCode::Esc => {
+                    if search.clear() {
+                        list.apply_search(&search.query);
+                        return ModalListKeyResult::Redraw;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match key.code {
+            KeyCode::Up => {
+                if modifiers.command {
+                    list.select_first();
+                } else {
+                    list.select_previous();
+                }
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::Down => {
+                if modifiers.command {
+                    list.select_last();
+                } else {
+                    list.select_next();
+                }
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::PageUp => {
+                list.page_up();
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::PageDown => {
+                list.page_down();
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::Home => {
+                list.select_first();
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::End => {
+                list.select_last();
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::Tab => {
+                list.select_next();
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::BackTab => {
+                list.select_previous();
+                ModalListKeyResult::Redraw
+            }
+            KeyCode::Enter => {
+                if let Some(selection) = list.current_selection() {
+                    ModalListKeyResult::Submit(InlineEvent::ListModalSubmit(selection))
+                } else {
+                    ModalListKeyResult::HandledNoRedraw
+                }
+            }
+            KeyCode::Esc => ModalListKeyResult::Cancel(InlineEvent::ListModalCancel),
+            KeyCode::Char(ch) if modifiers.control || modifiers.alt => match ch {
+                'n' | 'N' | 'j' | 'J' => {
+                    list.select_next();
+                    ModalListKeyResult::Redraw
+                }
+                'p' | 'P' | 'k' | 'K' => {
+                    list.select_previous();
+                    ModalListKeyResult::Redraw
+                }
+                _ => ModalListKeyResult::NotHandled,
+            },
+            _ => ModalListKeyResult::NotHandled,
+        }
+    }
+}
+
 impl ModalListItem {
     fn is_header(&self) -> bool {
         self.selection.is_none() && !self.is_divider
@@ -131,44 +256,6 @@ pub fn is_divider_title(item: &InlineListItem) -> bool {
     item.title
         .chars()
         .all(|ch| symbol.chars().any(|needle| needle == ch))
-}
-
-pub fn normalize_query(query: &str) -> String {
-    query
-        .split_whitespace()
-        .map(|segment| segment.to_ascii_lowercase())
-        .collect::<Vec<String>>()
-        .join(" ")
-}
-
-pub fn fuzzy_match(query: &str, candidate: &str) -> bool {
-    if query.is_empty() {
-        return true;
-    }
-    query
-        .split_whitespace()
-        .filter(|segment| !segment.is_empty())
-        .all(|segment| fuzzy_subsequence(segment, candidate))
-}
-
-pub fn fuzzy_subsequence(needle: &str, haystack: &str) -> bool {
-    if needle.is_empty() {
-        return true;
-    }
-    let mut needle_chars = needle.chars();
-    let mut current = match needle_chars.next() {
-        Some(value) => value,
-        None => return true,
-    };
-    for ch in haystack.chars() {
-        if ch == current {
-            match needle_chars.next() {
-                Some(next) => current = next,
-                None => return true,
-            }
-        }
-    }
-    false
 }
 
 pub struct ModalRenderStyles {
@@ -370,7 +457,9 @@ pub fn render_modal_list(
         return;
     }
 
-    list.ensure_visible(area.height);
+    let viewport_rows = area.height.saturating_sub(2);
+    list.set_viewport_rows(viewport_rows);
+    list.ensure_visible(viewport_rows);
     let items = modal_list_items(list, styles);
     let widget = List::new(items)
         .block(modal_list_block(list, styles))
@@ -916,6 +1005,7 @@ impl ModalListState {
             total_selectable,
             filter_terms: Vec::new(),
             filter_query: None,
+            viewport_rows: None,
         };
         modal_state.select_initial(selected);
         modal_state
@@ -977,6 +1067,62 @@ impl ModalListState {
         }
     }
 
+    pub fn select_first(&mut self) {
+        if let Some(first) = self.first_selectable_index() {
+            self.list_state.select(Some(first));
+        } else {
+            self.list_state.select(None);
+        }
+        if let Some(rows) = self.viewport_rows {
+            self.ensure_visible(rows);
+        }
+    }
+
+    pub fn select_last(&mut self) {
+        if let Some(last) = self.last_selectable_index() {
+            self.list_state.select(Some(last));
+        } else {
+            self.list_state.select(None);
+        }
+        if let Some(rows) = self.viewport_rows {
+            self.ensure_visible(rows);
+        }
+    }
+
+    pub fn page_up(&mut self) {
+        let step = self.page_step();
+        if step == 0 {
+            self.select_previous();
+            return;
+        }
+        for _ in 0..step {
+            let before = self.list_state.selected();
+            self.select_previous();
+            if self.list_state.selected() == before {
+                break;
+            }
+        }
+    }
+
+    pub fn page_down(&mut self) {
+        let step = self.page_step();
+        if step == 0 {
+            self.select_next();
+            return;
+        }
+        for _ in 0..step {
+            let before = self.list_state.selected();
+            self.select_next();
+            if self.list_state.selected() == before {
+                break;
+            }
+        }
+    }
+
+    pub fn set_viewport_rows(&mut self, rows: u16) {
+        self.viewport_rows = Some(rows);
+    }
+
     fn ensure_visible(&mut self, viewport: u16) {
         let Some(selected) = self.list_state.selected() else {
             return;
@@ -994,12 +1140,21 @@ impl ModalListState {
     }
 
     pub fn apply_search(&mut self, query: &str) {
+        let preferred = self.current_selection();
+        self.apply_search_with_preference(query, preferred);
+    }
+
+    pub fn apply_search_with_preference(
+        &mut self,
+        query: &str,
+        preferred: Option<InlineListSelection>,
+    ) {
         let trimmed = query.trim();
         if trimmed.is_empty() {
             self.visible_indices = (0..self.items.len()).collect();
             self.filter_terms.clear();
             self.filter_query = None;
-            self.select_initial(None);
+            self.select_initial(preferred);
             return;
         }
 
@@ -1056,7 +1211,7 @@ impl ModalListState {
         self.visible_indices = indices;
         self.filter_terms = terms;
         self.filter_query = Some(trimmed.to_string());
-        self.select_initial(None);
+        self.select_initial(preferred);
     }
 
     fn select_initial(&mut self, preferred: Option<InlineListSelection>) {
@@ -1109,5 +1264,329 @@ impl ModalListState {
 
     fn total_selectable(&self) -> usize {
         self.total_selectable
+    }
+
+    fn page_step(&self) -> usize {
+        let rows = self.viewport_rows.unwrap_or(0).max(1);
+        usize::from(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::style::{Modifier, Style};
+
+    fn base_item(title: &str) -> InlineListItem {
+        InlineListItem {
+            title: title.to_string(),
+            subtitle: None,
+            badge: None,
+            indent: 0,
+            selection: None,
+            search_value: None,
+        }
+    }
+
+    fn sample_list_modal() -> ModalState {
+        let items = vec![
+            InlineListItem {
+                title: "First".to_string(),
+                selection: Some(InlineListSelection::Model(0)),
+                search_value: Some("general".to_string()),
+                ..base_item("First")
+            },
+            InlineListItem {
+                title: "Second".to_string(),
+                selection: Some(InlineListSelection::Model(1)),
+                search_value: Some("other".to_string()),
+                ..base_item("Second")
+            },
+        ];
+
+        let list_state = ModalListState::new(items, None);
+        let search_state = ModalSearchState::from(InlineListSearchConfig {
+            label: "Search".to_string(),
+            placeholder: None,
+        });
+
+        let mut modal = ModalState {
+            title: "Test".to_string(),
+            lines: vec![],
+            list: Some(list_state),
+            secure_prompt: None,
+            popup_state: PopupState::default(),
+            restore_input: true,
+            restore_cursor: true,
+            search: Some(search_state),
+        };
+
+        if let Some(list) = modal.list.as_mut() {
+            let query = modal
+                .search
+                .as_ref()
+                .map(|state| state.query.clone())
+                .unwrap_or_default();
+            list.apply_search(&query);
+        }
+
+        modal
+    }
+
+    fn sample_list_modal_with_count(count: usize) -> ModalState {
+        let items = (0..count)
+            .map(|index| {
+                let label = format!("Item {}", index + 1);
+                InlineListItem {
+                    selection: Some(InlineListSelection::Model(index)),
+                    search_value: Some(label.to_ascii_lowercase()),
+                    ..base_item(&label)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        ModalState {
+            title: "Test".to_string(),
+            lines: vec![],
+            list: Some(ModalListState::new(items, None)),
+            secure_prompt: None,
+            popup_state: PopupState::default(),
+            restore_input: true,
+            restore_cursor: true,
+            search: None,
+        }
+    }
+
+    #[test]
+    fn apply_search_retains_related_structure() {
+        let divider = InlineListItem {
+            title: ui::INLINE_USER_MESSAGE_DIVIDER_SYMBOL.repeat(3),
+            ..base_item("")
+        };
+        let header = InlineListItem {
+            search_value: Some("General Models".to_string()),
+            ..base_item("Models")
+        };
+        let matching = InlineListItem {
+            indent: 1,
+            selection: Some(InlineListSelection::Model(0)),
+            search_value: Some("general purpose".to_string()),
+            ..base_item("General Purpose")
+        };
+        let non_matching = InlineListItem {
+            selection: Some(InlineListSelection::Model(1)),
+            search_value: Some("specialized".to_string()),
+            ..base_item("Specialized")
+        };
+
+        let mut state = ModalListState::new(vec![divider, header, matching, non_matching], None);
+
+        state.apply_search("general");
+
+        let visible_titles: Vec<String> = state
+            .visible_indices
+            .iter()
+            .map(|&idx| state.items[idx].title.clone())
+            .collect();
+
+        let expected_divider = ui::INLINE_USER_MESSAGE_DIVIDER_SYMBOL.repeat(3);
+        assert_eq!(
+            visible_titles,
+            vec![
+                expected_divider,
+                "Models".to_string(),
+                "General Purpose".to_string(),
+                "Specialized".to_string()
+            ]
+        );
+        assert_eq!(state.visible_selectable_count(), 2);
+        assert_eq!(state.filter_query(), Some("general"));
+
+        state.apply_search("");
+        assert_eq!(state.visible_indices.len(), state.items.len());
+        assert!(state.filter_query().is_none());
+    }
+
+    #[test]
+    fn highlight_segments_marks_matching_spans() {
+        let segments = highlight_segments(
+            "Hello",
+            Style::default(),
+            Style::default().add_modifier(Modifier::BOLD),
+            &["el".to_string()],
+        );
+
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0].content.as_ref(), "H");
+        assert_eq!(segments[0].style, Style::default());
+        assert_eq!(segments[1].content.as_ref(), "el");
+        assert_eq!(
+            segments[1].style,
+            Style::default().add_modifier(Modifier::BOLD)
+        );
+        assert_eq!(segments[2].content.as_ref(), "lo");
+        assert_eq!(segments[2].style, Style::default());
+    }
+
+    #[test]
+    fn list_modal_handles_search_typing() {
+        let mut modal = sample_list_modal();
+        let key = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        let result = modal.handle_list_key_event(&key, ModalKeyModifiers::default());
+
+        match result {
+            ModalListKeyResult::Redraw => {}
+            other => panic!("expected redraw, got {:?}", other),
+        }
+
+        let query = &modal.search.unwrap().query;
+        assert_eq!(query, "g");
+    }
+
+    #[test]
+    fn list_modal_submit_emits_event() {
+        let mut modal = sample_list_modal();
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        let result = modal.handle_list_key_event(&key, ModalKeyModifiers::default());
+
+        match result {
+            ModalListKeyResult::Submit(InlineEvent::ListModalSubmit(selection)) => {
+                assert_eq!(selection, InlineListSelection::Model(0));
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn list_modal_cancel_emits_event() {
+        let mut modal = sample_list_modal();
+        if let Some(search) = modal.search.as_mut() {
+            search.query = "value".to_string();
+        }
+
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        let result = modal.handle_list_key_event(&key, ModalKeyModifiers::default());
+
+        match result {
+            ModalListKeyResult::Redraw => {}
+            other => panic!("expected redraw to clear query first, got {:?}", other),
+        }
+
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        let result = modal.handle_list_key_event(&key, ModalKeyModifiers::default());
+
+        match result {
+            ModalListKeyResult::Cancel(InlineEvent::ListModalCancel) => {}
+            other => panic!("expected cancel event, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn list_modal_tab_moves_forward() {
+        let mut modal = sample_list_modal();
+        let key = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+        let result = modal.handle_list_key_event(&key, ModalKeyModifiers::default());
+
+        assert!(matches!(result, ModalListKeyResult::Redraw));
+        let selection = modal
+            .list
+            .as_ref()
+            .and_then(|list| list.current_selection());
+        assert_eq!(selection, Some(InlineListSelection::Model(1)));
+    }
+
+    #[test]
+    fn list_modal_backtab_moves_backward() {
+        let mut modal = sample_list_modal();
+        let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
+        let _ = modal.handle_list_key_event(&down, ModalKeyModifiers::default());
+
+        let key = KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT);
+        let result = modal.handle_list_key_event(&key, ModalKeyModifiers::default());
+
+        assert!(matches!(result, ModalListKeyResult::Redraw));
+        let selection = modal
+            .list
+            .as_ref()
+            .and_then(|list| list.current_selection());
+        assert_eq!(selection, Some(InlineListSelection::Model(0)));
+    }
+
+    #[test]
+    fn list_modal_control_navigation_moves_selection() {
+        let mut modal = sample_list_modal();
+        let tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+        let _ = modal.handle_list_key_event(&tab, ModalKeyModifiers::default());
+
+        let ctrl_p = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL);
+        let result = modal.handle_list_key_event(
+            &ctrl_p,
+            ModalKeyModifiers {
+                control: true,
+                alt: false,
+                command: false,
+            },
+        );
+
+        assert!(matches!(result, ModalListKeyResult::Redraw));
+        let selection = modal
+            .list
+            .as_ref()
+            .and_then(|list| list.current_selection());
+        assert_eq!(selection, Some(InlineListSelection::Model(0)));
+    }
+
+    #[test]
+    fn list_search_preserves_selection_when_item_matches() {
+        let mut modal = sample_list_modal();
+        let list = modal.list.as_mut().expect("list state");
+        list.select_next();
+
+        let previous = list.current_selection();
+        list.apply_search("other");
+
+        assert_eq!(list.current_selection(), previous);
+    }
+
+    #[test]
+    fn list_search_resets_selection_when_item_removed() {
+        let mut modal = sample_list_modal();
+        let list = modal.list.as_mut().expect("list state");
+        list.select_next();
+
+        list.apply_search("general");
+
+        assert_eq!(
+            list.current_selection(),
+            Some(InlineListSelection::Model(0))
+        );
+    }
+
+    #[test]
+    fn list_modal_page_navigation_respects_viewport() {
+        let mut modal = sample_list_modal_with_count(6);
+        let list = modal.list.as_mut().expect("list state");
+        list.set_viewport_rows(3);
+
+        let page_down = KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE);
+        let result = modal.handle_list_key_event(&page_down, ModalKeyModifiers::default());
+        assert!(matches!(result, ModalListKeyResult::Redraw));
+
+        let selection = modal
+            .list
+            .as_ref()
+            .and_then(|state| state.current_selection());
+        assert_eq!(selection, Some(InlineListSelection::Model(3)));
+
+        let page_up = KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE);
+        let result = modal.handle_list_key_event(&page_up, ModalKeyModifiers::default());
+        assert!(matches!(result, ModalListKeyResult::Redraw));
+
+        let selection = modal
+            .list
+            .as_ref()
+            .and_then(|state| state.current_selection());
+        assert_eq!(selection, Some(InlineListSelection::Model(0)));
     }
 }

--- a/vtcode-core/src/ui/tui/session/slash_palette.rs
+++ b/vtcode-core/src/ui/tui/session/slash_palette.rs
@@ -17,6 +17,7 @@ pub fn command_range(input: &str, cursor: usize) -> Option<SlashCommandRange> {
         return None;
     }
 
+    let mut last_range = None;
     let mut active_range = None;
 
     for (index, grapheme) in input.grapheme_indices(true) {
@@ -30,14 +31,22 @@ pub fn command_range(input: &str, cursor: usize) -> Option<SlashCommandRange> {
                 end: input.len(),
             });
         } else if grapheme.chars().all(char::is_whitespace) {
-            if let Some(range) = &mut active_range {
+            if let Some(mut range) = active_range.take() {
                 range.end = index;
+                last_range = Some(range);
             }
-            break;
+        } else if let Some(range) = &mut active_range {
+            range.end = index + grapheme.len();
         }
     }
 
-    active_range.filter(|range| range.end > range.start)
+    if let Some(range) = active_range {
+        if range.end > range.start {
+            return Some(range);
+        }
+    }
+
+    last_range.filter(|range| range.end > range.start)
 }
 
 pub fn command_prefix(input: &str, cursor: usize) -> Option<String> {

--- a/vtcode-core/src/ui/tui/session/slash_palette.rs
+++ b/vtcode-core/src/ui/tui/session/slash_palette.rs
@@ -1,0 +1,548 @@
+use std::ptr;
+
+use ratatui::widgets::ListState;
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::ui::search::normalize_query;
+use crate::ui::slash::{SlashCommandInfo, suggestions_for};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlashCommandRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+pub fn command_range(input: &str, cursor: usize) -> Option<SlashCommandRange> {
+    if !input.starts_with('/') {
+        return None;
+    }
+
+    let mut active_range = None;
+
+    for (index, grapheme) in input.grapheme_indices(true) {
+        if index > cursor {
+            break;
+        }
+
+        if grapheme == "/" {
+            active_range = Some(SlashCommandRange {
+                start: index,
+                end: input.len(),
+            });
+        } else if grapheme.chars().all(char::is_whitespace) {
+            if let Some(range) = &mut active_range {
+                range.end = index;
+            }
+            break;
+        }
+    }
+
+    active_range.filter(|range| range.end > range.start)
+}
+
+pub fn command_prefix(input: &str, cursor: usize) -> Option<String> {
+    let range = command_range(input, cursor)?;
+    let end = cursor.min(range.end);
+    let start = range.start + 1;
+    if end < start {
+        return Some(String::new());
+    }
+    Some(input[start..end].to_string())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashPaletteHighlightSegment {
+    pub content: String,
+    pub highlighted: bool,
+}
+
+impl SlashPaletteHighlightSegment {
+    pub fn highlighted(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            highlighted: true,
+        }
+    }
+
+    pub fn plain(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            highlighted: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SlashPaletteItem<'a> {
+    pub command: &'a SlashCommandInfo,
+    pub name_segments: Vec<SlashPaletteHighlightSegment>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashPaletteUpdate {
+    NoChange,
+    Cleared,
+    Changed {
+        suggestions_changed: bool,
+        selection_changed: bool,
+    },
+}
+
+#[derive(Debug, Default)]
+pub struct SlashPalette {
+    suggestions: Vec<&'static SlashCommandInfo>,
+    list_state: ListState,
+    visible_rows: usize,
+    filter_query: Option<String>,
+}
+
+impl SlashPalette {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn suggestions(&self) -> &[&'static SlashCommandInfo] {
+        &self.suggestions
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.suggestions.is_empty()
+    }
+
+    pub fn selected_command(&self) -> Option<&'static SlashCommandInfo> {
+        self.list_state
+            .selected()
+            .and_then(|index| self.suggestions.get(index).copied())
+    }
+
+    pub fn list_state_mut(&mut self) -> &mut ListState {
+        &mut self.list_state
+    }
+
+    pub fn clear_visible_rows(&mut self) {
+        self.visible_rows = 0;
+    }
+
+    pub fn set_visible_rows(&mut self, rows: usize) {
+        self.visible_rows = rows;
+        self.ensure_list_visible();
+    }
+
+    #[cfg(test)]
+    pub fn visible_rows(&self) -> usize {
+        self.visible_rows
+    }
+
+    pub fn update(&mut self, prefix: Option<&str>, limit: usize) -> SlashPaletteUpdate {
+        if prefix.is_none() {
+            if self.clear_internal() {
+                return SlashPaletteUpdate::Cleared;
+            }
+            return SlashPaletteUpdate::NoChange;
+        }
+
+        let prefix = prefix.unwrap();
+        let normalized = normalize_query(prefix);
+        let mut new_suggestions = suggestions_for(prefix);
+        if !prefix.is_empty() {
+            new_suggestions.truncate(limit);
+        }
+
+        let filter_query = if normalized.is_empty() {
+            None
+        } else if new_suggestions
+            .iter()
+            .all(|info| info.name.starts_with(&normalized))
+        {
+            Some(normalized.clone())
+        } else {
+            None
+        };
+
+        let suggestions_changed = self.replace_suggestions(new_suggestions);
+        self.filter_query = filter_query;
+        let selection_changed = self.ensure_selection();
+
+        if suggestions_changed || selection_changed {
+            SlashPaletteUpdate::Changed {
+                suggestions_changed,
+                selection_changed,
+            }
+        } else {
+            SlashPaletteUpdate::NoChange
+        }
+    }
+
+    pub fn clear(&mut self) -> bool {
+        self.clear_internal()
+    }
+
+    pub fn move_up(&mut self) -> bool {
+        if self.suggestions.is_empty() {
+            return false;
+        }
+
+        let visible_len = self.suggestions.len();
+        let current = self.list_state.selected().unwrap_or(0);
+        let new_index = if current > 0 {
+            current - 1
+        } else {
+            visible_len - 1
+        };
+
+        self.apply_selection(Some(new_index))
+    }
+
+    pub fn move_down(&mut self) -> bool {
+        if self.suggestions.is_empty() {
+            return false;
+        }
+
+        let visible_len = self.suggestions.len();
+        let current = self.list_state.selected().unwrap_or(visible_len - 1);
+        let new_index = if current + 1 < visible_len {
+            current + 1
+        } else {
+            0
+        };
+
+        self.apply_selection(Some(new_index))
+    }
+
+    pub fn select_first(&mut self) -> bool {
+        if self.suggestions.is_empty() {
+            return false;
+        }
+
+        self.apply_selection(Some(0))
+    }
+
+    pub fn select_last(&mut self) -> bool {
+        if self.suggestions.is_empty() {
+            return false;
+        }
+
+        let last = self.suggestions.len() - 1;
+        self.apply_selection(Some(last))
+    }
+
+    pub fn page_up(&mut self) -> bool {
+        if self.suggestions.is_empty() {
+            return false;
+        }
+
+        let step = self.visible_rows.max(1);
+        let current = self.list_state.selected().unwrap_or(0);
+        let new_index = current.saturating_sub(step);
+
+        self.apply_selection(Some(new_index))
+    }
+
+    pub fn page_down(&mut self) -> bool {
+        if self.suggestions.is_empty() {
+            return false;
+        }
+
+        let step = self.visible_rows.max(1);
+        let visible_len = self.suggestions.len();
+        let current = self.list_state.selected().unwrap_or(0);
+        let mut new_index = current.saturating_add(step);
+        if new_index >= visible_len {
+            new_index = visible_len - 1;
+        }
+
+        self.apply_selection(Some(new_index))
+    }
+
+    pub fn items(&self) -> Vec<SlashPaletteItem<'static>> {
+        self.suggestions
+            .iter()
+            .map(|command| SlashPaletteItem {
+                command,
+                name_segments: self.highlight_name_segments(command.name),
+            })
+            .collect()
+    }
+
+    fn clear_internal(&mut self) -> bool {
+        if self.suggestions.is_empty()
+            && self.list_state.selected().is_none()
+            && self.visible_rows == 0
+            && self.filter_query.is_none()
+        {
+            return false;
+        }
+
+        self.suggestions.clear();
+        self.list_state.select(None);
+        *self.list_state.offset_mut() = 0;
+        self.visible_rows = 0;
+        self.filter_query = None;
+        true
+    }
+
+    fn replace_suggestions(&mut self, new_suggestions: Vec<&'static SlashCommandInfo>) -> bool {
+        if self.suggestions.len() == new_suggestions.len()
+            && self
+                .suggestions
+                .iter()
+                .zip(&new_suggestions)
+                .all(|(current, candidate)| ptr::eq(*current, *candidate))
+        {
+            return false;
+        }
+
+        self.suggestions = new_suggestions;
+        true
+    }
+
+    fn ensure_selection(&mut self) -> bool {
+        if self.suggestions.is_empty() {
+            if self.list_state.selected().is_some() {
+                self.list_state.select(None);
+                *self.list_state.offset_mut() = 0;
+                return true;
+            }
+            return false;
+        }
+
+        let visible_len = self.suggestions.len();
+        let current = self.list_state.selected().unwrap_or(0);
+        let bounded = current.min(visible_len - 1);
+
+        if Some(bounded) == self.list_state.selected() {
+            self.ensure_list_visible();
+            false
+        } else {
+            self.apply_selection(Some(bounded))
+        }
+    }
+
+    fn apply_selection(&mut self, index: Option<usize>) -> bool {
+        if self.list_state.selected() == index {
+            return false;
+        }
+
+        self.list_state.select(index);
+        if index.is_none() {
+            *self.list_state.offset_mut() = 0;
+        }
+        self.ensure_list_visible();
+        true
+    }
+
+    fn ensure_list_visible(&mut self) {
+        if self.visible_rows == 0 {
+            return;
+        }
+
+        let Some(selected) = self.list_state.selected() else {
+            *self.list_state.offset_mut() = 0;
+            return;
+        };
+
+        let visible_rows = self.visible_rows;
+        let offset_ref = self.list_state.offset_mut();
+        let offset = *offset_ref;
+
+        if selected < offset {
+            *offset_ref = selected;
+        } else if selected >= offset + visible_rows {
+            *offset_ref = selected + 1 - visible_rows;
+        }
+    }
+
+    fn highlight_name_segments(&self, name: &str) -> Vec<SlashPaletteHighlightSegment> {
+        let Some(query) = self.filter_query.as_ref().filter(|query| !query.is_empty()) else {
+            return vec![SlashPaletteHighlightSegment::plain(name.to_string())];
+        };
+
+        let lowercase = name.to_ascii_lowercase();
+        if !lowercase.starts_with(query) {
+            return vec![SlashPaletteHighlightSegment::plain(name.to_string())];
+        }
+
+        let query_len = query.chars().count();
+        let mut highlighted = String::new();
+        let mut remainder = String::new();
+
+        for (index, ch) in name.chars().enumerate() {
+            if index < query_len {
+                highlighted.push(ch);
+            } else {
+                remainder.push(ch);
+            }
+        }
+
+        let mut segments = Vec::new();
+        if !highlighted.is_empty() {
+            segments.push(SlashPaletteHighlightSegment::highlighted(highlighted));
+        }
+        if !remainder.is_empty() {
+            segments.push(SlashPaletteHighlightSegment::plain(remainder));
+        }
+        if segments.is_empty() {
+            segments.push(SlashPaletteHighlightSegment::plain(String::new()));
+        }
+        segments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn palette_with_commands() -> SlashPalette {
+        let mut palette = SlashPalette::new();
+        let _ = palette.update(Some(""), usize::MAX);
+        palette
+    }
+
+    #[test]
+    fn update_applies_prefix_and_highlights_matches() {
+        let mut palette = SlashPalette::new();
+
+        let update = palette.update(Some("co"), 10);
+        assert!(matches!(
+            update,
+            SlashPaletteUpdate::Changed {
+                suggestions_changed: true,
+                selection_changed: true
+            }
+        ));
+
+        let items = palette.items();
+        assert!(!items.is_empty());
+        let command = items
+            .into_iter()
+            .find(|item| item.command.name == "command")
+            .expect("command suggestion available");
+
+        assert_eq!(command.name_segments.len(), 2);
+        assert!(command.name_segments[0].highlighted);
+        assert_eq!(command.name_segments[0].content, "co");
+        assert_eq!(command.name_segments[1].content, "mmand");
+    }
+
+    #[test]
+    fn update_without_matches_resets_highlights() {
+        let mut palette = SlashPalette::new();
+        let _ = palette.update(Some("co"), 10);
+        assert!(!palette.items().is_empty());
+
+        let update = palette.update(Some("zzz"), 10);
+        assert!(matches!(update, SlashPaletteUpdate::Changed { .. }));
+
+        for item in palette.items() {
+            assert!(
+                item.name_segments
+                    .iter()
+                    .all(|segment| !segment.highlighted)
+            );
+        }
+    }
+
+    #[test]
+    fn navigation_wraps_between_items() {
+        let mut palette = palette_with_commands();
+
+        assert!(palette.move_down());
+        let first = palette.list_state.selected();
+        assert_eq!(first, Some(1));
+
+        let mut moved = false;
+        for _ in 0..palette.suggestions.len() {
+            moved = palette.move_down();
+        }
+        assert!(moved);
+        assert_eq!(palette.list_state.selected(), Some(0));
+
+        assert!(palette.move_up());
+        assert_eq!(
+            palette.list_state.selected(),
+            Some(palette.suggestions.len() - 1)
+        );
+    }
+
+    #[test]
+    fn boundary_shortcuts_jump_to_expected_items() {
+        let mut palette = palette_with_commands();
+
+        assert!(palette.select_last());
+        assert_eq!(
+            palette.list_state.selected(),
+            Some(palette.suggestions.len() - 1)
+        );
+
+        assert!(palette.select_first());
+        assert_eq!(palette.list_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn page_navigation_advances_by_visible_rows() {
+        let mut palette = palette_with_commands();
+        palette.set_visible_rows(3);
+
+        assert!(palette.page_down());
+        assert_eq!(palette.list_state.selected(), Some(3));
+
+        assert!(palette.page_down());
+        assert_eq!(palette.list_state.selected(), Some(6));
+
+        assert!(palette.page_up());
+        assert_eq!(palette.list_state.selected(), Some(3));
+
+        assert!(palette.page_up());
+        assert_eq!(palette.list_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn clear_resets_state() {
+        let mut palette = SlashPalette::new();
+        let _ = palette.update(Some("co"), 10);
+        palette.set_visible_rows(3);
+
+        assert!(palette.clear());
+        assert!(palette.suggestions().is_empty());
+        assert_eq!(palette.list_state.selected(), None);
+        assert_eq!(palette.visible_rows(), 0);
+    }
+
+    #[test]
+    fn command_range_tracks_latest_slash_before_cursor() {
+        let input = "/one two /three";
+        let cursor = input.len();
+        let range = command_range(input, cursor).expect("range available");
+        assert_eq!(range.start, 9);
+        assert_eq!(range.end, input.len());
+    }
+
+    #[test]
+    fn command_range_stops_at_whitespace() {
+        let input = "/cmd arg";
+        let cursor = input.len();
+        let range = command_range(input, cursor).expect("range available");
+        assert_eq!(range.start, 0);
+        assert_eq!(range.end, 4);
+    }
+
+    #[test]
+    fn command_prefix_includes_partial_match() {
+        let input = "/hel";
+        let prefix = command_prefix(input, input.len()).expect("prefix available");
+        assert_eq!(prefix, "hel");
+    }
+
+    #[test]
+    fn command_prefix_is_empty_when_cursor_immediately_after_slash() {
+        let input = "/";
+        let prefix = command_prefix(input, 1).expect("prefix available");
+        assert!(prefix.is_empty());
+    }
+
+    #[test]
+    fn command_prefix_returns_none_when_not_in_command() {
+        let input = "say hello";
+        assert!(command_prefix(input, input.len()).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `ui::search` helper module for query normalization and fuzzy matching that both the modal list and slash palette reuse
- expand `suggestions_for` to support prefix, substring, and fuzzy fallbacks with deterministic ordering and regression tests
- have the slash palette update logic adopt the shared normalization and document the richer search coverage in the refactoring checklist

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f3a0d221888323aad202ee7705fb92