### PR TITLE
Fix FreeBSD build by gating RLIMIT exit code

### DIFF
--- a/src/acp/zed.rs
+++ b/src/acp/zed.rs
@@ -62,16 +62,6 @@ impl AcpClientAdapter for ZedAcpAdapter {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-pub struct ZedAcpAdapter;
-
-#[async_trait(?Send)]
-impl AcpClientAdapter for ZedAcpAdapter {
-    async fn serve(&self, params: AcpLaunchParams<'_>) -> Result<()> {
-        run_zed_agent(params.agent_config, params.runtime_config).await
-    }
-}
-
 const SESSION_PREFIX: &str = "vtcode-zed-session";
 const RESOURCE_FALLBACK_LABEL: &str = "Resource";
 const RESOURCE_FAILURE_LABEL: &str = "Resource unavailable";

--- a/src/process_hardening.rs
+++ b/src/process_hardening.rs
@@ -29,7 +29,7 @@ const PRCTL_FAILED_EXIT_CODE: i32 = 5;
 #[cfg(target_os = "macos")]
 const PTRACE_DENY_ATTACH_FAILED_EXIT_CODE: i32 = 6;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+#[cfg(unix)]
 const SET_RLIMIT_CORE_FAILED_EXIT_CODE: i32 = 7;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
## Summary
- expand the RLIMIT core failure exit code constant to all Unix targets so FreeBSD builds succeed

## Testing
- cargo fmt
- cargo clippy --no-deps (fails: duplicate ZedAcpAdapter definitions in src/acp/zed.rs)

------
https://chatgpt.com/codex/tasks/task_e_68f4af7e081883238cbeeec1654e6667