### PR TITLE
Add Codex-style inline config overrides

### DIFF
--- a/docs/config/CONFIGURATION_PRECEDENCE.md
+++ b/docs/config/CONFIGURATION_PRECEDENCE.md
@@ -14,6 +14,24 @@ When the CLI starts it looks for `vtcode.toml` in the following locations. The f
 
 This precedence allows local overrides while still falling back to organization-level or user-level defaults.
 
+### Inline CLI overrides
+
+Inspired by [OpenAI Codex CLI](https://github.com/openai/codex), VT Code now accepts
+`-c/--config key=value` overrides directly on the command line. These overrides
+apply **after** the configuration file is loaded, making them the highest
+precedence layer. Use multiple flags to set several keys during a single run.
+For example:
+
+```
+vtcode --workspace ~/repo \
+  --config agent.provider="openai" \
+  --config context.curation.enabled=false
+```
+
+Relative config paths passed via `--config path/to/vtcode.toml` remain supported
+and are resolved against the workspace before falling back to the current
+working directory.
+
 ## Default Values
 
 Layered defaults are defined in the Rust sources so the application can generate a baseline configuration and reason about missing fields:

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -73,7 +73,9 @@ Run the bridge directly to ensure it starts cleanly:
 ```
 
 Add `--config /absolute/path/to/vtcode.toml` if the configuration lives outside the default lookup
-locations. Successful startup leaves the process waiting on stdio; stop it with `Ctrl+C`.
+locations. You can also mirror Codex CLI behaviour with inline overrides such as
+`--config agent.provider="openai"` when launching the bridge. Successful startup leaves the process
+waiting on stdio; stop it with `Ctrl+C`.
 
 ## Register VT Code in Zed
 


### PR DESCRIPTION
## Summary
- add Codex-inspired `-c/--config` CLI overrides that accept both key/value pairs and file paths
- merge inline overrides into the loaded configuration during startup with TOML-aware helpers and unit coverage
- document the new precedence in the configuration guide and the Zed ACP workflow docs

## Testing
- cargo fmt
- cargo clippy
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f44bb4e674832394a5a647ffa45b2d