### PR TITLE
Add core interface layer for turn driving and ACP

### DIFF
--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,4 +1,4 @@
 mod zed;
 
 pub use vtcode_acp_client::{acp_client, register_acp_client};
-pub use zed::run_zed_agent;
+pub use zed::ZedAcpAdapter;

--- a/src/acp/zed.rs
+++ b/src/acp/zed.rs
@@ -22,6 +22,7 @@ use url::Url;
 use vtcode_core::config::constants::tools;
 use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, CapabilityLevel};
 use vtcode_core::config::{AgentClientProtocolZedConfig, ToolsConfig, VTCodeConfig};
+use vtcode_core::core::interfaces::acp::{AcpClientAdapter, AcpLaunchParams};
 use vtcode_core::llm::factory::{create_provider_for_model, create_provider_with_config};
 use vtcode_core::llm::provider::{
     FinishReason, LLMRequest, LLMStreamEvent, Message, ToolCall as ProviderToolCall, ToolChoice,
@@ -37,6 +38,16 @@ use vtcode_core::tools::registry::{
 use vtcode_core::tools::traits::Tool;
 
 use crate::workspace_trust::{WorkspaceTrustSyncOutcome, ensure_workspace_trust_level_silent};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ZedAcpAdapter;
+
+#[async_trait(?Send)]
+impl AcpClientAdapter for ZedAcpAdapter {
+    async fn serve(&self, params: AcpLaunchParams<'_>) -> Result<()> {
+        run_zed_agent(params.agent_config, params.runtime_config).await
+    }
+}
 
 const SESSION_PREFIX: &str = "vtcode-zed-session";
 const RESOURCE_FALLBACK_LABEL: &str = "Resource";

--- a/src/agent/runloop/mod.rs
+++ b/src/agent/runloop/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::path::PathBuf;
 use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
 use vtcode_core::config::types::{AgentConfig as CoreAgentConfig, ModelSelectionSource};
+use vtcode_core::core::interfaces::turn::{TurnDriver, TurnDriverParams};
 use vtcode_core::llm::provider::Message as ProviderMessage;
 use vtcode_core::utils::session_archive::SessionSnapshot;
 
@@ -44,8 +45,9 @@ pub async fn run_single_agent_loop(
 
     apply_runtime_overrides(vt_cfg.as_mut(), config);
 
-    unified::run_single_agent_loop_unified(config, vt_cfg, skip_confirmations, full_auto, resume)
-        .await
+    let driver = unified::UnifiedTurnDriver;
+    let params = TurnDriverParams::new(config, vt_cfg, skip_confirmations, full_auto, resume);
+    driver.drive_turn(params).await
 }
 
 pub(crate) fn is_context_overflow_error(message: &str) -> bool {

--- a/src/agent/runloop/unified/driver.rs
+++ b/src/agent/runloop/unified/driver.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use vtcode_core::core::interfaces::turn::{TurnDriver, TurnDriverParams};
+
+use crate::agent::runloop::ResumeSession;
+
+use super::turn::run_single_agent_loop_unified;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct UnifiedTurnDriver;
+
+#[async_trait]
+impl TurnDriver<ResumeSession> for UnifiedTurnDriver {
+    async fn drive_turn(&self, params: TurnDriverParams<'_, ResumeSession>) -> Result<()> {
+        run_single_agent_loop_unified(
+            params.agent_config,
+            params.vt_config,
+            params.skip_confirmations,
+            params.full_auto,
+            params.resume,
+        )
+        .await
+    }
+}

--- a/src/agent/runloop/unified/mod.rs
+++ b/src/agent/runloop/unified/mod.rs
@@ -2,6 +2,7 @@ mod context_manager;
 mod curator;
 mod diagnostics;
 mod display;
+mod driver;
 mod mcp_support;
 mod model_selection;
 mod palettes;
@@ -17,4 +18,4 @@ mod turn;
 mod ui_interaction;
 mod workspace_links;
 
-pub(crate) use turn::run_single_agent_loop_unified;
+pub(crate) use driver::UnifiedTurnDriver;

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -17,6 +17,7 @@ use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::core::agent::snapshots::{SnapshotConfig, SnapshotManager};
 use vtcode_core::core::decision_tracker::{Action as DTAction, DecisionOutcome, DecisionTracker};
+use vtcode_core::core::interfaces::ui::UiSession;
 use vtcode_core::core::router::{Router, TaskClass};
 use vtcode_core::llm::error_display;
 use vtcode_core::llm::provider::{self as uni};
@@ -253,7 +254,7 @@ pub(crate) async fn run_single_agent_loop_unified(
         .as_ref()
         .map(|cfg| cfg.ui.show_timeline_pane)
         .unwrap_or(ui::INLINE_SHOW_TIMELINE_PANE);
-    let session = spawn_session(
+    let mut session = spawn_session(
         theme_spec.clone(),
         default_placeholder.clone(),
         config.ui_surface,
@@ -261,7 +262,7 @@ pub(crate) async fn run_single_agent_loop_unified(
         show_timeline_pane,
     )
     .context("failed to launch inline session")?;
-    let handle = session.handle.clone();
+    let handle = session.clone_inline_handle();
     let highlight_config = vt_cfg
         .as_ref()
         .map(|cfg| cfg.syntax_highlighting.clone())
@@ -439,7 +440,6 @@ pub(crate) async fn run_single_agent_loop_unified(
     let mut linked_directories: Vec<LinkedDirectory> = Vec::new();
     let mut model_picker_state: Option<ModelPickerState> = None;
     let mut palette_state: Option<ActivePalette> = None;
-    let mut events = session.events;
     let mut last_forced_redraw = Instant::now();
     let mut input_status_state = InputStatusState::default();
     loop {
@@ -467,7 +467,7 @@ pub(crate) async fn run_single_agent_loop_unified(
             biased;
 
             _ = ctrl_c_notify.notified() => None,
-            event = events.recv() => event,
+            event = session.next_event() => event,
         };
 
         if ctrl_c_state.is_cancel_requested() {
@@ -811,7 +811,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                                 Some(&args),
                                 &mut renderer,
                                 &handle,
-                                &mut events,
+                                &mut session,
                                 default_placeholder.clone(),
                                 &ctrl_c_state,
                                 &ctrl_c_notify,
@@ -1386,7 +1386,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                         Some(&args_val),
                         &mut renderer,
                         &handle,
-                        &mut events,
+                        &mut session,
                         default_placeholder.clone(),
                         &ctrl_c_state,
                         &ctrl_c_notify,

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, bail};
 use vtcode_core::cli::args::AgentClientProtocolTarget;
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::config::{AgentClientProtocolTransport, VTCodeConfig};
+use vtcode_core::core::interfaces::acp::{AcpClientAdapter, AcpLaunchParams};
 
 pub async fn handle_acp_command(
     config: &CoreAgentConfig,
@@ -26,7 +27,9 @@ pub async fn handle_acp_command(
                 bail!("Only the stdio transport is currently supported for Zed ACP integration.");
             }
 
-            crate::acp::run_zed_agent(config, vt_cfg).await?
+            let adapter = crate::acp::ZedAcpAdapter;
+            let params = AcpLaunchParams::new(config, vt_cfg);
+            adapter.serve(params).await?
         }
     }
 

--- a/vtcode-core/src/core/interfaces/acp.rs
+++ b/vtcode-core/src/core/interfaces/acp.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::config::loader::VTCodeConfig;
+use crate::config::types::AgentConfig as CoreAgentConfig;
+
+/// Parameters required to launch an Agent Client Protocol adapter.
+#[derive(Debug)]
+pub struct AcpLaunchParams<'a> {
+    pub agent_config: &'a CoreAgentConfig,
+    pub runtime_config: &'a VTCodeConfig,
+}
+
+impl<'a> AcpLaunchParams<'a> {
+    pub fn new(agent_config: &'a CoreAgentConfig, runtime_config: &'a VTCodeConfig) -> Self {
+        Self {
+            agent_config,
+            runtime_config,
+        }
+    }
+}
+
+/// Interface for components that expose VTCode over the Agent Client Protocol.
+#[async_trait(?Send)]
+pub trait AcpClientAdapter: Send + Sync {
+    async fn serve(&self, params: AcpLaunchParams<'_>) -> Result<()>;
+}

--- a/vtcode-core/src/core/interfaces/mod.rs
+++ b/vtcode-core/src/core/interfaces/mod.rs
@@ -1,0 +1,14 @@
+//! Shared interface definitions bridging the CLI binary and reusable
+//! vtcode-core abstractions.
+//!
+//! The traits exposed here let the binary depend on narrow contracts for
+//! driving turns, interacting with the inline UI session, and servicing ACP
+//! transports without directly depending on concrete implementations.
+
+pub mod acp;
+pub mod turn;
+pub mod ui;
+
+pub use acp::{AcpClientAdapter, AcpLaunchParams};
+pub use turn::{TurnDriver, TurnDriverParams};
+pub use ui::UiSession;

--- a/vtcode-core/src/core/interfaces/turn.rs
+++ b/vtcode-core/src/core/interfaces/turn.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::config::loader::VTCodeConfig;
+use crate::config::types::AgentConfig as CoreAgentConfig;
+
+/// Parameters passed to a [`TurnDriver`] implementation for executing a single turn.
+#[derive(Debug)]
+pub struct TurnDriverParams<'a, Resume> {
+    pub agent_config: &'a CoreAgentConfig,
+    pub vt_config: Option<VTCodeConfig>,
+    pub skip_confirmations: bool,
+    pub full_auto: bool,
+    pub resume: Option<Resume>,
+}
+
+impl<'a, Resume> TurnDriverParams<'a, Resume> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        agent_config: &'a CoreAgentConfig,
+        vt_config: Option<VTCodeConfig>,
+        skip_confirmations: bool,
+        full_auto: bool,
+        resume: Option<Resume>,
+    ) -> Self {
+        Self {
+            agent_config,
+            vt_config,
+            skip_confirmations,
+            full_auto,
+            resume,
+        }
+    }
+
+    pub fn map_resume<F, NextResume>(self, map: F) -> TurnDriverParams<'a, NextResume>
+    where
+        F: FnOnce(Option<Resume>) -> Option<NextResume>,
+    {
+        TurnDriverParams {
+            agent_config: self.agent_config,
+            vt_config: self.vt_config,
+            skip_confirmations: self.skip_confirmations,
+            full_auto: self.full_auto,
+            resume: map(self.resume),
+        }
+    }
+}
+
+/// Abstraction over the core turn-driving loop used by the CLI and ACP bridges.
+#[async_trait]
+pub trait TurnDriver<Resume>: Send + Sync {
+    async fn drive_turn(&self, params: TurnDriverParams<'_, Resume>) -> Result<()>;
+}

--- a/vtcode-core/src/core/interfaces/ui.rs
+++ b/vtcode-core/src/core/interfaces/ui.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+
+use crate::ui::tui::{InlineEvent, InlineHandle, InlineSession};
+
+/// Common contract for interactive inline UI sessions.
+#[async_trait]
+pub trait UiSession {
+    fn inline_handle(&self) -> &InlineHandle;
+
+    fn clone_inline_handle(&self) -> InlineHandle {
+        self.inline_handle().clone()
+    }
+
+    async fn next_event(&mut self) -> Option<InlineEvent>;
+
+    fn request_redraw(&self) {
+        self.inline_handle().force_redraw();
+    }
+
+    fn shutdown(&self) {
+        self.inline_handle().shutdown();
+    }
+}
+
+#[async_trait]
+impl UiSession for InlineSession {
+    fn inline_handle(&self) -> &InlineHandle {
+        &self.handle
+    }
+
+    async fn next_event(&mut self) -> Option<InlineEvent> {
+        self.events.recv().await
+    }
+}

--- a/vtcode-core/src/core/mod.rs
+++ b/vtcode-core/src/core/mod.rs
@@ -56,6 +56,7 @@ pub mod context_curator;
 pub mod conversation_summarizer;
 pub mod decision_tracker;
 pub mod error_recovery;
+pub mod interfaces;
 pub mod orchestrator_retry;
 pub mod performance_monitor;
 pub mod performance_profiler;


### PR DESCRIPTION
## Summary
- add a `core::interfaces` module with reusable `TurnDriver`, `UiSession`, and `AcpClientAdapter` traits
- wrap the unified run loop with a `UnifiedTurnDriver` and update tool routing to consume the session abstraction
- expose a `ZedAcpAdapter` that implements the shared ACP interface and document checklist progress

## Testing
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f4550c68d88323961a011f5ee7ee13