### PR TITLE
Integrate perg fallback for rp_search

### DIFF
--- a/.vtcode/tool-policy.json
+++ b/.vtcode/tool-policy.json
@@ -9,7 +9,7 @@
     "curl",
     "edit_file",
     "git_diff",
-    "grep_search",
+    "rp_search",
     "list_files",
     "list_pty_sessions",
     "mcp::context7::get-library-docs",
@@ -30,7 +30,6 @@
     "write_file"
   ],
   "policies": {
-    "grep_search": "allow",
     "list_files": "allow",
     "update_plan": "allow",
     "run_terminal_cmd": "allow",
@@ -50,7 +49,8 @@
     "read_pty_session": "allow",
     "resize_pty_session": "allow",
     "send_pty_input": "prompt",
-    "git_diff": "allow"
+    "git_diff": "allow",
+    "rp_search": "allow"
   },
   "constraints": {
     "curl": {

--- a/.vtcode/tool-policy.json
+++ b/.vtcode/tool-policy.json
@@ -9,7 +9,7 @@
     "curl",
     "edit_file",
     "git_diff",
-    "rp_search",
+    "grep_file",
     "list_files",
     "list_pty_sessions",
     "mcp::context7::get-library-docs",
@@ -50,7 +50,7 @@
     "resize_pty_session": "allow",
     "send_pty_input": "prompt",
     "git_diff": "allow",
-    "rp_search": "allow"
+    "grep_file": "allow"
   },
   "constraints": {
     "curl": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ Any dates before this are in the past, and any dates after this are in the futur
 -   Update documentation if needed
 -   Consider performance implications
 -   Test with various input files and edge cases
--   Prefered ripgrep over grep for search
+-   Prefer the custom `rp_search` tool over invoking shell `rg` or `grep`
 -   DO NOT USE EMOJI THIS IS IMPORTANT
 -   Put all agent's configuration option to vtcode.toml. This is important, every logic should be read from this toml config instead of hardcode.
 -   Use MCP tools for enhanced context awareness if needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ Any dates before this are in the past, and any dates after this are in the futur
 -   Update documentation if needed
 -   Consider performance implications
 -   Test with various input files and edge cases
--   Prefer the custom `rp_search` tool over invoking shell `rg` or `grep`
+-   Prefer the custom `grep_file` tool over invoking shell `rg` or `grep`
 -   DO NOT USE EMOJI THIS IS IMPORTANT
 -   Put all agent's configuration option to vtcode.toml. This is important, every logic should be read from this toml config instead of hardcode.
 -   Use MCP tools for enhanced context awareness if needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ detailed_tracking = false
 - **67-82% Token Reduction**: System prompts streamlined from ~600 tokens to ~200 tokens
 - **80% Tool Description Efficiency**: Average tool description reduced from ~400 to ~80 tokens
 - **"Right Altitude" Principles**: Concise, actionable guidance over verbose instructions
-- **Progressive Disclosure**: Emphasize search-first approach with `rp_search` (alias `grep_search`) and `ast_grep_search`
+- **Progressive Disclosure**: Emphasize search-first approach with `rp_search` and `ast_grep_search`
 - **Clear Tool Purposes**: Eliminated capability overlap in tool descriptions
 - **Token Management Guidance**: Built-in advice for efficient context usage (e.g., `max_results` parameters)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ detailed_tracking = false
 - **67-82% Token Reduction**: System prompts streamlined from ~600 tokens to ~200 tokens
 - **80% Tool Description Efficiency**: Average tool description reduced from ~400 to ~80 tokens
 - **"Right Altitude" Principles**: Concise, actionable guidance over verbose instructions
-- **Progressive Disclosure**: Emphasize search-first approach with `grep_search` and `ast_grep_search`
+- **Progressive Disclosure**: Emphasize search-first approach with `rp_search` (alias `grep_search`) and `ast_grep_search`
 - **Clear Tool Purposes**: Eliminated capability overlap in tool descriptions
 - **Token Management Guidance**: Built-in advice for efficient context usage (e.g., `max_results` parameters)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ detailed_tracking = false
 - **67-82% Token Reduction**: System prompts streamlined from ~600 tokens to ~200 tokens
 - **80% Tool Description Efficiency**: Average tool description reduced from ~400 to ~80 tokens
 - **"Right Altitude" Principles**: Concise, actionable guidance over verbose instructions
-- **Progressive Disclosure**: Emphasize search-first approach with `rp_search` and `ast_grep_search`
+- **Progressive Disclosure**: Emphasize search-first approach with `grep_file` and `ast_grep_search`
 - **Clear Tool Purposes**: Eliminated capability overlap in tool descriptions
 - **Token Management Guidance**: Built-in advice for efficient context usage (e.g., `max_results` parameters)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "perg"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d89d1ebdc2bec902abd27d93f03d3ddcbf6d9a5fa0f465739cc967cb6c2366a"
+dependencies = [
+ "anyhow",
+ "clap",
+ "regex",
+ "walkdir",
+]
+
+[[package]]
 name = "pest"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4832,6 +4844,7 @@ dependencies = [
  "nucleo-matcher",
  "once_cell",
  "parking_lot",
+ "perg",
  "portable-pty 0.9.0",
  "quick_cache",
  "rand 0.8.5",

--- a/benches/search_benchmark.rs
+++ b/benches/search_benchmark.rs
@@ -26,7 +26,7 @@ fn benchmark_search_performance(c: &mut Criterion) {
                 "pattern": "fn main",
                 "path": "."
             });
-            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_SEARCH, args));
+            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_FILE, args));
         });
     });
 
@@ -37,7 +37,7 @@ fn benchmark_search_performance(c: &mut Criterion) {
                 "pattern": "\\bfunction\\b",
                 "path": "."
             });
-            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_SEARCH, args));
+            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_FILE, args));
         });
     });
 
@@ -49,7 +49,7 @@ fn benchmark_search_performance(c: &mut Criterion) {
                 "path": ".",
                 "case_sensitive": false
             });
-            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_SEARCH, args));
+            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_FILE, args));
         });
     });
 
@@ -61,7 +61,7 @@ fn benchmark_search_performance(c: &mut Criterion) {
                 "path": ".",
                 "context_lines": 3
             });
-            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_SEARCH, args));
+            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_FILE, args));
         });
     });
 
@@ -73,7 +73,7 @@ fn benchmark_search_performance(c: &mut Criterion) {
                 "path": ".",
                 "glob_pattern": "**/*.rs"
             });
-            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_SEARCH, args));
+            let _ = futures::executor::block_on(registry.execute_tool(tools::GREP_FILE, args));
         });
     });
 

--- a/docs/AST_GREP_TOOLS_ASSESSMENT_UPDATED.md
+++ b/docs/AST_GREP_TOOLS_ASSESSMENT_UPDATED.md
@@ -7,7 +7,7 @@ After running tests and examining the code, here's the accurate status of AST-gr
 ### 1. Partially Implemented Tools
 
 #### `ast_grep_search` PARTIALLY IMPLEMENTED
-- **Implementation**: Currently delegates to `rp_search` (ripgrep-based search)
+- **Implementation**: Currently delegates to `grep_file` (ripgrep-based search)
 - **Status**: Works but does not provide true AST-grep functionality
 - **Behavior**: Performs text-based search rather than syntax-aware AST pattern matching
 
@@ -35,7 +35,7 @@ Looking at the source code in `vtcode-core/src/tools.rs`:
 ```rust
 /// Search using AST-grep patterns
 async fn ast_grep_search(&self, args: Value) -> Result<Value> {
-    self.rp_search(args).await  // Delegates to regular ripgrep search
+    self.grep_file(args).await  // Delegates to regular ripgrep search
 }
 
 /// Transform code using AST-grep patterns

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -60,7 +60,7 @@ Tools now support multiple execution modes:
 
 ```rust
 // Standard usage (unchanged)
-let result = tool_registry.execute("rp_search", args).await?;
+let result = tool_registry.execute("grep_file", args).await?;
 
 // New mode-based usage
 let result = search_tool.execute_mode("fuzzy", args).await?;

--- a/docs/TOOL_POLICY_IMPLEMENTATION.md
+++ b/docs/TOOL_POLICY_IMPLEMENTATION.md
@@ -67,14 +67,14 @@ The system stores configuration in `~/.vtcode/tool-policy.json`:
         "write_file",
         "list_files",
         "run_terminal_cmd",
-        "rp_search"
+        "grep_file"
     ],
     "policies": {
         "read_file": "allow",
         "write_file": "prompt",
         "list_files": "allow",
         "run_terminal_cmd": "deny",
-        "rp_search": "allow"
+        "grep_file": "allow"
     }
 }
 ```

--- a/docs/context_engineering.md
+++ b/docs/context_engineering.md
@@ -58,7 +58,7 @@ Example from our default prompt:
 Instead of pre-loading everything, we use lightweight references:
 
 - **File Paths as Metadata**: List files first, read content only when relevant
-- **Search Before Read**: Use `rp_search` (alias `grep_search`) or `ast_grep_search` to identify relevant files
+- **Search Before Read**: Use `rp_search` or `ast_grep_search` to identify relevant files
 - **Chunked Reading**: Auto-truncate large files (>2000 lines) to first/last portions
 - **Pagination**: Tools support `per_page` and `page` parameters for large results
 

--- a/docs/context_engineering.md
+++ b/docs/context_engineering.md
@@ -58,7 +58,7 @@ Example from our default prompt:
 Instead of pre-loading everything, we use lightweight references:
 
 - **File Paths as Metadata**: List files first, read content only when relevant
-- **Search Before Read**: Use `grep_search` or `ast_grep_search` to identify relevant files
+- **Search Before Read**: Use `rp_search` (alias `grep_search`) or `ast_grep_search` to identify relevant files
 - **Chunked Reading**: Auto-truncate large files (>2000 lines) to first/last portions
 - **Pagination**: Tools support `per_page` and `page` parameters for large results
 
@@ -159,7 +159,7 @@ let compressed = compactor.compact_messages_intelligently().await?;
 Our tools are designed with context efficiency in mind:
 
 #### Search Tools
-- **grep_search**: Fast pattern matching with `max_results` limits
+- **rp_search**: Fast pattern matching with `max_results` limits
 - **ast_grep_search**: Syntax-aware search with `max_results` and `context_lines`
 - Return metadata first (file paths, line numbers) before content
 

--- a/docs/context_engineering.md
+++ b/docs/context_engineering.md
@@ -58,7 +58,7 @@ Example from our default prompt:
 Instead of pre-loading everything, we use lightweight references:
 
 - **File Paths as Metadata**: List files first, read content only when relevant
-- **Search Before Read**: Use `rp_search` or `ast_grep_search` to identify relevant files
+- **Search Before Read**: Use `grep_file` or `ast_grep_search` to identify relevant files
 - **Chunked Reading**: Auto-truncate large files (>2000 lines) to first/last portions
 - **Pagination**: Tools support `per_page` and `page` parameters for large results
 
@@ -159,7 +159,7 @@ let compressed = compactor.compact_messages_intelligently().await?;
 Our tools are designed with context efficiency in mind:
 
 #### Search Tools
-- **rp_search**: Fast pattern matching with `max_results` limits
+- **grep_file**: Fast pattern matching with `max_results` limits
 - **ast_grep_search**: Syntax-aware search with `max_results` and `context_lines`
 - Return metadata first (file paths, line numbers) before content
 

--- a/docs/context_engineering_best_practices.md
+++ b/docs/context_engineering_best_practices.md
@@ -181,7 +181,7 @@ drill down as needed. Maintain a mental model of your recent actions for coheren
 ## Tool Selection Strategy
 
 **For exploration:**
-- Start with `grep_search` or `ast_grep_search` to find relevant locations
+- Start with `rp_search` (alias `grep_search`) or `ast_grep_search` to find relevant locations
 - Use `list_files` to understand structure before diving into content
 - Only call `read_file` after identifying specific files of interest
 
@@ -343,7 +343,7 @@ pub fn get_tool_description(tool_name: &str, context: &ContextState) -> String {
     match context.phase {
         Phase::Exploration => {
             // Emphasize search tools
-            if matches!(tool_name, "grep_search" | "ast_grep_search") {
+            if matches!(tool_name, "rp_search" | "grep_search" | "ast_grep_search") {
                 format!("{}\n\n**Current Phase**: Use this to find relevant code before reading files.", base_desc)
             } else {
                 base_desc.to_string()

--- a/docs/context_engineering_best_practices.md
+++ b/docs/context_engineering_best_practices.md
@@ -181,7 +181,7 @@ drill down as needed. Maintain a mental model of your recent actions for coheren
 ## Tool Selection Strategy
 
 **For exploration:**
-- Start with `rp_search` (alias `grep_search`) or `ast_grep_search` to find relevant locations
+- Start with `rp_search` or `ast_grep_search` to find relevant locations
 - Use `list_files` to understand structure before diving into content
 - Only call `read_file` after identifying specific files of interest
 
@@ -343,7 +343,7 @@ pub fn get_tool_description(tool_name: &str, context: &ContextState) -> String {
     match context.phase {
         Phase::Exploration => {
             // Emphasize search tools
-            if matches!(tool_name, "rp_search" | "grep_search" | "ast_grep_search") {
+            if matches!(tool_name, "rp_search" | "ast_grep_search") {
                 format!("{}\n\n**Current Phase**: Use this to find relevant code before reading files.", base_desc)
             } else {
                 base_desc.to_string()

--- a/docs/context_engineering_best_practices.md
+++ b/docs/context_engineering_best_practices.md
@@ -181,7 +181,7 @@ drill down as needed. Maintain a mental model of your recent actions for coheren
 ## Tool Selection Strategy
 
 **For exploration:**
-- Start with `rp_search` or `ast_grep_search` to find relevant locations
+- Start with `grep_file` or `ast_grep_search` to find relevant locations
 - Use `list_files` to understand structure before diving into content
 - Only call `read_file` after identifying specific files of interest
 
@@ -343,7 +343,7 @@ pub fn get_tool_description(tool_name: &str, context: &ContextState) -> String {
     match context.phase {
         Phase::Exploration => {
             // Emphasize search tools
-            if matches!(tool_name, "rp_search" | "ast_grep_search") {
+            if matches!(tool_name, "grep_file" | "ast_grep_search") {
                 format!("{}\n\n**Current Phase**: Use this to find relevant code before reading files.", base_desc)
             } else {
                 base_desc.to_string()

--- a/docs/context_engineering_implementation.md
+++ b/docs/context_engineering_implementation.md
@@ -43,7 +43,7 @@ files until you've identified relevant matches."
 - Clarified when to use each tool vs alternatives
 
 **Tools Optimized**:
-- `rp_search` (alias `grep_search`): Emphasized token budget management with `max_results`
+- `rp_search`: Emphasized token budget management with `max_results`
 - `list_files`: Focused on metadata-as-references pattern
 - `read_file`: Highlighted auto-chunking for large files
 - `write_file` / `edit_file`: Clarified distinct use cases

--- a/docs/context_engineering_implementation.md
+++ b/docs/context_engineering_implementation.md
@@ -43,7 +43,7 @@ files until you've identified relevant matches."
 - Clarified when to use each tool vs alternatives
 
 **Tools Optimized**:
-- `grep_search`: Emphasized token budget management with `max_results`
+- `rp_search` (alias `grep_search`): Emphasized token budget management with `max_results`
 - `list_files`: Focused on metadata-as-references pattern
 - `read_file`: Highlighted auto-chunking for large files
 - `write_file` / `edit_file`: Clarified distinct use cases
@@ -171,7 +171,7 @@ VTCode already had several features aligned with Anthropic's principles:
 
 ### ✅ Pagination Support
 - `list_files`: `page` and `per_page` parameters
-- `grep_search`: `max_results` limit
+- `rp_search`: `max_results` limit
 - Prevents token overflow
 
 ## Remaining Work

--- a/docs/context_engineering_implementation.md
+++ b/docs/context_engineering_implementation.md
@@ -43,7 +43,7 @@ files until you've identified relevant matches."
 - Clarified when to use each tool vs alternatives
 
 **Tools Optimized**:
-- `rp_search`: Emphasized token budget management with `max_results`
+- `grep_file`: Emphasized token budget management with `max_results`
 - `list_files`: Focused on metadata-as-references pattern
 - `read_file`: Highlighted auto-chunking for large files
 - `write_file` / `edit_file`: Clarified distinct use cases
@@ -171,7 +171,7 @@ VTCode already had several features aligned with Anthropic's principles:
 
 ### ✅ Pagination Support
 - `list_files`: `page` and `per_page` parameters
-- `rp_search`: `max_results` limit
+- `grep_file`: `max_results` limit
 - Prevents token overflow
 
 ## Remaining Work

--- a/docs/context_engineering_summary.md
+++ b/docs/context_engineering_summary.md
@@ -286,7 +286,7 @@ pub struct ContextCurator {
 **Example:**
 
 ```rust
