### PR TITLE
Add tree-sitter Bash support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,6 +4317,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-bash"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871b0606e667e98a1237ebdc1b0d7056e0aebfdc3141d12b399865d4cb6ed8a6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4844,6 +4854,7 @@ dependencies = [
  "toml",
  "tracing",
  "tree-sitter",
+ "tree-sitter-bash",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -46,6 +46,7 @@ tree-sitter-javascript = "0.23"
 tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-java = "0.23"
+tree-sitter-bash = "0.25"
 flate2 = "1.0"
 indexmap = { version = "2.2", features = ["serde"] }
 itertools = "0.14.0"

--- a/vtcode-core/src/code/code_completion/context/analyzer.rs
+++ b/vtcode-core/src/code/code_completion/context/analyzer.rs
@@ -37,6 +37,7 @@ impl ContextAnalyzer {
                 crate::tools::tree_sitter::LanguageSupport::TypeScript => "typescript".to_string(),
                 crate::tools::tree_sitter::LanguageSupport::Go => "go".to_string(),
                 crate::tools::tree_sitter::LanguageSupport::Java => "java".to_string(),
+                crate::tools::tree_sitter::LanguageSupport::Bash => "bash".to_string(),
                 crate::tools::tree_sitter::LanguageSupport::Swift => "swift".to_string(),
             };
         }
@@ -65,6 +66,7 @@ impl ContextAnalyzer {
             "typescript" => crate::tools::tree_sitter::LanguageSupport::TypeScript,
             "go" => crate::tools::tree_sitter::LanguageSupport::Go,
             "java" => crate::tools::tree_sitter::LanguageSupport::Java,
+            "bash" | "sh" => crate::tools::tree_sitter::LanguageSupport::Bash,
             _ => crate::tools::tree_sitter::LanguageSupport::Rust,
         };
 
@@ -111,6 +113,7 @@ impl ContextAnalyzer {
             "typescript" => crate::tools::tree_sitter::LanguageSupport::TypeScript,
             "go" => crate::tools::tree_sitter::LanguageSupport::Go,
             "java" => crate::tools::tree_sitter::LanguageSupport::Java,
+            "bash" | "sh" => crate::tools::tree_sitter::LanguageSupport::Bash,
             _ => crate::tools::tree_sitter::LanguageSupport::Rust,
         };
 
@@ -157,6 +160,15 @@ impl ContextAnalyzer {
                     imports.push(import_text.to_string());
                 }
             }
+            crate::tools::tree_sitter::LanguageSupport::Bash => {
+                if kind == "command" {
+                    let import_text = &source[node.start_byte()..node.end_byte()];
+                    let trimmed = import_text.trim_start();
+                    if trimmed.starts_with("source ") || trimmed.starts_with(". ") {
+                        imports.push(import_text.to_string());
+                    }
+                }
+            }
             _ => {
                 // Generic approach for other languages
                 if kind.contains("import") || kind.contains("require") {
@@ -185,6 +197,7 @@ impl ContextAnalyzer {
             "typescript" => crate::tools::tree_sitter::LanguageSupport::TypeScript,
             "go" => crate::tools::tree_sitter::LanguageSupport::Go,
             "java" => crate::tools::tree_sitter::LanguageSupport::Java,
+            "bash" | "sh" => crate::tools::tree_sitter::LanguageSupport::Bash,
             _ => crate::tools::tree_sitter::LanguageSupport::Rust,
         };
 

--- a/vtcode-core/src/tools/tree_sitter/mod.rs
+++ b/vtcode-core/src/tools/tree_sitter/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Features
 //!
-//! - **Multi-language Support**: Rust, Python, JavaScript, TypeScript, Go, Java, optional Swift
+//! - **Multi-language Support**: Rust, Python, JavaScript, TypeScript, Go, Java, Bash, optional Swift
 //! - **Syntax Tree Analysis**: Parse code into structured syntax trees
 //! - **Symbol Extraction**: Extract functions, classes, variables, and imports
 //! - **Code Navigation**: Navigate code structures with precision


### PR DESCRIPTION
## Summary
- add the tree-sitter-bash crate and register Bash as a supported language in the analyzer
- provide Bash-specific queries, symbol extraction, and dependency handling for analysis utilities
- update the completion context analyzer and documentation to recognize Bash sources

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f4478e48ac8323a2c7f3cc1552710a