### PR TITLE
Fix ACP adapter reuse for CLI and library

### DIFF
--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,22 +1,7 @@
-#[cfg(test)]
 pub mod permissions;
-#[cfg(not(test))]
-mod permissions;
-
-#[cfg(test)]
 pub mod reports;
-#[cfg(not(test))]
-mod reports;
-
-#[cfg(test)]
 pub mod tooling;
-#[cfg(not(test))]
-mod tooling;
-
-#[cfg(test)]
 pub mod workspace;
-#[cfg(not(test))]
-mod workspace;
 mod zed;
 
 pub use vtcode_acp_client::{acp_client, register_acp_client};

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use vtcode::acp::ZedAcpAdapter;
 use vtcode_core::cli::args::AgentClientProtocolTarget;
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::config::{AgentClientProtocolTransport, VTCodeConfig};
@@ -27,7 +28,7 @@ pub async fn handle_acp_command(
                 bail!("Only the stdio transport is currently supported for Zed ACP integration.");
             }
 
-            let adapter = crate::acp::ZedAcpAdapter;
+            let adapter = ZedAcpAdapter;
             let params = AcpLaunchParams::new(config, vt_cfg);
             adapter.serve(params).await?
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,8 +161,8 @@
 //! This package contains the binary executable for VT Code.
 //! For the core library functionality, see [`vtcode-core`](https://docs.rs/vtcode-core).
 
-#[cfg(test)]
 pub mod acp;
+mod workspace_trust;
 
 pub mod startup;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use vtcode::startup::StartupContext;
 use vtcode_core::cli::args::{Cli, Commands};
 use vtcode_core::config::api_keys::load_dotenv;
 
-mod acp;
 mod agent;
 mod cli; // local CLI handlers in src/cli // agent runloops (single-agent only)
 mod process_hardening;


### PR DESCRIPTION
## Summary
- remove the CLI crate's private `acp` module in favor of the library's re-exported ACP surface
- update the ACP command handler to construct `ZedAcpAdapter` from the shared library module
- keep the library exposing the ACP module for integrations while leaving workspace trust helper private

## Testing
- cargo clippy
- cargo test --test acp_integration

------
https://chatgpt.com/codex/tasks/task_e_68f46cbe90fc83238116dd90101aafa0