-Phase::Exploration => "grep_search: Use this to find relevant code before reading files"
+Phase::Exploration => "rp_search (alias `grep_search`): Use this to find relevant code before reading files"
 Phase::Implementation => "edit_file: Make precise changes; preferred over write_file"
 Phase::Validation => "run_terminal_cmd: Validate changes with tests"
 ```

--- a/docs/context_engineering_summary.md
+++ b/docs/context_engineering_summary.md
@@ -286,7 +286,7 @@ pub struct ContextCurator {
 **Example:**
 
 ```rust
-Phase::Exploration => "rp_search (alias `grep_search`): Use this to find relevant code before reading files"
+Phase::Exploration => "rp_search: Use this to find relevant code before reading files"
 Phase::Implementation => "edit_file: Make precise changes; preferred over write_file"
 Phase::Validation => "run_terminal_cmd: Validate changes with tests"
 ```

--- a/docs/context_engineering_summary.md
+++ b/docs/context_engineering_summary.md
@@ -286,7 +286,7 @@ pub struct ContextCurator {
 **Example:**
 
 ```rust
-Phase::Exploration => "rp_search: Use this to find relevant code before reading files"
+Phase::Exploration => "grep_file: Use this to find relevant code before reading files"
 Phase::Implementation => "edit_file: Make precise changes; preferred over write_file"
 Phase::Validation => "run_terminal_cmd: Validate changes with tests"
 ```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -167,7 +167,7 @@ Test regex-based search:
 
 ```rust
 #[tokio::test]
-async fn test_grep_search_tool() {
+async fn test_rp_search_tool() {
     let env = TestEnv::new();
     let content = "fn main() { println!(\"test\"); }";
     env.create_test_file("test.rs", content);
@@ -179,7 +179,7 @@ async fn test_grep_search_tool() {
         "path": "."
     });
 
-    let result = registry.execute("grep_search", args).await;
+    let result = registry.execute("rp_search", args).await;
     assert!(result.is_ok());
 }
 ```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -167,7 +167,7 @@ Test regex-based search:
 
 ```rust
 #[tokio::test]
-async fn test_rp_search_tool() {
+async fn test_grep_file_tool() {
     let env = TestEnv::new();
     let content = "fn main() { println!(\"test\"); }";
     env.create_test_file("test.rs", content);
@@ -179,7 +179,7 @@ async fn test_rp_search_tool() {
         "path": "."
     });
 
-    let result = registry.execute("rp_search", args).await;
+    let result = registry.execute("grep_file", args).await;
     assert!(result.is_ok());
 }
 ```

--- a/docs/guides/full_auto_mode.md
+++ b/docs/guides/full_auto_mode.md
@@ -37,7 +37,7 @@ profile_path = "automation/full_auto_profile.toml"
 allowed_tools = [
     "read_file",
     "list_files",
-    "grep_search",
+    "rp_search",
     "simple_search",
     "run_terminal_cmd", # optionally include write or shell tools
 ]

--- a/docs/guides/full_auto_mode.md
+++ b/docs/guides/full_auto_mode.md
@@ -37,7 +37,7 @@ profile_path = "automation/full_auto_profile.toml"
 allowed_tools = [
     "read_file",
     "list_files",
-    "rp_search",
+    "grep_file",
     "simple_search",
     "run_terminal_cmd", # optionally include write or shell tools
 ]

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -130,7 +130,7 @@ Edit `settings.json` (Command Palette → `zed: open settings`) and add a custom
   invocation. Paths supplied by tools are normalised against the trusted workspace so relative
   segments stay inside the project before the request reaches the client.
 - **Tool policy compatibility** – VT Code still advertises its core tool suite (for example
-  `run_terminal_cmd`, `bash`, `grep_search`, `write_file`) through ACP when the model supports
+  `run_terminal_cmd`, `bash`, `rp_search`, `write_file`) through ACP when the model supports
   function calling. The bridge evaluates each request against the workspace's tool-policy settings
   before executing commands locally, ensuring shell access and editing tools behave the same as in
   the native CLI. Policy defaults and overrides defined under `[tools]` in `vtcode.toml` apply to

--- a/docs/guides/zed-acp.md
+++ b/docs/guides/zed-acp.md
@@ -130,7 +130,7 @@ Edit `settings.json` (Command Palette → `zed: open settings`) and add a custom
   invocation. Paths supplied by tools are normalised against the trusted workspace so relative
   segments stay inside the project before the request reaches the client.
 - **Tool policy compatibility** – VT Code still advertises its core tool suite (for example
-  `run_terminal_cmd`, `bash`, `rp_search`, `write_file`) through ACP when the model supports
+  `run_terminal_cmd`, `bash`, `grep_file`, `write_file`) through ACP when the model supports
   function calling. The bridge evaluates each request against the workspace's tool-policy settings
   before executing commands locally, ensuring shell access and editing tools behave the same as in
   the native CLI. Policy defaults and overrides defined under `[tools]` in `vtcode.toml` apply to

--- a/docs/improved_system_prompts.md
+++ b/docs/improved_system_prompts.md
@@ -25,7 +25,7 @@ Work within `WORKSPACE_DIR`. Use targeted exploration (search, inspect) before m
 - Preserve recent decisions and errors in your working memory
 
 ## Available Tools
-**Exploration**: list_files, rg, ast_grep_search
+**Exploration**: list_files, rp_search, ast_grep_search
 **File Ops**: read_file, write_file, edit_file
 **Execution**: run_terminal_cmd (with PTY support)
 **Network**: curl (HTTPS only, no localhost/private IPs)
@@ -58,13 +58,13 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 
 **Response Framework:**
 1. **Assess the situation** – Understand what the user needs; ask clarifying questions if ambiguous
-2. **Gather context efficiently** – Use search tools (rg, ast-grep) to locate relevant code before reading files
+2. **Gather context efficiently** – Use search tools (rp_search — alias `grep_search` — and ast-grep) to locate relevant code before reading files
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
 
 **Context Management:**
-- Start with lightweight searches (grep_search, list_files) before reading full files
+- Start with lightweight searches (rp_search, list_files) before reading full files
 - Load file metadata as references; read content only when necessary
 - Summarize verbose outputs; avoid echoing large command results
 - Track your recent actions and decisions to maintain coherence
@@ -78,7 +78,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 - Acknowledge urgency or complexity in the user's request and respond with appropriate clarity
 
 **Tools Available:**
-**Exploration:** list_files, grep_search, ast_grep_search
+**Exploration:** list_files, rp_search, ast_grep_search
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (with PTY support)
 **Network:** curl (HTTPS only, no localhost/private IPs)
@@ -116,7 +116,7 @@ Load only what's necessary. Use search tools first. Summarize results.
 
 **Tools:**
 **Files:** list_files, read_file, write_file, edit_file
-**Search:** grep_search, ast_grep_search
+**Search:** rp_search, ast_grep_search
 **Shell:** run_terminal_cmd
 **Network:** curl (HTTPS only)
 
@@ -154,7 +154,7 @@ Handle complex coding tasks that require deep understanding, structural changes,
 
 **Context Management:**
 - Minimize attention budget usage through strategic tool selection
-- Use search (grep_search, ast_grep_search) before reading to identify relevant code
+- Use search (rp_search, ast_grep_search) before reading to identify relevant code
 - Build understanding layer-by-layer with progressive disclosure
 - Maintain working memory of recent decisions, changes, and outcomes
 - Reference past tool results without re-executing
@@ -169,12 +169,12 @@ Handle complex coding tasks that require deep understanding, structural changes,
 - For errors, analyze root causes before proposing fixes
 
 **Tool Selection Strategy:**
-- **Exploration Phase:** grep_search → list_files → ast_grep_search → read_file
+- **Exploration Phase:** rp_search → list_files → ast_grep_search → read_file
 - **Implementation Phase:** edit_file (preferred) or write_file → run_terminal_cmd (validate)
 - **Analysis Phase:** ast_grep_search (structural) → tree-sitter parsing → performance profiling
 
 **Advanced Tools:**
-**Exploration:** list_files, grep_search, ast_grep_search (tree-sitter-powered)
+**Exploration:** list_files, rp_search, ast_grep_search (tree-sitter-powered)
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (full PTY emulation)
 **Network:** curl (HTTPS only, sandboxed)

--- a/docs/improved_system_prompts.md
+++ b/docs/improved_system_prompts.md
@@ -58,7 +58,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 
 **Response Framework:**
 1. **Assess the situation** – Understand what the user needs; ask clarifying questions if ambiguous
-2. **Gather context efficiently** – Use search tools (rp_search — alias `grep_search` — and ast-grep) to locate relevant code before reading files
+2. **Gather context efficiently** – Use search tools (rp_search and ast-grep) to locate relevant code before reading files
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction

--- a/docs/improved_system_prompts.md
+++ b/docs/improved_system_prompts.md
@@ -25,7 +25,7 @@ Work within `WORKSPACE_DIR`. Use targeted exploration (search, inspect) before m
 - Preserve recent decisions and errors in your working memory
 
 ## Available Tools
-**Exploration**: list_files, rp_search, ast_grep_search
+**Exploration**: list_files, grep_file, ast_grep_search
 **File Ops**: read_file, write_file, edit_file
 **Execution**: run_terminal_cmd (with PTY support)
 **Network**: curl (HTTPS only, no localhost/private IPs)
@@ -58,13 +58,13 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 
 **Response Framework:**
 1. **Assess the situation** – Understand what the user needs; ask clarifying questions if ambiguous
-2. **Gather context efficiently** – Use search tools (rp_search and ast-grep) to locate relevant code before reading files
+2. **Gather context efficiently** – Use search tools (grep_file and ast-grep) to locate relevant code before reading files
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
 
 **Context Management:**
-- Start with lightweight searches (rp_search, list_files) before reading full files
+- Start with lightweight searches (grep_file, list_files) before reading full files
 - Load file metadata as references; read content only when necessary
 - Summarize verbose outputs; avoid echoing large command results
 - Track your recent actions and decisions to maintain coherence
@@ -78,7 +78,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 - Acknowledge urgency or complexity in the user's request and respond with appropriate clarity
 
 **Tools Available:**
-**Exploration:** list_files, rp_search, ast_grep_search
+**Exploration:** list_files, grep_file, ast_grep_search
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (with PTY support)
 **Network:** curl (HTTPS only, no localhost/private IPs)
@@ -116,7 +116,7 @@ Load only what's necessary. Use search tools first. Summarize results.
 
 **Tools:**
 **Files:** list_files, read_file, write_file, edit_file
-**Search:** rp_search, ast_grep_search
+**Search:** grep_file, ast_grep_search
 **Shell:** run_terminal_cmd
 **Network:** curl (HTTPS only)
 
@@ -154,7 +154,7 @@ Handle complex coding tasks that require deep understanding, structural changes,
 
 **Context Management:**
 - Minimize attention budget usage through strategic tool selection
-- Use search (rp_search, ast_grep_search) before reading to identify relevant code
+- Use search (grep_file, ast_grep_search) before reading to identify relevant code
 - Build understanding layer-by-layer with progressive disclosure
 - Maintain working memory of recent decisions, changes, and outcomes
 - Reference past tool results without re-executing
@@ -169,12 +169,12 @@ Handle complex coding tasks that require deep understanding, structural changes,
 - For errors, analyze root causes before proposing fixes
 
 **Tool Selection Strategy:**
-- **Exploration Phase:** rp_search → list_files → ast_grep_search → read_file
+- **Exploration Phase:** grep_file → list_files → ast_grep_search → read_file
 - **Implementation Phase:** edit_file (preferred) or write_file → run_terminal_cmd (validate)
 - **Analysis Phase:** ast_grep_search (structural) → tree-sitter parsing → performance profiling
 
 **Advanced Tools:**
-**Exploration:** list_files, rp_search, ast_grep_search (tree-sitter-powered)
+**Exploration:** list_files, grep_file, ast_grep_search (tree-sitter-powered)
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (full PTY emulation)
 **Network:** curl (HTTPS only, sandboxed)

--- a/docs/phase_1_2_implementation_summary.md
+++ b/docs/phase_1_2_implementation_summary.md
@@ -116,7 +116,7 @@ Automatically detects conversation phase from recent messages:
 Dynamically selects relevant tools based on phase:
 
 **Exploration Phase:**
-- Prioritizes: grep_search, list_files, ast_grep_search
+- Prioritizes: rp_search, list_files, ast_grep_search
 - Rationale: User needs to find and understand code
 
 **Implementation Phase:**

--- a/docs/phase_1_2_implementation_summary.md
+++ b/docs/phase_1_2_implementation_summary.md
@@ -116,7 +116,7 @@ Automatically detects conversation phase from recent messages:
 Dynamically selects relevant tools based on phase:
 
 **Exploration Phase:**
-- Prioritizes: rp_search, list_files, ast_grep_search
+- Prioritizes: grep_file, list_files, ast_grep_search
 - Rationale: User needs to find and understand code
 
 **Implementation Phase:**

--- a/docs/tools/TOOL_SPECS.md
+++ b/docs/tools/TOOL_SPECS.md
@@ -11,9 +11,9 @@ This document summarizes the updated tool schemas and guidance following Anthrop
 
 ## Tools
 
--   grep_search
+-   rp_search
 
-    -   Purpose: Unified code search. Modes: `exact` | `fuzzy` | `multi` | `similarity`.
+    -   Purpose: Unified code search (legacy alias `grep_search`). Modes: `exact` | `fuzzy` | `multi` | `similarity`.
     -   Key args: `pattern` (string), `path` (string, default "."), `max_results` (int), `mode` (string), `response_format` (string: concise|detailed).
     -   Multi-mode: `patterns: string[]`, `logic: 'AND'|'OR'`.
     -   Similarity-mode: `reference_file` (string), `content_type: 'structure'|'imports'|'functions'|'all'`.
@@ -73,7 +73,7 @@ The workspace `.vtcode/tool-policy.json` may include constraints like:
             "max_items_per_call": 500,
             "default_response_format": "concise"
         },
-        "grep_search": {
+        "rp_search": {
             "max_results_per_call": 200,
             "default_response_format": "concise"
         },

--- a/docs/tools/TOOL_SPECS.md
+++ b/docs/tools/TOOL_SPECS.md
@@ -13,7 +13,7 @@ This document summarizes the updated tool schemas and guidance following Anthrop
 
 -   rp_search
 
-    -   Purpose: Unified code search (legacy alias `grep_search`). Modes: `exact` | `fuzzy` | `multi` | `similarity`.
+    -   Purpose: Unified code search. Modes: `exact` | `fuzzy` | `multi` | `similarity`.
     -   Key args: `pattern` (string), `path` (string, default "."), `max_results` (int), `mode` (string), `response_format` (string: concise|detailed).
     -   Multi-mode: `patterns: string[]`, `logic: 'AND'|'OR'`.
     -   Similarity-mode: `reference_file` (string), `content_type: 'structure'|'imports'|'functions'|'all'`.

--- a/docs/tools/TOOL_SPECS.md
+++ b/docs/tools/TOOL_SPECS.md
@@ -11,7 +11,7 @@ This document summarizes the updated tool schemas and guidance following Anthrop
 
 ## Tools
 
--   rp_search
+-   grep_file
 
     -   Purpose: Unified code search. Modes: `exact` | `fuzzy` | `multi` | `similarity`.
     -   Key args: `pattern` (string), `path` (string, default "."), `max_results` (int), `mode` (string), `response_format` (string: concise|detailed).
@@ -73,7 +73,7 @@ The workspace `.vtcode/tool-policy.json` may include constraints like:
             "max_items_per_call": 500,
             "default_response_format": "concise"
         },
-        "rp_search": {
+        "grep_file": {
             "max_results_per_call": 200,
             "default_response_format": "concise"
         },

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -5,8 +5,8 @@ This guide summarizes common actions and how to invoke them with vtcode. The age
 ## rp_search (ripgrep-like)
 
 High-speed code search with glob filters, context lines, and optional literal/regex matching.
-VTCode prefers the system `rg` binary, but if it is unavailable the embedded [perg](https://crates.io/crates/perg)
-engine seamlessly serves the same JSON response format so downstream tools behave identically.
+VTCode routes searches through the custom `rp_search` tool. It calls the system `rg` binary when available, and falls back to the embedded [perg](https://crates.io/crates/perg)
+engine so downstream tools receive the same JSON response format. Prefer `rp_search` instead of invoking shell `rg`/`grep` yourself.
 
 - Input fields:
   - `pattern` (string, required): Search pattern. Treated as regex unless `literal=true`.

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -5,6 +5,8 @@ This guide summarizes common actions and how to invoke them with vtcode. The age
 ## rp_search (ripgrep-like)
 
 High-speed code search with glob filters, context lines, and optional literal/regex matching.
+VTCode prefers the system `rg` binary, but if it is unavailable the embedded [perg](https://crates.io/crates/perg)
+engine seamlessly serves the same JSON response format so downstream tools behave identically.
 
 - Input fields:
   - `pattern` (string, required): Search pattern. Treated as regex unless `literal=true`.

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -2,11 +2,11 @@
 
 This guide summarizes common actions and how to invoke them with vtcode. The agent exposes a suite of tools to the LLM; you interact with them via chat. When you ask to search, read, or edit files, the agent chooses an appropriate tool.
 
-## rp_search (ripgrep-like)
+## grep_file (ripgrep-like)
 
 High-speed code search with glob filters, context lines, and optional literal/regex matching.
-VTCode routes searches through the custom `rp_search` tool. It calls the system `rg` binary when available, and falls back to the embedded [perg](https://crates.io/crates/perg)
-engine so downstream tools receive the same JSON response format. Prefer `rp_search` instead of invoking shell `rg`/`grep` yourself.
+VTCode routes searches through the custom `grep_file` tool. It calls the system `rg` binary when available, and falls back to the embedded [perg](https://crates.io/crates/perg)
+engine so downstream tools receive the same JSON response format. Prefer `grep_file` instead of invoking shell `rg`/`grep` yourself.
 
 - Input fields:
   - `pattern` (string, required): Search pattern. Treated as regex unless `literal=true`.
@@ -28,7 +28,7 @@ engine so downstream tools receive the same JSON response format. Prefer `rp_sea
 
 ```
 Ask: Search for TODO|FIXME across the repo with 2 lines of context in .rs files
-(Agent uses rp_search with)
+(Agent uses grep_file with)
 {
   "pattern": "TODO|FIXME",
   "path": ".",
@@ -72,6 +72,6 @@ tool.
 ## Tips
 
 - The agent respects `.vtcodegitignore` to exclude files from search and I/O.
-- Prefer `rp_search` for fast, focused searches with glob filters and context.
+- Prefer `grep_file` for fast, focused searches with glob filters and context.
 - Ask for “N lines of context” when searching to understand usage in-place.
 - Shell commands are filtered by allow/deny lists and can be extended via `VTCODE_<AGENT>_COMMANDS_*` environment variables.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -236,7 +236,7 @@ usage_tips = [
     "Share the outcome you need or ask for a quick /status summary.",
     "Reference AGENTS.md expectations before changing files.",
     "Draft or refresh your TODOs with update_plan before editing.",
-    "Prefer targeted reads (read_file, grep_search) before editing.",
+    "Prefer targeted reads (read_file, rp_search) before editing.",
 ]
 recommended_actions = [
     "Outline a 3-6 step TODO plan via update_plan before coding.",

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -236,7 +236,7 @@ usage_tips = [
     "Share the outcome you need or ask for a quick /status summary.",
     "Reference AGENTS.md expectations before changing files.",
     "Draft or refresh your TODOs with update_plan before editing.",
-    "Prefer targeted reads (read_file, rp_search) before editing.",
+    "Prefer targeted reads (read_file, grep_file) before editing.",
 ]
 recommended_actions = [
     "Outline a 3-6 step TODO plan via update_plan before coding.",

--- a/prompts/coder_system.md
+++ b/prompts/coder_system.md
@@ -164,13 +164,13 @@ Execute test suites with detailed reporting.
 
 ### Code Analysis
 
-#### grep_search
+#### rp_search
 
-Search codebase for patterns and references.
+Search codebase for patterns and references. (Legacy alias: `grep_search`.)
 
 ```json
 {
-    "tool_name": "grep_search",
+    "tool_name": "rp_search",
     "parameters": {
         "pattern": "function_name",
         "path": "/src",

--- a/prompts/coder_system.md
+++ b/prompts/coder_system.md
@@ -166,7 +166,7 @@ Execute test suites with detailed reporting.
 
 #### rp_search
 
-Search codebase for patterns and references. (Legacy alias: `grep_search`.)
+Search codebase for patterns and references.
 
 ```json
 {

--- a/prompts/coder_system.md
+++ b/prompts/coder_system.md
@@ -164,13 +164,13 @@ Execute test suites with detailed reporting.
 
 ### Code Analysis
 
-#### rp_search
+#### grep_file
 
 Search codebase for patterns and references.
 
 ```json
 {
-    "tool_name": "rp_search",
+    "tool_name": "grep_file",
     "parameters": {
         "pattern": "function_name",
         "path": "/src",

--- a/prompts/explorer_system.md
+++ b/prompts/explorer_system.md
@@ -89,7 +89,7 @@ Get metadata for files without reading full content.
 
 #### rp_search
 
-Search file contents using patterns. (Legacy alias: `grep_search`.)
+Search file contents using patterns.
 
 ```json
 {

--- a/prompts/explorer_system.md
+++ b/prompts/explorer_system.md
@@ -87,13 +87,13 @@ Get metadata for files without reading full content.
 
 ### Search Operations
 
-#### grep_search
+#### rp_search
 
-Search file contents using patterns.
+Search file contents using patterns. (Legacy alias: `grep_search`.)
 
 ```json
 {
-    "tool_name": "grep_search",
+    "tool_name": "rp_search",
     "parameters": {
         "pattern": "regex_pattern",
         "path": "/search/directory",

--- a/prompts/explorer_system.md
+++ b/prompts/explorer_system.md
@@ -87,13 +87,13 @@ Get metadata for files without reading full content.
 
 ### Search Operations
 
-#### rp_search
+#### grep_file
 
 Search file contents using patterns.
 
 ```json
 {
-    "tool_name": "rp_search",
+    "tool_name": "grep_file",
     "parameters": {
         "pattern": "regex_pattern",
         "path": "/search/directory",

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -26,7 +26,7 @@ Within this workspace, "VT Code" refers to this open-source agentic coding inter
 
 ## Context Management
 - Pull only the files and sections required to execute the current step; avoid bulk-reading directories or large outputs unless absolutely necessary.
-- Prefer targeted inspection tools (e.g., `rg`, `ast-grep`) instead of dumping entire files to stdout.
+- Prefer targeted inspection tools (e.g., `rp_search`, `ast-grep`) instead of dumping entire files to stdout.
 - Summarize long command results rather than echoing every line back to the user, and keep shared context concise.
 
 ## Capabilities
@@ -50,7 +50,7 @@ Within this workspace, "VT Code" refers to this open-source agentic coding inter
 
 ## Tooling Expectations
 - Prefer focused tools over broad shell commands.
-- **Search**: favor `rg` (or `rp_search`) for textual queries; use AST-aware tools such as `ast_grep_*` or `srgn` for structured edits.
+- **Search**: favor the custom `rp_search` tool for textual queries; only fall back to shell `rg`/`grep` if the tool fails. Use AST-aware tools such as `ast_grep_*` or `srgn` for structured edits.
 - `list_files` uses a git-aware walker (`ignore` crate) with `nucleo-matcher`
   fuzzy scoring—use it for workspace file discovery instead of ad-hoc shell globbing.
 - **Edits**: prefer `edit_file`/`write_file`/`srgn`; ensure atomic, scoped diffs.

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -26,7 +26,7 @@ Within this workspace, "VT Code" refers to this open-source agentic coding inter
 
 ## Context Management
 - Pull only the files and sections required to execute the current step; avoid bulk-reading directories or large outputs unless absolutely necessary.
-- Prefer targeted inspection tools (e.g., `rp_search`, `ast-grep`) instead of dumping entire files to stdout.
+- Prefer targeted inspection tools (e.g., `grep_file`, `ast-grep`) instead of dumping entire files to stdout.
 - Summarize long command results rather than echoing every line back to the user, and keep shared context concise.
 
 ## Capabilities
@@ -50,7 +50,7 @@ Within this workspace, "VT Code" refers to this open-source agentic coding inter
 
 ## Tooling Expectations
 - Prefer focused tools over broad shell commands.
-- **Search**: favor the custom `rp_search` tool for textual queries; only fall back to shell `rg`/`grep` if the tool fails. Use AST-aware tools such as `ast_grep_*` or `srgn` for structured edits.
+- **Search**: favor the custom `grep_file` tool for textual queries; only fall back to shell `rg`/`grep` if the tool fails. Use AST-aware tools such as `ast_grep_*` or `srgn` for structured edits.
 - `list_files` uses a git-aware walker (`ignore` crate) with `nucleo-matcher`
   fuzzy scoring—use it for workspace file discovery instead of ad-hoc shell globbing.
 - **Edits**: prefer `edit_file`/`write_file`/`srgn`; ensure atomic, scoped diffs.

--- a/prompts/system_codex_enhanced.md
+++ b/prompts/system_codex_enhanced.md
@@ -13,6 +13,7 @@
 -   **PTY Access**: run_pty_cmd, run_pty_cmd_streaming for full terminal emulation (use for interactive commands, shells, REPLs, SSH sessions, etc.)
 
 > `rp_search` unifies ripgrep with an in-process perg fallback. If the `rg` binary is missing, perg automatically serves results using the same concise JSON structure, so downstream workflows remain unchanged.
+> Always prefer the `rp_search` tool instead of invoking shell `rg`/`grep` commands directly.
 
 ### AST-Grep Power Tools
 

--- a/prompts/system_codex_enhanced.md
+++ b/prompts/system_codex_enhanced.md
@@ -3,7 +3,7 @@
 ## AVAILABLE TOOLS
 
 -   **File Operations**: list_files, read_file, write_file, edit_file, delete_file
--   **Search & Analysis**: rp_search (ripgrep), codebase_search, read_lints
+-   **Search & Analysis**: rp_search (ripgrep/perg hybrid), codebase_search, read_lints
 -   **AST-based Code Operations**: ast_grep_search, ast_grep_transform, ast_grep_lint, ast_grep_refactor (syntax-aware code search, transformation, and analysis)
 -   **Advanced File Operations**: batch_file_operations, extract_dependencies
 -   **Code Quality**: code analysis, linting, formatting
@@ -11,6 +11,8 @@
 -   **Git Operations**: git status, git diff, git log
 -   **Terminal Access**: run_terminal_cmd for basic shell operations
 -   **PTY Access**: run_pty_cmd, run_pty_cmd_streaming for full terminal emulation (use for interactive commands, shells, REPLs, SSH sessions, etc.)
+
+> `rp_search` unifies ripgrep with an in-process perg fallback. If the `rg` binary is missing, perg automatically serves results using the same concise JSON structure, so downstream workflows remain unchanged.
 
 ### AST-Grep Power Tools
 

--- a/prompts/system_codex_enhanced.md
+++ b/prompts/system_codex_enhanced.md
@@ -3,7 +3,7 @@
 ## AVAILABLE TOOLS
 
 -   **File Operations**: list_files, read_file, write_file, edit_file, delete_file
--   **Search & Analysis**: rp_search (ripgrep/perg hybrid), codebase_search, read_lints
+-   **Search & Analysis**: grep_file (ripgrep/perg hybrid), codebase_search, read_lints
 -   **AST-based Code Operations**: ast_grep_search, ast_grep_transform, ast_grep_lint, ast_grep_refactor (syntax-aware code search, transformation, and analysis)
 -   **Advanced File Operations**: batch_file_operations, extract_dependencies
 -   **Code Quality**: code analysis, linting, formatting
@@ -12,8 +12,8 @@
 -   **Terminal Access**: run_terminal_cmd for basic shell operations
 -   **PTY Access**: run_pty_cmd, run_pty_cmd_streaming for full terminal emulation (use for interactive commands, shells, REPLs, SSH sessions, etc.)
 
-> `rp_search` unifies ripgrep with an in-process perg fallback. If the `rg` binary is missing, perg automatically serves results using the same concise JSON structure, so downstream workflows remain unchanged.
-> Always prefer the `rp_search` tool instead of invoking shell `rg`/`grep` commands directly.
+> `grep_file` unifies ripgrep with an in-process perg fallback. If the `rg` binary is missing, perg automatically serves results using the same concise JSON structure, so downstream workflows remain unchanged.
+> Always prefer the `grep_file` tool instead of invoking shell `rg`/`grep` commands directly.
 
 ### AST-Grep Power Tools
 
@@ -178,7 +178,7 @@ ast_grep_search("Command::new($cmd).arg($user_input)")
 ```bash
 # 1. Scan for vulnerabilities using multiple approaches
 ast_grep_search "dangerous_pattern"
-rp_search "hardcoded.*password|secret.*="
+grep_file "hardcoded.*password|secret.*="
 read_lints  # Check existing linter warnings
 
 # 2. Generate comprehensive security report
@@ -237,8 +237,8 @@ ast_grep_search "fs::read_to_string($path)"
 **Hardcoded Secrets:**
 
 ```
-rp_search "password\s*=\s*[\"'][^\"']+[\"']"
-rp_search "api_key\s*=\s*[\"'][^\"']+[\"']"
+grep_file "password\s*=\s*[\"'][^\"']+[\"']"
+grep_file "api_key\s*=\s*[\"'][^\"']+[\"']"
 ```
 
 ## VALIDATION AND QUALITY ASSURANCE

--- a/src/agent/runloop/text_tools.rs
+++ b/src/agent/runloop/text_tools.rs
@@ -130,7 +130,7 @@ fn is_known_textual_tool(name: &str) -> bool {
             | tools::RUN_TERMINAL_CMD
             | tools::BASH
             | tools::CURL
-            | tools::GREP_SEARCH
+            | tools::GREP_FILE
             | tools::LIST_FILES
             | tools::UPDATE_PLAN
             | tools::AST_GREP_SEARCH

--- a/src/agent/runloop/unified/tool_summary.rs
+++ b/src/agent/runloop/unified/tool_summary.rs
@@ -35,7 +35,7 @@ pub(crate) fn describe_tool_action(tool_name: &str, args: &Value) -> (String, Ha
         tool_names::LIST_FILES => {
             describe_list_files(args).unwrap_or_else(|| ("List files".to_string(), HashSet::new()))
         }
-        tool_names::GREP_SEARCH => describe_grep_search(args)
+        tool_names::GREP_SEARCH => describe_rp_search(args)
             .unwrap_or_else(|| ("Search with grep".to_string(), HashSet::new())),
         tool_names::READ_FILE => describe_path_action(args, "Read file", &["path"])
             .unwrap_or_else(|| ("Read file".to_string(), HashSet::new())),
@@ -134,7 +134,7 @@ fn describe_list_files(args: &Value) -> Option<(String, HashSet<String>)> {
     None
 }
 
-fn describe_grep_search(args: &Value) -> Option<(String, HashSet<String>)> {
+fn describe_rp_search(args: &Value) -> Option<(String, HashSet<String>)> {
     let pattern = lookup_string(args, "pattern");
     let path = lookup_string(args, "path");
     match (pattern, path) {

--- a/src/agent/runloop/unified/tool_summary.rs
+++ b/src/agent/runloop/unified/tool_summary.rs
@@ -35,7 +35,7 @@ pub(crate) fn describe_tool_action(tool_name: &str, args: &Value) -> (String, Ha
         tool_names::LIST_FILES => {
             describe_list_files(args).unwrap_or_else(|| ("List files".to_string(), HashSet::new()))
         }
-        tool_names::GREP_SEARCH => describe_rp_search(args)
+        tool_names::GREP_FILE => describe_grep_file(args)
             .unwrap_or_else(|| ("Search with grep".to_string(), HashSet::new())),
         tool_names::READ_FILE => describe_path_action(args, "Read file", &["path"])
             .unwrap_or_else(|| ("Read file".to_string(), HashSet::new())),
@@ -134,7 +134,7 @@ fn describe_list_files(args: &Value) -> Option<(String, HashSet<String>)> {
     None
 }
 
-fn describe_rp_search(args: &Value) -> Option<(String, HashSet<String>)> {
+fn describe_grep_file(args: &Value) -> Option<(String, HashSet<String>)> {
     let pattern = lookup_string(args, "pattern");
     let path = lookup_string(args, "path");
     match (pattern, path) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -131,7 +131,7 @@ read_file = "allow"
 
     #[tokio::test]
     #[ignore]
-    async fn test_grep_search_tool() {
+    async fn test_rp_search_tool() {
         let temp_dir = TempDir::new().unwrap();
         std::env::set_current_dir(&temp_dir).unwrap();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -131,7 +131,7 @@ read_file = "allow"
 
     #[tokio::test]
     #[ignore]
-    async fn test_rp_search_tool() {
+    async fn test_grep_file_tool() {
         let temp_dir = TempDir::new().unwrap();
         std::env::set_current_dir(&temp_dir).unwrap();
 
@@ -153,7 +153,7 @@ fn calculate_sum(a: i32, b: i32) -> i32 {
             "type": "regex"
         });
 
-        let result = registry.execute_tool("rp_search", args).await;
+        let result = registry.execute_tool("grep_file", args).await;
         assert!(result.is_ok());
 
         let response: serde_json::Value = result.unwrap();

--- a/tests/mock_data.rs
+++ b/tests/mock_data.rs
@@ -62,7 +62,7 @@ impl MockGeminiResponses {
                 "content": {
                     "parts": [{
                         "functionCall": {
-                            "name": "grep_search",
+                            "name": "rp_search",
                             "args": {
                                 "pattern": "fn main",
                                 "path": ".",

--- a/tests/mock_data.rs
+++ b/tests/mock_data.rs
@@ -62,7 +62,7 @@ impl MockGeminiResponses {
                 "content": {
                     "parts": [{
                         "functionCall": {
-                            "name": "rp_search",
+                            "name": "grep_file",
                             "args": {
                                 "pattern": "fn main",
                                 "path": ".",

--- a/tests/prompt_loader.rs
+++ b/tests/prompt_loader.rs
@@ -196,7 +196,7 @@ You are a helpful coding assistant for the VTCode Rust project with access to fi
 ## Available Tools
 - list_files: List files and directories
 - read_file: Read file contents  
-- rp_search: Search for patterns in code
+- grep_file: Search for patterns in code
 - run_terminal_cmd: Execute terminal commands
 
 ## Instructions

--- a/tests/test_consolidated_search.rs
+++ b/tests/test_consolidated_search.rs
@@ -7,7 +7,7 @@ use vtcode_core::tools::ToolRegistry;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Testing consolidated rp_search functionality...");
+    println!("Testing consolidated grep_file functionality...");
 
     let root = PathBuf::from(".");
     let mut registry = ToolRegistry::new(root);
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n1. Testing exact search mode:");
     let result = registry
         .execute_tool(
-            "rp_search",
+            "grep_file",
             json!({
                 "pattern": "fn main",
                 "path": "src",
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n2. Testing fuzzy search mode:");
     let result = registry
         .execute_tool(
-            "rp_search",
+            "grep_file",
             json!({
                 "pattern": "main",
                 "path": "src",
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n3. Testing multi-pattern search (AND):");
     let result = registry
         .execute_tool(
-            "rp_search",
+            "grep_file",
             json!({
                 "pattern": "dummy", // Required but not used in multi mode
                 "path": "src",
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n4. Testing multi-pattern search (OR):");
     let result = registry
         .execute_tool(
-            "rp_search",
+            "grep_file",
             json!({
                 "pattern": "dummy", // Required but not used in multi mode
                 "path": "src",

--- a/tests/test_tool_policy.rs
+++ b/tests/test_tool_policy.rs
@@ -233,7 +233,7 @@ fn main() -> Result<()> {
         "write_file".to_string(),
         "list_files".to_string(),
         "run_terminal_cmd".to_string(),
-        "rp_search".to_string(),
+        "grep_file".to_string(),
     ];
     policy_manager.update_available_tools(updated_tools)?;
     policy_manager.print_status();
@@ -244,7 +244,7 @@ fn main() -> Result<()> {
     let final_tools = vec![
         "read_file".to_string(),
         "list_files".to_string(),
-        "rp_search".to_string(),
+        "grep_file".to_string(),
     ];
     policy_manager.update_available_tools(final_tools)?;
     policy_manager.print_status();

--- a/tests/tools_anthropic_alignment.rs
+++ b/tests/tools_anthropic_alignment.rs
@@ -50,14 +50,14 @@ async fn list_files_pagination_and_default_response_format() {
 
 #[tokio::test]
 #[ignore]
-async fn grep_search_default_concise_and_cap() {
+async fn rp_search_default_concise_and_cap() {
     // Skip if ripgrep is not available
     if std::process::Command::new("rg")
         .arg("--version")
         .output()
         .is_err()
     {
-        eprintln!("skipping grep_search_default_concise_and_cap: ripgrep not installed");
+        eprintln!("skipping rp_search_default_concise_and_cap: ripgrep not installed");
         return;
     }
     let dir = tempdir().unwrap();

--- a/tests/tools_anthropic_alignment.rs
+++ b/tests/tools_anthropic_alignment.rs
@@ -50,14 +50,14 @@ async fn list_files_pagination_and_default_response_format() {
 
 #[tokio::test]
 #[ignore]
-async fn rp_search_default_concise_and_cap() {
+async fn grep_file_default_concise_and_cap() {
     // Skip if ripgrep is not available
     if std::process::Command::new("rg")
         .arg("--version")
         .output()
         .is_err()
     {
-        eprintln!("skipping rp_search_default_concise_and_cap: ripgrep not installed");
+        eprintln!("skipping grep_file_default_concise_and_cap: ripgrep not installed");
         return;
     }
     let dir = tempdir().unwrap();
@@ -71,16 +71,16 @@ async fn rp_search_default_concise_and_cap() {
         vtcode_dir.join("tool-policy.json"),
         json!({
             "version": 1,
-            "available_tools": [tools::GREP_SEARCH],
-            "policies": { tools::GREP_SEARCH: "allow" },
-            "constraints": { tools::GREP_SEARCH: { "max_results_per_call": 1, "default_response_format": "concise" } }
+            "available_tools": [tools::GREP_FILE],
+            "policies": { tools::GREP_FILE: "allow" },
+            "constraints": { tools::GREP_FILE: { "max_results_per_call": 1, "default_response_format": "concise" } }
         }).to_string(),
     ).unwrap();
 
     let mut registry = ToolRegistry::new(ws.clone());
     let out = registry
         .execute_tool(
-            tools::GREP_SEARCH,
+            tools::GREP_FILE,
             json!({
                 "pattern": "TODO",
                 "path": ".",

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -95,6 +95,7 @@ tui-scrollview = "0.5.1"
 tui-popup = "0.6"
 tui-prompts = "0.5"
 ignore = "0.4"
+perg = "0.6.1"
 nucleo-matcher = "0.3"
 line-clipping = "0.3"
 comrak = { version = "0.24", default-features = false }

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -653,7 +653,6 @@ pub mod urls {
 /// Tool name constants to avoid hardcoding strings throughout the codebase
 pub mod tools {
     pub const GREP_SEARCH: &str = "rp_search";
-    pub const GREP_SEARCH_LEGACY: &str = "grep_search";
     pub const LIST_FILES: &str = "list_files";
     pub const RUN_TERMINAL_CMD: &str = "run_terminal_cmd";
     pub const RUN_PTY_CMD: &str = "run_pty_cmd";

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -652,7 +652,8 @@ pub mod urls {
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase
 pub mod tools {
-    pub const GREP_SEARCH: &str = "grep_search";
+    pub const GREP_SEARCH: &str = "rp_search";
+    pub const GREP_SEARCH_LEGACY: &str = "grep_search";
     pub const LIST_FILES: &str = "list_files";
     pub const RUN_TERMINAL_CMD: &str = "run_terminal_cmd";
     pub const RUN_PTY_CMD: &str = "run_pty_cmd";

--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -652,7 +652,7 @@ pub mod urls {
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase
 pub mod tools {
-    pub const GREP_SEARCH: &str = "rp_search";
+    pub const GREP_FILE: &str = "grep_file";
     pub const LIST_FILES: &str = "list_files";
     pub const RUN_TERMINAL_CMD: &str = "run_terminal_cmd";
     pub const RUN_PTY_CMD: &str = "run_pty_cmd";

--- a/vtcode-core/src/config/core/automation.rs
+++ b/vtcode-core/src/config/core/automation.rs
@@ -62,7 +62,7 @@ fn default_full_auto_allowed_tools() -> Vec<String> {
     vec![
         tools::READ_FILE.to_string(),
         tools::LIST_FILES.to_string(),
-        tools::GREP_SEARCH.to_string(),
+        tools::GREP_FILE.to_string(),
         tools::SIMPLE_SEARCH.to_string(),
     ]
 }

--- a/vtcode-core/src/config/core/tools.rs
+++ b/vtcode-core/src/config/core/tools.rs
@@ -32,7 +32,7 @@ pub struct ToolsConfig {
 impl Default for ToolsConfig {
     fn default() -> Self {
         let mut policies = IndexMap::new();
-        policies.insert(tools::GREP_SEARCH.to_string(), ToolPolicy::Allow);
+        policies.insert(tools::GREP_FILE.to_string(), ToolPolicy::Allow);
         policies.insert(tools::LIST_FILES.to_string(), ToolPolicy::Allow);
         policies.insert(tools::UPDATE_PLAN.to_string(), ToolPolicy::Allow);
         policies.insert(tools::READ_FILE.to_string(), ToolPolicy::Allow);

--- a/vtcode-core/src/core/context_curator.rs
+++ b/vtcode-core/src/core/context_curator.rs
@@ -610,7 +610,7 @@ mod tests {
 
         let tools = vec![
             ToolDefinition {
-                name: "grep_search".to_string(),
+                name: "rp_search".to_string(),
                 description: "Search for patterns".to_string(),
                 estimated_tokens: 50,
             },
@@ -680,7 +680,7 @@ mod tests {
 
         let tools = vec![
             ToolDefinition {
-                name: "grep_search".to_string(),
+                name: "rp_search".to_string(),
                 description: "Search for patterns".to_string(),
                 estimated_tokens: 20,
             },

--- a/vtcode-core/src/core/context_curator.rs
+++ b/vtcode-core/src/core/context_curator.rs
@@ -610,7 +610,7 @@ mod tests {
 
         let tools = vec![
             ToolDefinition {
-                name: "rp_search".to_string(),
+                name: "grep_file".to_string(),
                 description: "Search for patterns".to_string(),
                 estimated_tokens: 50,
             },
@@ -680,7 +680,7 @@ mod tests {
 
         let tools = vec![
             ToolDefinition {
-                name: "rp_search".to_string(),
+                name: "grep_file".to_string(),
                 description: "Search for patterns".to_string(),
                 estimated_tokens: 20,
             },

--- a/vtcode-core/src/prompts/system.rs
+++ b/vtcode-core/src/prompts/system.rs
@@ -20,14 +20,14 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 
 **Response Framework:**
 1. **Assess the situation** – Understand what the user needs; ask clarifying questions if ambiguous
-2. **Gather context efficiently** – Use search tools (grep_search, ast_grep_search) to locate relevant code before reading files
+2. **Gather context efficiently** – Use search tools (rp_search via the `grep_search` tool, ast_grep_search) to locate relevant code before reading files
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
 6. **Plan TODOs** – For new sessions or tasks, outline a 3–6 step TODO list with update_plan before executing
 
 **Context Management:**
-- Start with lightweight searches (grep_search, list_files) before reading full files
+- Start with lightweight searches (rp_search through the `grep_search` tool, list_files) before reading full files
 - Load file metadata as references; read content only when necessary
 - Summarize verbose outputs; avoid echoing large command results
 - Track your recent actions and decisions to maintain coherence
@@ -36,13 +36,14 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 **Guidelines:**
 - When multiple approaches exist, choose the simplest that fully addresses the issue
 - If a file is mentioned, search for it first to understand its context and location
+- Route grep-style searches through rp_search (`grep_search`); avoid shell `rg`/`grep` unless the tool fails
 - Keep the TODO plan current; update update_plan after each completed step
 - Always preserve existing code style and patterns in the codebase
 - For potentially destructive operations (delete, major refactor), explain the impact before proceeding
 - Acknowledge urgency or complexity in the user's request and respond with appropriate clarity
 
 **Tools Available:**
-**Exploration:** list_files, grep_search, ast_grep_search
+**Exploration:** list_files, rp_search (`grep_search`), ast_grep_search
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (with PTY support)
 **Network:** curl (HTTPS only, no localhost/private IPs)
@@ -68,7 +69,7 @@ Load only what's necessary. Use search tools first. Summarize results.
 
 **Tools:**
 **Files:** list_files, read_file, write_file, edit_file
-**Search:** grep_search, ast_grep_search
+**Search:** rp_search (`grep_search`), ast_grep_search
 **Shell:** run_terminal_cmd
 **Network:** curl (HTTPS only)
 **Version Control:** git_diff (prefer this over raw `git diff` for structured output)
@@ -95,7 +96,7 @@ Handle complex coding tasks that require deep understanding, structural changes,
 
 **Context Management:**
 - Minimize attention budget usage through strategic tool selection
-- Use search (grep_search, ast_grep_search) before reading to identify relevant code
+- Use search (rp_search via `grep_search`, ast_grep_search) before reading to identify relevant code
 - Build understanding layer-by-layer with progressive disclosure
 - Maintain working memory of recent decisions, changes, and outcomes
 - Reference past tool results without re-executing
@@ -110,12 +111,12 @@ Handle complex coding tasks that require deep understanding, structural changes,
 - For errors, analyze root causes before proposing fixes
 
 **Tool Selection Strategy:**
-- **Exploration Phase:** grep_search → list_files → ast_grep_search → read_file
+- **Exploration Phase:** rp_search (`grep_search`) → list_files → ast_grep_search → read_file
 - **Implementation Phase:** edit_file (preferred) or write_file → run_terminal_cmd (validate)
 - **Analysis Phase:** ast_grep_search (structural) → tree-sitter parsing → performance profiling
 
 **Advanced Tools:**
-**Exploration:** list_files, grep_search, ast_grep_search (tree-sitter-powered)
+**Exploration:** list_files, rp_search (`grep_search`), ast_grep_search (tree-sitter-powered)
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (full PTY emulation)
 **Network:** curl (HTTPS only, sandboxed)

--- a/vtcode-core/src/prompts/system.rs
+++ b/vtcode-core/src/prompts/system.rs
@@ -20,14 +20,14 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 
 **Response Framework:**
 1. **Assess the situation** – Understand what the user needs; ask clarifying questions if ambiguous
-2. **Gather context efficiently** – Use search tools (rp_search via the `grep_search` tool, ast_grep_search) to locate relevant code before reading files
+2. **Gather context efficiently** – Use search tools (rp_search — alias `grep_search` — and ast_grep_search) to locate relevant code before reading files
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
 6. **Plan TODOs** – For new sessions or tasks, outline a 3–6 step TODO list with update_plan before executing
 
 **Context Management:**
-- Start with lightweight searches (rp_search through the `grep_search` tool, list_files) before reading full files
+- Start with lightweight searches (rp_search, list_files) before reading full files
 - Load file metadata as references; read content only when necessary
 - Summarize verbose outputs; avoid echoing large command results
 - Track your recent actions and decisions to maintain coherence
@@ -36,14 +36,14 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 **Guidelines:**
 - When multiple approaches exist, choose the simplest that fully addresses the issue
 - If a file is mentioned, search for it first to understand its context and location
-- Route grep-style searches through rp_search (`grep_search`); avoid shell `rg`/`grep` unless the tool fails
+- Route grep-style searches through rp_search (legacy alias `grep_search`); avoid shell `rg`/`grep` unless the tool fails
 - Keep the TODO plan current; update update_plan after each completed step
 - Always preserve existing code style and patterns in the codebase
 - For potentially destructive operations (delete, major refactor), explain the impact before proceeding
 - Acknowledge urgency or complexity in the user's request and respond with appropriate clarity
 
 **Tools Available:**
-**Exploration:** list_files, rp_search (`grep_search`), ast_grep_search
+**Exploration:** list_files, rp_search, ast_grep_search
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (with PTY support)
 **Network:** curl (HTTPS only, no localhost/private IPs)
@@ -69,7 +69,7 @@ Load only what's necessary. Use search tools first. Summarize results.
 
 **Tools:**
 **Files:** list_files, read_file, write_file, edit_file
-**Search:** rp_search (`grep_search`), ast_grep_search
+**Search:** rp_search, ast_grep_search
 **Shell:** run_terminal_cmd
 **Network:** curl (HTTPS only)
 **Version Control:** git_diff (prefer this over raw `git diff` for structured output)
@@ -96,7 +96,7 @@ Handle complex coding tasks that require deep understanding, structural changes,
 
 **Context Management:**
 - Minimize attention budget usage through strategic tool selection
-- Use search (rp_search via `grep_search`, ast_grep_search) before reading to identify relevant code
+- Use search (rp_search, ast_grep_search) before reading to identify relevant code
 - Build understanding layer-by-layer with progressive disclosure
 - Maintain working memory of recent decisions, changes, and outcomes
 - Reference past tool results without re-executing
@@ -111,12 +111,12 @@ Handle complex coding tasks that require deep understanding, structural changes,
 - For errors, analyze root causes before proposing fixes
 
 **Tool Selection Strategy:**
-- **Exploration Phase:** rp_search (`grep_search`) → list_files → ast_grep_search → read_file
+- **Exploration Phase:** rp_search → list_files → ast_grep_search → read_file
 - **Implementation Phase:** edit_file (preferred) or write_file → run_terminal_cmd (validate)
 - **Analysis Phase:** ast_grep_search (structural) → tree-sitter parsing → performance profiling
 
 **Advanced Tools:**
-**Exploration:** list_files, rp_search (`grep_search`), ast_grep_search (tree-sitter-powered)
+**Exploration:** list_files, rp_search, ast_grep_search (tree-sitter-powered)
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (full PTY emulation)
 **Network:** curl (HTTPS only, sandboxed)

--- a/vtcode-core/src/prompts/system.rs
+++ b/vtcode-core/src/prompts/system.rs
@@ -20,7 +20,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 
 **Response Framework:**
 1. **Assess the situation** – Understand what the user needs; ask clarifying questions if ambiguous
-2. **Gather context efficiently** – Use search tools (rp_search — alias `grep_search` — and ast_grep_search) to locate relevant code before reading files
+2. **Gather context efficiently** – Use search tools (rp_search and ast_grep_search) to locate relevant code before reading files
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
@@ -36,7 +36,7 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 **Guidelines:**
 - When multiple approaches exist, choose the simplest that fully addresses the issue
 - If a file is mentioned, search for it first to understand its context and location
-- Route grep-style searches through rp_search (legacy alias `grep_search`); avoid shell `rg`/`grep` unless the tool fails
+- Route grep-style searches through rp_search; avoid shell `rg`/`grep` unless the tool fails
 - Keep the TODO plan current; update update_plan after each completed step
 - Always preserve existing code style and patterns in the codebase
 - For potentially destructive operations (delete, major refactor), explain the impact before proceeding

--- a/vtcode-core/src/prompts/system.rs
+++ b/vtcode-core/src/prompts/system.rs
@@ -20,14 +20,14 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 
 **Response Framework:**
 1. **Assess the situation** – Understand what the user needs; ask clarifying questions if ambiguous
-2. **Gather context efficiently** – Use search tools (rp_search and ast_grep_search) to locate relevant code before reading files
+2. **Gather context efficiently** – Use search tools (grep_file and ast_grep_search) to locate relevant code before reading files
 3. **Make precise changes** – Prefer targeted edits (edit_file) over full rewrites; preserve existing patterns
 4. **Verify outcomes** – Test changes with appropriate commands; check for errors
 5. **Confirm completion** – Summarize what was done and verify user satisfaction
 6. **Plan TODOs** – For new sessions or tasks, outline a 3–6 step TODO list with update_plan before executing
 
 **Context Management:**
-- Start with lightweight searches (rp_search, list_files) before reading full files
+- Start with lightweight searches (grep_file, list_files) before reading full files
 - Load file metadata as references; read content only when necessary
 - Summarize verbose outputs; avoid echoing large command results
 - Track your recent actions and decisions to maintain coherence
@@ -36,14 +36,14 @@ Explore code efficiently, make targeted changes, validate outcomes, and maintain
 **Guidelines:**
 - When multiple approaches exist, choose the simplest that fully addresses the issue
 - If a file is mentioned, search for it first to understand its context and location
-- Route grep-style searches through rp_search; avoid shell `rg`/`grep` unless the tool fails
+- Route grep-style searches through grep_file; avoid shell `rg`/`grep` unless the tool fails
 - Keep the TODO plan current; update update_plan after each completed step
 - Always preserve existing code style and patterns in the codebase
 - For potentially destructive operations (delete, major refactor), explain the impact before proceeding
 - Acknowledge urgency or complexity in the user's request and respond with appropriate clarity
 
 **Tools Available:**
-**Exploration:** list_files, rp_search, ast_grep_search
+**Exploration:** list_files, grep_file, ast_grep_search
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (with PTY support)
 **Network:** curl (HTTPS only, no localhost/private IPs)
@@ -69,7 +69,7 @@ Load only what's necessary. Use search tools first. Summarize results.
 
 **Tools:**
 **Files:** list_files, read_file, write_file, edit_file
-**Search:** rp_search, ast_grep_search
+**Search:** grep_file, ast_grep_search
 **Shell:** run_terminal_cmd
 **Network:** curl (HTTPS only)
 **Version Control:** git_diff (prefer this over raw `git diff` for structured output)
@@ -96,7 +96,7 @@ Handle complex coding tasks that require deep understanding, structural changes,
 
 **Context Management:**
 - Minimize attention budget usage through strategic tool selection
-- Use search (rp_search, ast_grep_search) before reading to identify relevant code
+- Use search (grep_file, ast_grep_search) before reading to identify relevant code
 - Build understanding layer-by-layer with progressive disclosure
 - Maintain working memory of recent decisions, changes, and outcomes
 - Reference past tool results without re-executing
@@ -111,12 +111,12 @@ Handle complex coding tasks that require deep understanding, structural changes,
 - For errors, analyze root causes before proposing fixes
 
 **Tool Selection Strategy:**
-- **Exploration Phase:** rp_search → list_files → ast_grep_search → read_file
+- **Exploration Phase:** grep_file → list_files → ast_grep_search → read_file
 - **Implementation Phase:** edit_file (preferred) or write_file → run_terminal_cmd (validate)
 - **Analysis Phase:** ast_grep_search (structural) → tree-sitter parsing → performance profiling
 
 **Advanced Tools:**
-**Exploration:** list_files, rp_search, ast_grep_search (tree-sitter-powered)
+**Exploration:** list_files, grep_file, ast_grep_search (tree-sitter-powered)
 **File Operations:** read_file, write_file, edit_file
 **Execution:** run_terminal_cmd (full PTY emulation)
 **Network:** curl (HTTPS only, sandboxed)

--- a/vtcode-core/src/tool_policy.rs
+++ b/vtcode-core/src/tool_policy.rs
@@ -23,6 +23,7 @@ use crate::utils::ansi::{AnsiRenderer, MessageStyle};
 use crate::config::constants::tools;
 use crate::config::core::tools::{ToolPolicy as ConfigToolPolicy, ToolsConfig};
 use crate::config::mcp::{McpAllowListConfig, McpAllowListRules};
+use crate::tools::names::canonical_tool_name;
 
 const AUTO_ALLOW_TOOLS: &[&str] = &[
     tools::GREP_SEARCH,
@@ -399,6 +400,7 @@ impl ToolPolicyManager {
             // Fall back to standard format with graceful recovery on parse errors
             match serde_json::from_str(&content) {
                 Ok(mut config) => {
+                    Self::migrate_legacy_tool_names(&mut config);
                     Self::apply_auto_allow_defaults(&mut config);
                     Self::ensure_network_constraints(&mut config);
                     Ok(config)
@@ -433,6 +435,35 @@ impl ToolPolicyManager {
             }
         }
         Self::ensure_network_constraints(config);
+    }
+
+    fn migrate_legacy_tool_names(config: &mut ToolPolicyConfig) {
+        if let Some(policy) = config.policies.shift_remove(tools::GREP_SEARCH_LEGACY) {
+            config
+                .policies
+                .entry(tools::GREP_SEARCH.to_string())
+                .or_insert(policy);
+        }
+
+        if let Some(constraints) = config.constraints.shift_remove(tools::GREP_SEARCH_LEGACY) {
+            config
+                .constraints
+                .entry(tools::GREP_SEARCH.to_string())
+                .or_insert(constraints);
+        }
+
+        let mut replaced = false;
+        for entry in config.available_tools.iter_mut() {
+            if entry == tools::GREP_SEARCH_LEGACY {
+                *entry = tools::GREP_SEARCH.to_string();
+                replaced = true;
+            }
+        }
+
+        if replaced {
+            config.available_tools.sort();
+            config.available_tools.dedup();
+        }
     }
 
     fn ensure_network_constraints(config: &mut ToolPolicyConfig) {
@@ -527,6 +558,7 @@ impl ToolPolicyManager {
     }
 
     fn apply_config_policy(&mut self, tool_name: &str, policy: ConfigToolPolicy) {
+        let canonical = canonical_tool_name(tool_name);
         let runtime_policy = match policy {
             ConfigToolPolicy::Allow => ToolPolicy::Allow,
             ConfigToolPolicy::Prompt => ToolPolicy::Prompt,
@@ -535,12 +567,21 @@ impl ToolPolicyManager {
 
         self.config
             .policies
-            .insert(tool_name.to_string(), runtime_policy);
+            .insert(canonical.into_owned(), runtime_policy);
     }
 
     fn resolve_config_policy(tools_config: &ToolsConfig, tool_name: &str) -> ConfigToolPolicy {
-        if let Some(policy) = tools_config.policies.get(tool_name) {
+        let canonical = canonical_tool_name(tool_name);
+        let lookup = canonical.as_ref();
+
+        if let Some(policy) = tools_config.policies.get(lookup) {
             return policy.clone();
+        }
+
+        if lookup == tools::GREP_SEARCH {
+            if let Some(policy) = tools_config.policies.get(tools::GREP_SEARCH_LEGACY) {
+                return policy.clone();
+            }
         }
 
         match tool_name {
@@ -571,8 +612,16 @@ impl ToolPolicyManager {
 
     /// Update the tool list and save configuration
     pub fn update_available_tools(&mut self, tools: Vec<String>) -> Result<()> {
+        let mut canonical_tools = Vec::new();
+        for tool in tools {
+            let canonical = canonical_tool_name(&tool).into_owned();
+            if !canonical_tools.contains(&canonical) {
+                canonical_tools.push(canonical);
+            }
+        }
+
         let current_tools: HashSet<_> = self.config.policies.keys().cloned().collect();
-        let new_tools: HashSet<_> = tools
+        let new_tools: HashSet<_> = canonical_tools
             .iter()
             .filter(|name| !name.starts_with("mcp::"))
             .cloned()
@@ -580,8 +629,7 @@ impl ToolPolicyManager {
 
         let mut has_changes = false;
 
-        // Add new tools with appropriate defaults
-        for tool in tools
+        for tool in canonical_tools
             .iter()
             .filter(|tool| !tool.starts_with("mcp::") && !current_tools.contains(*tool))
         {
@@ -594,7 +642,6 @@ impl ToolPolicyManager {
             has_changes = true;
         }
 
-        // Remove deleted tools - use itertools to find tools to remove
         let tools_to_remove: Vec<_> = self
             .config
             .policies
@@ -608,10 +655,8 @@ impl ToolPolicyManager {
             has_changes = true;
         }
 
-        // Check if available tools list has actually changed
-        if self.config.available_tools != tools {
-            // Update available tools list
-            self.config.available_tools = tools;
+        if self.config.available_tools != canonical_tools {
+            self.config.available_tools = canonical_tools;
             has_changes = true;
         }
 
@@ -756,20 +801,22 @@ impl ToolPolicyManager {
 
     /// Get policy for a specific tool
     pub fn get_policy(&self, tool_name: &str) -> ToolPolicy {
+        let canonical = canonical_tool_name(tool_name);
         if let Some((provider, tool)) = parse_mcp_policy_key(tool_name) {
             return self.get_mcp_tool_policy(&provider, &tool);
         }
 
         self.config
             .policies
-            .get(tool_name)
+            .get(canonical.as_ref())
             .cloned()
             .unwrap_or(ToolPolicy::Prompt)
     }
 
     /// Get optional constraints for a specific tool
     pub fn get_constraints(&self, tool_name: &str) -> Option<&ToolConstraints> {
-        self.config.constraints.get(tool_name)
+        let canonical = canonical_tool_name(tool_name);
+        self.config.constraints.get(canonical.as_ref())
     }
 
     /// Check if tool should be executed based on policy
@@ -789,22 +836,26 @@ impl ToolPolicyManager {
             };
         }
 
-        match self.get_policy(tool_name) {
+        let canonical = canonical_tool_name(tool_name);
+
+        match self.get_policy(canonical.as_ref()) {
             ToolPolicy::Allow => Ok(true),
             ToolPolicy::Deny => Ok(false),
             ToolPolicy::Prompt => {
-                if AUTO_ALLOW_TOOLS.contains(&tool_name) {
-                    self.set_policy(tool_name, ToolPolicy::Allow)?;
+                let canonical_name = canonical.as_ref();
+                if AUTO_ALLOW_TOOLS.contains(&canonical_name) {
+                    self.set_policy(canonical_name, ToolPolicy::Allow)?;
                     return Ok(true);
                 }
-                let should_execute = self.prompt_user_for_tool(tool_name)?;
+                let should_execute = self.prompt_user_for_tool(canonical_name)?;
                 Ok(should_execute)
             }
         }
     }
 
     pub fn is_auto_allow_tool(tool_name: &str) -> bool {
-        AUTO_ALLOW_TOOLS.contains(&tool_name)
+        let canonical = canonical_tool_name(tool_name);
+        AUTO_ALLOW_TOOLS.contains(&canonical.as_ref())
     }
 
     /// Prompt user for tool execution permission
@@ -920,7 +971,8 @@ impl ToolPolicyManager {
             return self.set_mcp_tool_policy(&provider, &tool, policy);
         }
 
-        self.config.policies.insert(tool_name.to_string(), policy);
+        let canonical = canonical_tool_name(tool_name);
+        self.config.policies.insert(canonical.into_owned(), policy);
         self.save_config()
     }
 

--- a/vtcode-core/src/tool_policy.rs
+++ b/vtcode-core/src/tool_policy.rs
@@ -26,7 +26,7 @@ use crate::config::mcp::{McpAllowListConfig, McpAllowListRules};
 use crate::tools::names::canonical_tool_name;
 
 const AUTO_ALLOW_TOOLS: &[&str] = &[
-    tools::GREP_SEARCH,
+    tools::GREP_FILE,
     tools::LIST_FILES,
     tools::UPDATE_PLAN,
     tools::RUN_TERMINAL_CMD,

--- a/vtcode-core/src/tools/advanced_search.rs
+++ b/vtcode-core/src/tools/advanced_search.rs
@@ -44,7 +44,7 @@ impl Default for SearchOptions {
 
 impl AdvancedSearchTool {
     pub fn new(workspace_root: PathBuf, _grep_search: Arc<GrepSearchManager>) -> Self {
-        // grep_search was unused; keep constructor signature for compatibility but drop the field
+        // rp_search manager is unused; keep constructor signature for compatibility but drop the field
         Self { workspace_root }
     }
 

--- a/vtcode-core/src/tools/advanced_search.rs
+++ b/vtcode-core/src/tools/advanced_search.rs
@@ -44,7 +44,7 @@ impl Default for SearchOptions {
 
 impl AdvancedSearchTool {
     pub fn new(workspace_root: PathBuf, _grep_search: Arc<GrepSearchManager>) -> Self {
-        // rp_search manager is unused; keep constructor signature for compatibility but drop the field
+        // grep_file manager is unused; keep constructor signature for compatibility but drop the field
         Self { workspace_root }
     }
 
@@ -527,8 +527,8 @@ mod tests {
             .await
             .unwrap();
 
-        let rp_search = Arc::new(GrepSearchManager::new(workspace_root.clone()));
-        let search_tool = AdvancedSearchTool::new(workspace_root, rp_search);
+        let grep_file = Arc::new(GrepSearchManager::new(workspace_root.clone()));
+        let search_tool = AdvancedSearchTool::new(workspace_root, grep_file);
 
         let options = SearchOptions {
             case_sensitive: false,
@@ -552,8 +552,8 @@ mod tests {
             .await
             .unwrap();
 
-        let rp_search = Arc::new(GrepSearchManager::new(workspace_root.clone()));
-        let search_tool = AdvancedSearchTool::new(workspace_root, rp_search);
+        let grep_file = Arc::new(GrepSearchManager::new(workspace_root.clone()));
+        let search_tool = AdvancedSearchTool::new(workspace_root, grep_file);
 
         let options = SearchOptions {
             case_sensitive: false,

--- a/vtcode-core/src/tools/file_ops.rs
+++ b/vtcode-core/src/tools/file_ops.rs
@@ -24,7 +24,7 @@ pub struct FileOpsTool {
 
 impl FileOpsTool {
     pub fn new(workspace_root: PathBuf, _grep_search: Arc<GrepSearchManager>) -> Self {
-        // grep_search was unused; keep param to avoid broad call-site churn
+        // rp_search manager is unused; keep param to avoid broad call-site churn
         Self { workspace_root }
     }
 

--- a/vtcode-core/src/tools/file_ops.rs
+++ b/vtcode-core/src/tools/file_ops.rs
@@ -24,7 +24,7 @@ pub struct FileOpsTool {
 
 impl FileOpsTool {
     pub fn new(workspace_root: PathBuf, _grep_search: Arc<GrepSearchManager>) -> Self {
-        // rp_search manager is unused; keep param to avoid broad call-site churn
+        // grep_file manager is unused; keep param to avoid broad call-site churn
         Self { workspace_root }
     }
 

--- a/vtcode-core/src/tools/grep_search.rs
+++ b/vtcode-core/src/tools/grep_search.rs
@@ -11,10 +11,14 @@
 //! 4. If there is an in-flight search that is not a prefix of the latest thing
 //!    the user typed, it is cancelled.
 
-use anyhow::Result;
-use serde_json;
+use anyhow::{Context, Error as AnyhowError, Result};
+use glob::Pattern;
+use perg::{SearchConfig, search_paths};
+use regex::escape;
+use serde_json::{self, Value, json};
+use std::io::ErrorKind;
 use std::num::NonZeroUsize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
@@ -46,6 +50,13 @@ pub struct GrepSearchInput {
     pub context_lines: Option<usize>,
     pub include_hidden: Option<bool>,
     pub max_results: Option<usize>,
+}
+
+fn is_hidden_path(path: &str) -> bool {
+    Path::new(path)
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .any(|segment| segment.starts_with('.') && segment != "." && segment != "..")
 }
 
 /// Result of a ripgrep search
@@ -170,99 +181,32 @@ impl GrepSearchManager {
         st.last_result.clone()
     }
 
-    fn spawn_rp_search(
-        query: String,
-        search_dir: PathBuf,
-        cancellation_token: Arc<AtomicBool>,
-        search_state: Arc<Mutex<SearchState>>,
-    ) {
-        use std::process::Command;
-
-        thread::spawn(move || {
-            // Check if cancelled before starting
-            if cancellation_token.load(Ordering::Relaxed) {
-                // Reset the active search state
-                {
-                    #[expect(clippy::unwrap_used)]
-                    let mut st = search_state.lock().unwrap();
-                    if let Some(active_search) = &st.active_search
-                        && Arc::ptr_eq(&active_search.cancellation_token, &cancellation_token)
-                    {
-                        st.active_search = None;
-                    }
-                }
-                return;
-            }
-
-            // Build the ripgrep command
-            let mut cmd = Command::new("rg");
-            cmd.arg("-j").arg(NUM_SEARCH_THREADS.get().to_string());
-
-            // Add the search pattern
-            cmd.arg(&query);
-
-            // Add the search path
-            cmd.arg(search_dir.to_string_lossy().as_ref());
-
-            // Output as JSON for easier parsing
-            cmd.arg("--json");
-
-            // Set result limits
-            cmd.arg("--max-count")
-                .arg(MAX_SEARCH_RESULTS.get().to_string());
-
-            // Execute the command
-            let output = cmd.output();
-
-            let is_cancelled = cancellation_token.load(Ordering::Relaxed);
-            if !is_cancelled
-                && let Ok(output) = output
-                && output.status.success()
-            {
-                let output_str = String::from_utf8_lossy(&output.stdout);
-                let mut matches = Vec::new();
-                for line in output_str.lines() {
-                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-                        matches.push(val);
-                    }
-                }
-                let result = GrepSearchResult {
-                    query: query.clone(),
-                    matches,
-                };
-                #[expect(clippy::unwrap_used)]
-                let mut st = search_state.lock().unwrap();
-                st.last_result = Some(result);
-            }
-
-            // Reset the active search state
-            {
-                #[expect(clippy::unwrap_used)]
-                let mut st = search_state.lock().unwrap();
-                if let Some(active_search) = &st.active_search
-                    && Arc::ptr_eq(&active_search.cancellation_token, &cancellation_token)
-                {
-                    st.active_search = None;
+    fn execute_with_backends(input: &GrepSearchInput) -> Result<Vec<Value>> {
+        match Self::run_ripgrep_backend(input) {
+            Ok(matches) => Ok(matches),
+            Err(err) => {
+                if Self::is_ripgrep_missing(&err) {
+                    Self::run_perg_backend(input).with_context(|| {
+                        format!(
+                            "perg fallback failed for pattern '{}' under '{}'",
+                            input.pattern, input.path
+                        )
+                    })
+                } else {
+                    Err(err)
                 }
             }
-        });
+        }
     }
 
-    /// Perform an actual ripgrep search with the given input parameters
-    pub async fn perform_search(&self, input: GrepSearchInput) -> Result<GrepSearchResult> {
-        // std::path::Path import removed as it's not directly used
+    fn run_ripgrep_backend(input: &GrepSearchInput) -> Result<Vec<Value>> {
         use std::process::Command;
 
-        // Build the ripgrep command
         let mut cmd = Command::new("rg");
-
-        // Add the search pattern
+        cmd.arg("-j").arg(NUM_SEARCH_THREADS.get().to_string());
         cmd.arg(&input.pattern);
-
-        // Add the search path
         cmd.arg(&input.path);
 
-        // Add optional flags
         if let Some(case_sensitive) = input.case_sensitive {
             if case_sensitive {
                 cmd.arg("--case-sensitive");
@@ -291,38 +235,181 @@ impl GrepSearchManager {
             cmd.arg("--hidden");
         }
 
-        // Set result limits
         let max_results = input.max_results.unwrap_or(MAX_SEARCH_RESULTS.get());
         cmd.arg("--max-count").arg(max_results.to_string());
-
-        // Output as JSON for easier parsing
         cmd.arg("--json");
 
-        // Execute the command
-        let output = cmd.output()?;
+        let output = cmd.output().with_context(|| {
+            format!("failed to execute ripgrep for pattern '{}'", input.pattern)
+        })?;
 
-        if !output.status.success() {
-            // If ripgrep is not found, return an error
-            if String::from_utf8_lossy(&output.stderr).contains("not found") {
-                return Err(anyhow::anyhow!(
-                    "ripgrep (rg) command not found. Please install ripgrep to use search functionality."
-                ));
-            }
-
-            // For other errors, still return results but with a warning
-        }
-
-        // Parse the JSON output
         let output_str = String::from_utf8_lossy(&output.stdout);
         let mut matches = Vec::new();
-
         for line in output_str.lines() {
-            if !line.trim().is_empty()
-                && let Ok(json_value) = serde_json::from_str::<serde_json::Value>(line)
-            {
-                matches.push(json_value);
+            if let Ok(value) = serde_json::from_str::<Value>(line) {
+                matches.push(value);
             }
         }
+
+        Ok(matches)
+    }
+
+    fn run_perg_backend(input: &GrepSearchInput) -> Result<Vec<Value>> {
+        let mut pattern = input.pattern.clone();
+        if input.literal.unwrap_or(false) {
+            pattern = escape(&pattern);
+        }
+
+        let config = SearchConfig::new(
+            pattern,
+            !input.case_sensitive.unwrap_or(true),
+            true,
+            true,
+            false,
+            false,
+            false,
+        );
+
+        let mut output_buffer = Vec::new();
+        let search_targets = vec![input.path.clone()];
+        search_paths(&config, &search_targets, true, true, &mut output_buffer)
+            .with_context(|| format!("perg search failed for path '{}'", input.path))?;
+
+        let output = String::from_utf8(output_buffer)
+            .with_context(|| "perg search output was not valid UTF-8".to_string())?;
+
+        let glob_filter =
+            if let Some(pattern) = &input.glob_pattern {
+                Some(Pattern::new(pattern).with_context(|| {
+                    format!("invalid glob pattern '{}' for perg fallback", pattern)
+                })?)
+            } else {
+                None
+            };
+
+        let include_hidden = input.include_hidden.unwrap_or(false);
+        let max_results = input.max_results.unwrap_or(MAX_SEARCH_RESULTS.get());
+        let mut matches = Vec::new();
+
+        for line in output.lines() {
+            if matches.len() >= max_results {
+                break;
+            }
+
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let mut parts = line.splitn(3, ':');
+            let file = match parts.next() {
+                Some(path) if !path.is_empty() => path,
+                _ => continue,
+            };
+
+            if let Some(pattern) = &glob_filter {
+                if !pattern.matches(file) {
+                    continue;
+                }
+            }
+
+            if !include_hidden && is_hidden_path(file) {
+                continue;
+            }
+
+            let line_number = parts
+                .next()
+                .and_then(|num| num.parse::<u64>().ok())
+                .unwrap_or(0);
+            let text = parts.next().unwrap_or("");
+
+            matches.push(json!({
+                "type": "match",
+                "data": {
+                    "path": {"text": file},
+                    "line_number": line_number,
+                    "lines": {"text": format!("{}\n", text)},
+                }
+            }));
+        }
+
+        Ok(matches)
+    }
+
+    fn is_ripgrep_missing(err: &AnyhowError) -> bool {
+        err.chain().any(|cause| {
+            cause
+                .downcast_ref::<std::io::Error>()
+                .map(|io_err| io_err.kind() == ErrorKind::NotFound)
+                .unwrap_or(false)
+        })
+    }
+
+    fn spawn_rp_search(
+        query: String,
+        search_dir: PathBuf,
+        cancellation_token: Arc<AtomicBool>,
+        search_state: Arc<Mutex<SearchState>>,
+    ) {
+        thread::spawn(move || {
+            // Check if cancelled before starting
+            if cancellation_token.load(Ordering::Relaxed) {
+                // Reset the active search state
+                {
+                    #[expect(clippy::unwrap_used)]
+                    let mut st = search_state.lock().unwrap();
+                    if let Some(active_search) = &st.active_search
+                        && Arc::ptr_eq(&active_search.cancellation_token, &cancellation_token)
+                    {
+                        st.active_search = None;
+                    }
+                }
+                return;
+            }
+
+            let input = GrepSearchInput {
+                pattern: query.clone(),
+                path: search_dir.to_string_lossy().into_owned(),
+                case_sensitive: Some(true),
+                literal: Some(false),
+                glob_pattern: None,
+                context_lines: None,
+                include_hidden: Some(false),
+                max_results: Some(MAX_SEARCH_RESULTS.get()),
+            };
+
+            let search_result = GrepSearchManager::execute_with_backends(&input);
+
+            let is_cancelled = cancellation_token.load(Ordering::Relaxed);
+            if !is_cancelled {
+                if let Ok(matches) = search_result {
+                    if !matches.is_empty() {
+                        let result = GrepSearchResult {
+                            query: query.clone(),
+                            matches,
+                        };
+                        #[expect(clippy::unwrap_used)]
+                        let mut st = search_state.lock().unwrap();
+                        st.last_result = Some(result);
+                    }
+                }
+            }
+
+            // Reset the active search state
+            {
+                #[expect(clippy::unwrap_used)]
+                let mut st = search_state.lock().unwrap();
+                if let Some(active_search) = &st.active_search
+                    && Arc::ptr_eq(&active_search.cancellation_token, &cancellation_token)
+                {
+                    st.active_search = None;
+                }
+            }
+        });
+    }
+
+    /// Perform an actual ripgrep search with the given input parameters
+    pub async fn perform_search(&self, input: GrepSearchInput) -> Result<GrepSearchResult> {
+        let matches = GrepSearchManager::execute_with_backends(&input)?;
 
         Ok(GrepSearchResult {
             query: input.pattern,

--- a/vtcode-core/src/tools/grep_search.rs
+++ b/vtcode-core/src/tools/grep_search.rs
@@ -1,4 +1,4 @@
-//! Helper that owns the debounce/cancellation logic for `rp_search` operations.
+//! Helper that owns the debounce/cancellation logic for `grep_file` operations.
 //!
 //! This module manages the orchestration of ripgrep searches, implementing
 //! debounce and cancellation logic to ensure responsive and efficient searches.
@@ -66,7 +66,7 @@ pub struct GrepSearchResult {
     pub matches: Vec<serde_json::Value>,
 }
 
-/// State machine for grep_search orchestration.
+/// State machine for grep_file orchestration.
 pub struct GrepSearchManager {
     /// Unified state guarded by one mutex.
     state: Arc<Mutex<SearchState>>,
@@ -170,7 +170,7 @@ impl GrepSearchManager {
                 query
             };
 
-            GrepSearchManager::spawn_rp_search(query, search_dir, cancellation_token, state);
+            GrepSearchManager::spawn_grep_file(query, search_dir, cancellation_token, state);
         });
     }
 
@@ -344,7 +344,7 @@ impl GrepSearchManager {
         })
     }
 
-    fn spawn_rp_search(
+    fn spawn_grep_file(
         query: String,
         search_dir: PathBuf,
         cancellation_token: Arc<AtomicBool>,

--- a/vtcode-core/src/tools/grep_search.rs
+++ b/vtcode-core/src/tools/grep_search.rs
@@ -305,23 +305,25 @@ impl GrepSearchManager {
                 None => continue,
             };
 
-            let mut remaining = prefix;
+            let mut prefix_end = prefix.len();
             let mut numeric_segments = Vec::new();
 
-            while let Some((rest, segment)) = remaining.rsplit_once(':') {
-                if segment.chars().all(|c| c.is_ascii_digit()) {
+            while let Some(pos) = prefix[..prefix_end].rfind(':') {
+                let segment = &prefix[pos + 1..prefix_end];
+
+                if !segment.is_empty() && segment.chars().all(|c| c.is_ascii_digit()) {
                     numeric_segments.push(segment);
-                    remaining = rest;
+                    prefix_end = pos;
                 } else {
                     break;
                 }
             }
 
-            if remaining.is_empty() {
+            if prefix_end == 0 {
                 continue;
             }
 
-            let file = remaining;
+            let file = &prefix[..prefix_end];
 
             if let Some(pattern) = &glob_filter {
                 if !pattern.matches(file) {

--- a/vtcode-core/src/tools/mod.rs
+++ b/vtcode-core/src/tools/mod.rs
@@ -134,6 +134,7 @@ pub mod file_ops;
 pub mod file_search;
 pub mod git_diff;
 pub mod grep_search;
+pub mod names;
 pub mod plan;
 pub mod pty;
 pub mod registry;

--- a/vtcode-core/src/tools/names.rs
+++ b/vtcode-core/src/tools/names.rs
@@ -1,21 +1,11 @@
 use std::borrow::Cow;
 
-use crate::config::constants::tools;
-
-const RP_SEARCH_ALIASES: &[&str] = &[tools::GREP_SEARCH_LEGACY];
-
 /// Normalize tool identifiers to their canonical registry names.
 pub fn canonical_tool_name<'a>(name: &'a str) -> Cow<'a, str> {
-    match name {
-        tools::GREP_SEARCH_LEGACY => Cow::Borrowed(tools::GREP_SEARCH),
-        _ => Cow::Borrowed(name),
-    }
+    Cow::Borrowed(name)
 }
 
 /// Return known aliases for a canonical tool name.
-pub fn tool_aliases(name: &str) -> &'static [&'static str] {
-    match name {
-        tools::GREP_SEARCH => RP_SEARCH_ALIASES,
-        _ => &[],
-    }
+pub fn tool_aliases(_name: &str) -> &'static [&'static str] {
+    &[]
 }

--- a/vtcode-core/src/tools/names.rs
+++ b/vtcode-core/src/tools/names.rs
@@ -1,0 +1,21 @@
+use std::borrow::Cow;
+
+use crate::config::constants::tools;
+
+const RP_SEARCH_ALIASES: &[&str] = &[tools::GREP_SEARCH_LEGACY];
+
+/// Normalize tool identifiers to their canonical registry names.
+pub fn canonical_tool_name<'a>(name: &'a str) -> Cow<'a, str> {
+    match name {
+        tools::GREP_SEARCH_LEGACY => Cow::Borrowed(tools::GREP_SEARCH),
+        _ => Cow::Borrowed(name),
+    }
+}
+
+/// Return known aliases for a canonical tool name.
+pub fn tool_aliases(name: &str) -> &'static [&'static str] {
+    match name {
+        tools::GREP_SEARCH => RP_SEARCH_ALIASES,
+        _ => &[],
+    }
+}

--- a/vtcode-core/src/tools/registry/builtins.rs
+++ b/vtcode-core/src/tools/registry/builtins.rs
@@ -23,10 +23,10 @@ pub(super) fn register_builtin_tools(inventory: &mut ToolInventory, todo_plannin
 pub(super) fn builtin_tool_registrations() -> Vec<ToolRegistration> {
     vec![
         ToolRegistration::new(
-            tools::GREP_SEARCH,
+            tools::GREP_FILE,
             CapabilityLevel::CodeSearch,
             false,
-            ToolRegistry::grep_search_executor,
+            ToolRegistry::grep_file_executor,
         ),
         ToolRegistration::new(
             tools::LIST_FILES,

--- a/vtcode-core/src/tools/registry/declarations.rs
+++ b/vtcode-core/src/tools/registry/declarations.rs
@@ -11,7 +11,7 @@ fn base_function_declarations() -> Vec<FunctionDeclaration> {
     vec![
         // Ripgrep search tool
         FunctionDeclaration {
-            name: tools::GREP_SEARCH.to_string(),
+            name: tools::GREP_FILE.to_string(),
             description: "Fast code search using ripgrep. Find code patterns, function definitions, TODOs, or text across files. Supports exact/fuzzy/multi-pattern/similarity modes. Use 'concise' format and reasonable max_results to manage token budget. Search first, read second—avoid loading full files until you've identified relevant matches.".to_string(),
             parameters: json!({
                 "type": "object",

--- a/vtcode-core/src/tools/registry/executors.rs
+++ b/vtcode-core/src/tools/registry/executors.rs
@@ -16,7 +16,7 @@ use crate::tools::{PlanUpdateResult, PtyCommandRequest, UpdatePlanArgs};
 use super::ToolRegistry;
 
 impl ToolRegistry {
-    pub(super) fn grep_search_executor(&mut self, args: Value) -> BoxFuture<'_, Result<Value>> {
+    pub(super) fn grep_file_executor(&mut self, args: Value) -> BoxFuture<'_, Result<Value>> {
         let tool = self.inventory.search_tool().clone();
         Box::pin(async move { tool.execute(args).await })
     }

--- a/vtcode-core/src/tools/registry/inventory.rs
+++ b/vtcode-core/src/tools/registry/inventory.rs
@@ -111,7 +111,7 @@ impl ToolInventory {
         &self.git_diff_tool
     }
 
-    pub fn grep_search_manager(&self) -> Arc<GrepSearchManager> {
+    pub fn grep_file_manager(&self) -> Arc<GrepSearchManager> {
         self.grep_search.clone()
     }
 

--- a/vtcode-core/src/tools/registry/legacy.rs
+++ b/vtcode-core/src/tools/registry/legacy.rs
@@ -96,12 +96,12 @@ impl ToolRegistry {
         Err(anyhow!("delete_file not yet implemented in modular system"))
     }
 
-    pub async fn rp_search(&mut self, args: Value) -> Result<Value> {
-        self.execute_tool(tools::GREP_SEARCH, args).await
+    pub async fn grep_file(&mut self, args: Value) -> Result<Value> {
+        self.execute_tool(tools::GREP_FILE, args).await
     }
 
-    pub fn last_rp_search_result(&self) -> Option<GrepSearchResult> {
-        self.grep_search_manager().last_result()
+    pub fn last_grep_file_result(&self) -> Option<GrepSearchResult> {
+        self.grep_file_manager().last_result()
     }
 
     pub async fn list_files(&mut self, args: Value) -> Result<Value> {

--- a/vtcode-core/src/tools/registry/mod.rs
+++ b/vtcode-core/src/tools/registry/mod.rs
@@ -34,6 +34,7 @@ use crate::tool_policy::{ToolPolicy, ToolPolicyManager};
 use crate::tools::ast_grep::AstGrepEngine;
 use crate::tools::file_ops::FileOpsTool;
 use crate::tools::grep_search::GrepSearchManager;
+use crate::tools::names::{canonical_tool_name, tool_aliases};
 use crate::tools::pty::PtyManager;
 use anyhow::Result;
 use serde_json::Value;
@@ -108,7 +109,14 @@ impl ToolRegistry {
     }
 
     fn sync_policy_catalog(&mut self) {
-        let available = self.inventory.available_tools();
+        let mut available = self.inventory.available_tools();
+        let mut alias_entries = Vec::new();
+        for tool in &available {
+            for alias in tool_aliases(tool) {
+                alias_entries.push(alias.to_string());
+            }
+        }
+        available.extend(alias_entries);
         let mcp_keys = self.mcp_policy_keys();
         self.policy_gateway
             .sync_available_tools(available, &mcp_keys);
@@ -265,36 +273,47 @@ impl ToolRegistry {
     }
 
     pub async fn execute_tool(&mut self, name: &str, args: Value) -> Result<Value> {
+        let canonical_name = canonical_tool_name(name);
+        let tool_name = canonical_name.as_ref();
+        let display_name = if tool_name == name {
+            name.to_string()
+        } else {
+            format!("{} (alias for {})", name, tool_name)
+        };
+
         if self.policy_gateway.has_full_auto_allowlist()
-            && !self.policy_gateway.is_allowed_in_full_auto(name)
+            && !self.policy_gateway.is_allowed_in_full_auto(tool_name)
         {
             let error = ToolExecutionError::new(
-                name.to_string(),
+                tool_name.to_string(),
                 ToolErrorType::PolicyViolation,
                 format!(
                     "Tool '{}' is not permitted while full-auto mode is active",
-                    name
+                    display_name
                 ),
             );
             return Ok(error.to_json_value());
         }
 
-        let skip_policy_prompt = self.policy_gateway.take_preapproved(name);
+        let skip_policy_prompt = self.policy_gateway.take_preapproved(tool_name);
 
-        if !skip_policy_prompt && !self.policy_gateway.should_execute_tool(name)? {
+        if !skip_policy_prompt && !self.policy_gateway.should_execute_tool(tool_name)? {
             let error = ToolExecutionError::new(
-                name.to_string(),
+                tool_name.to_string(),
                 ToolErrorType::PolicyViolation,
-                format!("Tool '{}' execution denied by policy", name),
+                format!("Tool '{}' execution denied by policy", display_name),
             );
             return Ok(error.to_json_value());
         }
 
-        let args = match self.policy_gateway.apply_policy_constraints(name, args) {
+        let args = match self
+            .policy_gateway
+            .apply_policy_constraints(tool_name, args)
+        {
             Ok(args) => args,
             Err(err) => {
                 let error = ToolExecutionError::with_original_error(
-                    name.to_string(),
+                    tool_name.to_string(),
                     ToolErrorType::InvalidParameters,
                     "Failed to apply policy constraints".to_string(),
                     err.to_string(),
@@ -303,7 +322,7 @@ impl ToolRegistry {
             }
         };
 
-        let registration = match self.inventory.registration_for(name) {
+        let registration = match self.inventory.registration_for(tool_name) {
             Some(registration) => registration,
             None => {
                 // If not found in standard registry, check if it's an MCP tool
@@ -334,7 +353,7 @@ impl ToolRegistry {
 
                                 // MCP client doesn't have this tool either
                                 let error = ToolExecutionError::new(
-                                    name.to_string(),
+                                    tool_name.to_string(),
                                     ToolErrorType::ToolNotFound,
                                     format!("Unknown MCP tool: {}", actual_tool_name),
                                 );
@@ -346,7 +365,7 @@ impl ToolRegistry {
                                     actual_tool_name, e
                                 );
                                 let error = ToolExecutionError::with_original_error(
-                                    name.to_string(),
+                                    tool_name.to_string(),
                                     ToolErrorType::ExecutionError,
                                     format!(
                                         "Failed to verify MCP tool '{}' due to provider errors",
@@ -359,31 +378,34 @@ impl ToolRegistry {
                         }
                     } else {
                         // Check if MCP client has a tool with this exact name
-                        match mcp_client.has_mcp_tool(name).await {
+                        match mcp_client.has_mcp_tool(tool_name).await {
                             Ok(true) => {
                                 debug!(
                                     "Tool '{}' not found in registry, delegating to MCP client",
-                                    name
+                                    tool_name
                                 );
-                                return self.execute_mcp_tool(name, args).await;
+                                return self.execute_mcp_tool(tool_name, args).await;
                             }
                             Ok(false) => {
                                 // MCP client doesn't have this tool either
                                 let error = ToolExecutionError::new(
-                                    name.to_string(),
+                                    tool_name.to_string(),
                                     ToolErrorType::ToolNotFound,
-                                    format!("Unknown tool: {}", name),
+                                    format!("Unknown tool: {}", display_name),
                                 );
                                 return Ok(error.to_json_value());
                             }
                             Err(e) => {
-                                warn!("Error checking MCP tool availability for '{}': {}", name, e);
+                                warn!(
+                                    "Error checking MCP tool availability for '{}': {}",
+                                    tool_name, e
+                                );
                                 let error = ToolExecutionError::with_original_error(
-                                    name.to_string(),
+                                    tool_name.to_string(),
                                     ToolErrorType::ExecutionError,
                                     format!(
                                         "Failed to verify MCP tool '{}' due to provider errors",
-                                        name
+                                        tool_name
                                     ),
                                     e.to_string(),
                                 );
@@ -394,9 +416,9 @@ impl ToolRegistry {
                 } else {
                     // No MCP client available
                     let error = ToolExecutionError::new(
-                        name.to_string(),
+                        tool_name.to_string(),
                         ToolErrorType::ToolNotFound,
-                        format!("Unknown tool: {}", name),
+                        format!("Unknown tool: {}", display_name),
                     );
                     return Ok(error.to_json_value());
                 }
@@ -406,7 +428,7 @@ impl ToolRegistry {
         let uses_pty = registration.uses_pty();
         if uses_pty && let Err(err) = self.start_pty_session() {
             let error = ToolExecutionError::with_original_error(
-                name.to_string(),
+                tool_name.to_string(),
                 ToolErrorType::ExecutionError,
                 "Failed to start PTY session".to_string(),
                 err.to_string(),
@@ -429,7 +451,7 @@ impl ToolRegistry {
             Err(err) => {
                 let error_type = classify_error(&err);
                 let error = ToolExecutionError::with_original_error(
-                    name.to_string(),
+                    tool_name.to_string(),
                     error_type,
                     format!("Tool execution failed: {}", err),
                     err.to_string(),

--- a/vtcode-core/src/tools/registry/mod.rs
+++ b/vtcode-core/src/tools/registry/mod.rs
@@ -187,8 +187,8 @@ impl ToolRegistry {
         self.inventory.file_ops_tool()
     }
 
-    pub fn grep_search_manager(&self) -> Arc<GrepSearchManager> {
-        self.inventory.grep_search_manager()
+    pub fn grep_file_manager(&self) -> Arc<GrepSearchManager> {
+        self.inventory.grep_file_manager()
     }
 
     pub fn pty_manager(&self) -> &PtyManager {

--- a/vtcode-core/src/tools/registry/policy.rs
+++ b/vtcode-core/src/tools/registry/policy.rs
@@ -8,6 +8,7 @@ use serde_json::{Value, json};
 use crate::config::constants::tools;
 use crate::config::mcp::McpAllowListConfig;
 use crate::tool_policy::{ToolPolicy, ToolPolicyManager};
+use crate::tools::names::canonical_tool_name;
 
 use super::ToolPermissionDecision;
 
@@ -48,10 +49,13 @@ impl ToolPolicyGateway {
     }
 
     pub fn apply_policy_constraints(&self, name: &str, mut args: Value) -> Result<Value> {
+        let canonical = canonical_tool_name(name);
+        let normalized = canonical.as_ref();
+
         if let Some(constraints) = self
             .tool_policy
             .as_ref()
-            .and_then(|tp| tp.get_constraints(name))
+            .and_then(|tp| tp.get_constraints(normalized))
             .cloned()
         {
             let obj = args
@@ -69,12 +73,12 @@ impl ToolPolicyGateway {
                 return Err(anyhow!(format!(
                     "Mode '{}' not allowed by policy for '{}'. Allowed: {}",
                     mode,
-                    name,
+                    normalized,
                     allowed.join(", ")
                 )));
             }
 
-            match name {
+            match normalized {
                 n if n == tools::LIST_FILES => {
                     if let Some(cap) = constraints.max_items_per_call {
                         let requested = obj
@@ -202,16 +206,18 @@ impl ToolPolicyGateway {
     }
 
     pub fn set_tool_policy(&mut self, tool_name: &str, policy: ToolPolicy) -> Result<()> {
+        let canonical = canonical_tool_name(tool_name);
         self.tool_policy
             .as_mut()
             .expect("Tool policy manager not initialized")
-            .set_policy(tool_name, policy)
+            .set_policy(canonical.as_ref(), policy)
     }
 
     pub fn get_tool_policy(&self, tool_name: &str) -> ToolPolicy {
+        let canonical = canonical_tool_name(tool_name);
         self.tool_policy
             .as_ref()
-            .map(|tp| tp.get_policy(tool_name))
+            .map(|tp| tp.get_policy(canonical.as_ref()))
             .unwrap_or(ToolPolicy::Allow)
     }
 
@@ -254,13 +260,15 @@ impl ToolPolicyGateway {
             .any(|tool| tool.trim() == tools::WILDCARD_ALL)
         {
             for tool in available_tools {
-                normalized.insert(tool.to_string());
+                let canonical = canonical_tool_name(tool);
+                normalized.insert(canonical.into_owned());
             }
         } else {
             for tool in allowed_tools {
                 let trimmed = tool.trim();
                 if !trimmed.is_empty() {
-                    normalized.insert(trimmed.to_string());
+                    let canonical = canonical_tool_name(trimmed);
+                    normalized.insert(canonical.into_owned());
                 }
             }
         }
@@ -281,9 +289,10 @@ impl ToolPolicyGateway {
     }
 
     pub fn is_allowed_in_full_auto(&self, name: &str) -> bool {
+        let canonical = canonical_tool_name(name);
         self.full_auto_allowlist
             .as_ref()
-            .map(|allowlist| allowlist.contains(name))
+            .map(|allowlist| allowlist.contains(canonical.as_ref()))
             .unwrap_or(true)
     }
 
@@ -292,36 +301,39 @@ impl ToolPolicyGateway {
     }
 
     pub fn evaluate_tool_policy(&mut self, name: &str) -> Result<ToolPermissionDecision> {
+        let canonical = canonical_tool_name(name);
+        let normalized = canonical.as_ref();
+
         if let Some(allowlist) = self.full_auto_allowlist.as_ref() {
-            if !allowlist.contains(name) {
+            if !allowlist.contains(normalized) {
                 return Ok(ToolPermissionDecision::Deny);
             }
 
             if let Some(policy_manager) = self.tool_policy.as_mut() {
-                match policy_manager.get_policy(name) {
+                match policy_manager.get_policy(normalized) {
                     ToolPolicy::Deny => return Ok(ToolPermissionDecision::Deny),
                     ToolPolicy::Allow | ToolPolicy::Prompt => {
-                        self.preapproved_tools.insert(name.to_string());
+                        self.preapproved_tools.insert(normalized.to_string());
                         return Ok(ToolPermissionDecision::Allow);
                     }
                 }
             }
 
-            self.preapproved_tools.insert(name.to_string());
+            self.preapproved_tools.insert(normalized.to_string());
             return Ok(ToolPermissionDecision::Allow);
         }
 
         if let Some(policy_manager) = self.tool_policy.as_mut() {
-            match policy_manager.get_policy(name) {
+            match policy_manager.get_policy(normalized) {
                 ToolPolicy::Allow => {
-                    self.preapproved_tools.insert(name.to_string());
+                    self.preapproved_tools.insert(normalized.to_string());
                     Ok(ToolPermissionDecision::Allow)
                 }
                 ToolPolicy::Deny => Ok(ToolPermissionDecision::Deny),
                 ToolPolicy::Prompt => {
-                    if ToolPolicyManager::is_auto_allow_tool(name) {
-                        policy_manager.set_policy(name, ToolPolicy::Allow)?;
-                        self.preapproved_tools.insert(name.to_string());
+                    if ToolPolicyManager::is_auto_allow_tool(normalized) {
+                        policy_manager.set_policy(normalized, ToolPolicy::Allow)?;
+                        self.preapproved_tools.insert(normalized.to_string());
                         Ok(ToolPermissionDecision::Allow)
                     } else {
                         Ok(ToolPermissionDecision::Prompt)
@@ -329,22 +341,25 @@ impl ToolPolicyGateway {
                 }
             }
         } else {
-            self.preapproved_tools.insert(name.to_string());
+            self.preapproved_tools.insert(normalized.to_string());
             Ok(ToolPermissionDecision::Allow)
         }
     }
 
     pub fn take_preapproved(&mut self, name: &str) -> bool {
-        self.preapproved_tools.remove(name)
+        let canonical = canonical_tool_name(name);
+        self.preapproved_tools.remove(canonical.as_ref())
     }
 
     pub fn preapprove(&mut self, name: &str) {
-        self.preapproved_tools.insert(name.to_string());
+        let canonical = canonical_tool_name(name);
+        self.preapproved_tools.insert(canonical.into_owned());
     }
 
     pub fn should_execute_tool(&mut self, name: &str) -> Result<bool> {
+        let canonical = canonical_tool_name(name);
         if let Some(policy_manager) = self.tool_policy.as_mut() {
-            policy_manager.should_execute_tool(name)
+            policy_manager.should_execute_tool(canonical.as_ref())
         } else {
             Ok(true)
         }

--- a/vtcode-core/src/tools/registry/policy.rs
+++ b/vtcode-core/src/tools/registry/policy.rs
@@ -94,7 +94,7 @@ impl ToolPolicyGateway {
                         }
                     }
                 }
-                n if n == tools::GREP_SEARCH => {
+                n if n == tools::GREP_FILE => {
                     if let Some(cap) = constraints.max_results_per_call {
                         let requested = obj
                             .get("max_results")

--- a/vtcode-core/src/tools/search.rs
+++ b/vtcode-core/src/tools/search.rs
@@ -29,7 +29,7 @@ impl SearchTool {
         let pattern = args
             .get("pattern")
             .and_then(|p| p.as_str())
-            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: grep_search({{\"pattern\": \"TODO|FIXME\", \"path\": \"src\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: rp_search({{\"pattern\": \"TODO|FIXME\", \"path\": \"src\"}})"))?;
 
         let input = GrepSearchInput {
             pattern: pattern.to_string(),
@@ -99,7 +99,7 @@ impl SearchTool {
         let pattern = args
             .get("pattern")
             .and_then(|p| p.as_str())
-            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: grep_search({{\"mode\": \"fuzzy\", \"pattern\": \"todo\", \"path\": \"src\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: rp_search({{\"mode\": \"fuzzy\", \"pattern\": \"todo\", \"path\": \"src\"}})"))?;
 
         let input = GrepSearchInput {
             pattern: pattern.to_string(),
@@ -170,7 +170,7 @@ impl SearchTool {
     async fn execute_multi(&self, args: Value) -> Result<Value> {
         let args_obj = args
             .as_object()
-            .ok_or_else(|| anyhow!("Error: Invalid 'multi' arguments. Required: {{ patterns: string[] }}. Optional: {{ logic: 'AND'|'OR' }}. Example: grep_search({{\"mode\": \"multi\", \"patterns\": [\"fn \\w+\", \"use \\w+\"], \"logic\": \"AND\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Invalid 'multi' arguments. Required: {{ patterns: string[] }}. Optional: {{ logic: 'AND'|'OR' }}. Example: rp_search({{\"mode\": \"multi\", \"patterns\": [\"fn \\w+\", \"use \\w+\"], \"logic\": \"AND\"}})"))?;
 
         let patterns = args_obj
             .get("patterns")
@@ -223,12 +223,12 @@ impl SearchTool {
     async fn execute_similarity(&self, args: Value) -> Result<Value> {
         let args_obj = args
             .as_object()
-            .ok_or_else(|| anyhow!("Error: Invalid 'similarity' arguments. Required: {{ reference_file: string }}. Optional: {{ content_type: 'structure'|'imports'|'functions'|'all' }}. Example: grep_search({{\"mode\": \"similarity\", \"reference_file\": \"src/lib.rs\", \"content_type\": \"functions\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Invalid 'similarity' arguments. Required: {{ reference_file: string }}. Optional: {{ content_type: 'structure'|'imports'|'functions'|'all' }}. Example: rp_search({{\"mode\": \"similarity\", \"reference_file\": \"src/lib.rs\", \"content_type\": \"functions\"}})"))?;
 
         let reference_file = args_obj
             .get("reference_file")
             .and_then(|f| f.as_str())
-            .ok_or_else(|| anyhow!("Error: Missing 'reference_file'. Example: grep_search({{\"mode\": \"similarity\", \"reference_file\": \"src/main.rs\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Missing 'reference_file'. Example: rp_search({{\"mode\": \"similarity\", \"reference_file\": \"src/main.rs\"}})"))?;
 
         let content_type = args_obj
             .get("content_type")

--- a/vtcode-core/src/tools/search.rs
+++ b/vtcode-core/src/tools/search.rs
@@ -29,7 +29,7 @@ impl SearchTool {
         let pattern = args
             .get("pattern")
             .and_then(|p| p.as_str())
-            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: rp_search({{\"pattern\": \"TODO|FIXME\", \"path\": \"src\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: grep_file({{\"pattern\": \"TODO|FIXME\", \"path\": \"src\"}})"))?;
 
         let input = GrepSearchInput {
             pattern: pattern.to_string(),
@@ -99,7 +99,7 @@ impl SearchTool {
         let pattern = args
             .get("pattern")
             .and_then(|p| p.as_str())
-            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: rp_search({{\"mode\": \"fuzzy\", \"pattern\": \"todo\", \"path\": \"src\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Missing 'pattern'. Example: grep_file({{\"mode\": \"fuzzy\", \"pattern\": \"todo\", \"path\": \"src\"}})"))?;
 
         let input = GrepSearchInput {
             pattern: pattern.to_string(),
@@ -170,7 +170,7 @@ impl SearchTool {
     async fn execute_multi(&self, args: Value) -> Result<Value> {
         let args_obj = args
             .as_object()
-            .ok_or_else(|| anyhow!("Error: Invalid 'multi' arguments. Required: {{ patterns: string[] }}. Optional: {{ logic: 'AND'|'OR' }}. Example: rp_search({{\"mode\": \"multi\", \"patterns\": [\"fn \\w+\", \"use \\w+\"], \"logic\": \"AND\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Invalid 'multi' arguments. Required: {{ patterns: string[] }}. Optional: {{ logic: 'AND'|'OR' }}. Example: grep_file({{\"mode\": \"multi\", \"patterns\": [\"fn \\w+\", \"use \\w+\"], \"logic\": \"AND\"}})"))?;
 
         let patterns = args_obj
             .get("patterns")
@@ -223,12 +223,12 @@ impl SearchTool {
     async fn execute_similarity(&self, args: Value) -> Result<Value> {
         let args_obj = args
             .as_object()
-            .ok_or_else(|| anyhow!("Error: Invalid 'similarity' arguments. Required: {{ reference_file: string }}. Optional: {{ content_type: 'structure'|'imports'|'functions'|'all' }}. Example: rp_search({{\"mode\": \"similarity\", \"reference_file\": \"src/lib.rs\", \"content_type\": \"functions\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Invalid 'similarity' arguments. Required: {{ reference_file: string }}. Optional: {{ content_type: 'structure'|'imports'|'functions'|'all' }}. Example: grep_file({{\"mode\": \"similarity\", \"reference_file\": \"src/lib.rs\", \"content_type\": \"functions\"}})"))?;
 
         let reference_file = args_obj
             .get("reference_file")
             .and_then(|f| f.as_str())
-            .ok_or_else(|| anyhow!("Error: Missing 'reference_file'. Example: rp_search({{\"mode\": \"similarity\", \"reference_file\": \"src/main.rs\"}})"))?;
+            .ok_or_else(|| anyhow!("Error: Missing 'reference_file'. Example: grep_file({{\"mode\": \"similarity\", \"reference_file\": \"src/main.rs\"}})"))?;
 
         let content_type = args_obj
             .get("content_type")
@@ -413,7 +413,7 @@ impl Tool for SearchTool {
     }
 
     fn name(&self) -> &'static str {
-        tools::GREP_SEARCH
+        tools::GREP_FILE
     }
 
     fn description(&self) -> &'static str {

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -59,7 +59,7 @@ create_pty_session = "allow"
 curl = "prompt"
 edit_file = "allow"
 git_diff = "allow"
-grep_search = "allow"
+rp_search = "allow"
 list_files = "allow"
 list_pty_sessions = "allow"
 read_file = "allow"
@@ -239,7 +239,7 @@ allowed_tools = [
     "write_file",
     "read_file",
     "list_files",
-    "grep_search",
+    "rp_search",
     "simple_search",
 ]
 require_profile_ack = true

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -59,7 +59,7 @@ create_pty_session = "allow"
 curl = "prompt"
 edit_file = "allow"
 git_diff = "allow"
-rp_search = "allow"
+grep_file = "allow"
 list_files = "allow"
 list_pty_sessions = "allow"
 read_file = "allow"
@@ -239,7 +239,7 @@ allowed_tools = [
     "write_file",
     "read_file",
     "list_files",
-    "rp_search",
+    "grep_file",
     "simple_search",
 ]
 require_profile_ack = true

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -92,7 +92,7 @@ usage_tips = [
     "Share your goal or ask for /status to recap configuration.",
     "Reference AGENTS.md norms before editing.",
     "Draft or refresh your TODOs with update_plan before modifying code.",
-    "Prefer targeted reads (read_file, grep_search) before modifying code.",
+    "Prefer targeted reads (read_file, rp_search) before modifying code.",
 ]
 # Suggested follow-up actions.
 recommended_actions = [
@@ -111,7 +111,7 @@ max_tool_loops = 100
 
 # Override default policy for specific tools.
 [tools.policies]
-grep_search = "allow"
+rp_search = "allow"
 list_files = "allow"
 update_plan = "allow"
 read_file = "allow"

--- a/vtcode.toml.example
+++ b/vtcode.toml.example
@@ -92,7 +92,7 @@ usage_tips = [
     "Share your goal or ask for /status to recap configuration.",
     "Reference AGENTS.md norms before editing.",
     "Draft or refresh your TODOs with update_plan before modifying code.",
-    "Prefer targeted reads (read_file, rp_search) before modifying code.",
+    "Prefer targeted reads (read_file, grep_file) before modifying code.",
 ]
 # Suggested follow-up actions.
 recommended_actions = [
@@ -111,7 +111,7 @@ max_tool_loops = 100
 
 # Override default policy for specific tools.
 [tools.policies]
-rp_search = "allow"
+grep_file = "allow"
 list_files = "allow"
 update_plan = "allow"
 read_file = "allow"


### PR DESCRIPTION
## Summary
- add the perg crate to vtcode-core and use it as a fallback backend when ripgrep is unavailable
- update the grep search manager to unify ripgrep and perg execution while preserving result formatting and cancellation behaviour
- document the ripgrep/perg hybrid in the user guide and system prompt for the agent

## Testing
- cargo fmt
- cargo clippy
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f45544cf148323958d5f8bf47b4e29