### PR TITLE
Document vtcode-llm environment configuration and mocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,6 +4793,10 @@ dependencies = [
 name = "vtcode-tools"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
+ "serde_json",
+ "tempfile",
+ "tokio",
  "vtcode-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4781,6 +4781,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vtcode-llm"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "futures",
+ "vtcode-core",
+]
+
+[[package]]
+name = "vtcode-tools"
+version = "0.0.1"
+dependencies = [
+ "vtcode-core",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,12 @@ exclude = [
 default-run = "vtcode"
 
 [workspace]
-members = ["vtcode-acp-client", "vtcode-core"]
+members = [
+    "vtcode-acp-client",
+    "vtcode-core",
+    "vtcode-llm",
+    "vtcode-tools",
+]
 
 [workspace.lints]
 rust = {}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It supports multiple LLM providers: OpenAI, Anthropic, xAI, DeepSeek, Gemini, Op
 - [Zed IDE Integration](#zed-ide-integration)
 - [Command Line Interface](#command-line-interface)
 - [System Architecture](#system-architecture)
+- [Component Extraction Roadmap](#component-extraction-roadmap)
 - [Development](#development)
 - [References](#references)
 
@@ -143,6 +144,15 @@ The architecture divides into `vtcode-core` (reusable library) and `src/` (CLI e
 - **Observability**: Logs to file/console with structured format; metrics (e.g., cache hit rate, token usage) exposed via debug flags.
 
 Performance notes: Multi-threaded Tokio reduces latency for I/O-bound tasks (~20% faster than single-thread); context compression yields 50-80% token savings in long sessions. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for dependency graph and profiling data.
+
+## Component Extraction Roadmap
+
+We are in the process of extracting reusable subsystems from this workspace so other Rust agents can build on VT Code’s tooling without adopting the entire TUI. The initiative currently focuses on two prototype crates:
+
+- [`vtcode-llm`](vtcode-llm/): provider-agnostic client facade that unifies request/response handling across Gemini, OpenAI, Anthropic, xAI, DeepSeek, and Z.AI with streaming and function calling gated behind feature flags.
+- [`vtcode-tools`](vtcode-tools/): modular tool registry exposing sandboxed shell execution, AST/grep utilities, planners, and telemetry hooks with optional features for heavyweight dependencies.
+
+Progress, open tasks, and release checklists live in [docs/component_extraction_plan.md](docs/component_extraction_plan.md) and the companion [docs/component_extraction_todo.md](docs/component_extraction_todo.md) tracker. We will publish pre-release versions of these crates once the documentation and policy adapters are decoupled; in the meantime, community feedback on the roadmap and desired integration points is welcome via issues or discussions.
 
 ## Key Capabilities
 

--- a/docs/component_extraction_plan.md
+++ b/docs/component_extraction_plan.md
@@ -102,6 +102,7 @@ This document captures the results of a quick architectural survey of VTCode wit
 - Mapped external integration requirements for prospective consumers and drafted a feature flag matrix covering providers, heavyweight tools, and optional telemetry so the prototype crates can slim dependencies while staying configurable.
 - Introduced initial feature gates in both prototype crates so downstream consumers can opt into provider-specific exports, tool categories, telemetry helpers, and function-calling utilities without pulling the entire workspace surface by default.
 - Published dedicated environment configuration guidance for `vtcode-llm`, documenting provider API keys, configuration helper patterns, and the new mock client utilities for deterministic tests.
+- Documented how `vtcode-tools` adopters can supply their own policy storage by exposing constructors that accept custom `ToolPolicyManager` instances and publishing the `docs/vtcode_tools_policy.md` guide.
 
 ## Feature Flag Strategy
 
@@ -178,4 +179,7 @@ This document captures the results of a quick architectural survey of VTCode wit
 6. ✅ Publish environment variable documentation and mock client guidance for `vtcode-llm` so adopters understand configuration requirements before the crate is released.
    - Authored `docs/vtcode_llm_environment.md` covering provider API keys, configuration trait usage patterns, and examples for combining environment variables with the owned adapter helpers.
    - Added a `mock` feature module exposing `StaticResponseClient` so downstream tests can queue deterministic responses without reaching real providers.
-7. Document how `vtcode-tools` consumers can replace the default policy wiring so configuration structs live outside the crate boundary.
+7. ✅ Document how `vtcode-tools` consumers can replace the default policy wiring so configuration structs live outside the crate boundary.
+   - Added `ToolPolicyManager::new_with_config_path` and custom `ToolRegistry` constructors so downstream projects can inject pre-configured policy managers without touching VTCode's `.vtcode` directory.
+   - Authored `docs/vtcode_tools_policy.md` with step-by-step guidance on enabling the `policies` feature, selecting a storage path, and wiring the custom manager into the registry.
+8. Publish headless integration examples demonstrating `vtcode-tools` usage with custom policy storage and feature flags for lightweight adoption.

--- a/docs/component_extraction_plan.md
+++ b/docs/component_extraction_plan.md
@@ -182,4 +182,7 @@ This document captures the results of a quick architectural survey of VTCode wit
 7. ✅ Document how `vtcode-tools` consumers can replace the default policy wiring so configuration structs live outside the crate boundary.
    - Added `ToolPolicyManager::new_with_config_path` and custom `ToolRegistry` constructors so downstream projects can inject pre-configured policy managers without touching VTCode's `.vtcode` directory.
    - Authored `docs/vtcode_tools_policy.md` with step-by-step guidance on enabling the `policies` feature, selecting a storage path, and wiring the custom manager into the registry.
-8. Publish headless integration examples demonstrating `vtcode-tools` usage with custom policy storage and feature flags for lightweight adoption.
+8. ✅ Publish headless integration examples demonstrating `vtcode-tools` usage with custom policy storage and feature flags for lightweight adoption.
+   - Added `examples/headless_custom_policy.rs` under the `vtcode-tools` crate to showcase registry usage without the TUI, wiring a workspace-local `ToolPolicyManager` and disabling planning for a lighter default toolset.
+   - Documented how to compile the example with `--no-default-features --features "policies"` so downstream adopters can opt into policy support without the heavier tool categories.
+9. Define shared filesystem/telemetry traits (`vtcode-commons`) to reduce duplication between the extracted crates before publishing them independently.

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -1,0 +1,24 @@
+# Component Extraction TODO
+
+This list tracks actionable tasks spawned from the component extraction plan as we prototype new crates.
+
+## `vtcode-llm`
+- [x] Scaffold prototype crate that re-exports the existing LLM abstraction layer.
+- [x] Document external API surface area and propose feature flags for providers, function calling, telemetry, and mocks.
+- [x] Introduce a provider configuration trait to decouple from `vtcode_core::utils::dot_config`.
+- [x] Gate provider implementations behind feature flags to shrink dependency footprint.
+- [x] Add documentation on expected environment variables and provide mock clients for testing.
+
+## `vtcode-tools`
+- [x] Scaffold prototype crate that re-exports the tool registry and built-in tools.
+- [x] Outline feature flag groups for heavyweight tools, policy wiring, telemetry, and examples.
+- [ ] Extract policy wiring so configuration structs live outside the crate boundary.
+- [x] Make tree-sitter and heavy tooling optional via feature flags.
+- [ ] Publish integration examples exercising registry setup and execution in a headless context.
+
+## Cross-Cutting
+- [x] Capture external integration prerequisites (environment variables, binary dependencies) and align them with optional feature groups.
+- [ ] Define shared base traits (`vtcode-commons`) for filesystem paths, telemetry, and error handling used by multiple crates.
+- [x] Establish a migration checklist covering documentation, CI, and release steps for each extracted crate.
+- [x] Audit dependency licenses (tree-sitter grammars, provider SDKs) to confirm compatibility before publishing.
+- [x] Update project README once the first crate is ready for community feedback (linked roadmap + feedback invitation).

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -14,7 +14,7 @@ This list tracks actionable tasks spawned from the component extraction plan as 
 - [x] Outline feature flag groups for heavyweight tools, policy wiring, telemetry, and examples.
 - [x] Extract policy wiring so configuration structs live outside the crate boundary.
 - [x] Make tree-sitter and heavy tooling optional via feature flags.
-- [ ] Publish integration examples exercising registry setup and execution in a headless context.
+- [x] Publish integration examples exercising registry setup and execution in a headless context.
 
 ## Cross-Cutting
 - [x] Capture external integration prerequisites (environment variables, binary dependencies) and align them with optional feature groups.

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -12,7 +12,7 @@ This list tracks actionable tasks spawned from the component extraction plan as 
 ## `vtcode-tools`
 - [x] Scaffold prototype crate that re-exports the tool registry and built-in tools.
 - [x] Outline feature flag groups for heavyweight tools, policy wiring, telemetry, and examples.
-- [ ] Extract policy wiring so configuration structs live outside the crate boundary.
+- [x] Extract policy wiring so configuration structs live outside the crate boundary.
 - [x] Make tree-sitter and heavy tooling optional via feature flags.
 - [ ] Publish integration examples exercising registry setup and execution in a headless context.
 

--- a/docs/vtcode_llm_environment.md
+++ b/docs/vtcode_llm_environment.md
@@ -1,0 +1,89 @@
+# `vtcode-llm` Environment Configuration Guide
+
+This guide explains how the `vtcode-llm` crate discovers provider credentials, maps
+feature flags to environment variables, and offers lightweight mocks for downstream
+integration tests. It is intended for consumers who want to adopt the crate without
+bringing in VTCode's full configuration system.
+
+## Provider environment variables
+
+Each provider feature corresponds to one or more environment variables. Keys should
+be populated before constructing a client so the `ProviderConfig` trait can surface
+the secret values.
+
+| Feature flag | Primary variable | Aliases | Notes |
+| --- | --- | --- | --- |
+| `google` | `GEMINI_API_KEY` | `GOOGLE_API_KEY` | Gemini clients accept either variable; the first non-empty value wins. |
+| `openai` | `OPENAI_API_KEY` | – | Required for GPT models served by OpenAI. |
+| `anthropic` | `ANTHROPIC_API_KEY` | – | Required for Claude models. |
+| `deepseek` | `DEEPSEEK_API_KEY` | – | Required for DeepSeek models. |
+| `openrouter` | `OPENROUTER_API_KEY` | – | Required for OpenRouter routing. |
+| `xai` | `XAI_API_KEY` | – | Required for xAI Grok models. |
+| `zai` | `ZAI_API_KEY` | – | Required for Zhipu AI (Z.AI) models. |
+| `moonshot` | `MOONSHOT_API_KEY` | – | Required for Moonshot AI models. |
+| `ollama` | _N/A_ | – | Ollama uses a local runtime and does not require an API key. |
+
+When multiple providers are enabled, populate the variables you plan to use. Downstream
+applications can surface their own configuration UX but should forward the resolved
+secrets to the `ProviderConfig` implementor.
+
+## Loading keys with `ProviderConfig`
+
+Implementors of [`config::ProviderConfig`](../vtcode-llm/src/config.rs) decide where
+credentials originate. A common pattern is to read from environment variables and then
+pass the owned values to `OwnedProviderConfig` before building a client:
+
+```rust
+use std::env;
+use vtcode_llm::config::{as_factory_config, OwnedProviderConfig};
+
+fn gemini_from_env() -> anyhow::Result<vtcode_core::llm::factory::ProviderConfig> {
+    let key = env::var("GEMINI_API_KEY")
+        .or_else(|_| env::var("GOOGLE_API_KEY"))
+        .map_err(|_| anyhow::anyhow!("Set GEMINI_API_KEY or GOOGLE_API_KEY"))?;
+
+    let config = OwnedProviderConfig::new()
+        .with_api_key(key)
+        .with_model("gemini-2.0-flash-exp".to_string());
+
+    Ok(as_factory_config(&config))
+}
+```
+
+Because the trait only exposes borrowed data, callers can also point to secrets stored
+in files, KMS-backed fetchers, or other secret managers.
+
+## Using the optional mock client
+
+Enable the `mock` feature to access `mock::StaticResponseClient`, a lightweight
+implementation of the `LLMClient` trait designed for deterministic tests:
+
+```toml
+# Cargo.toml
+vtcode-llm = { version = "0.0.1", features = ["mock", "openai"] }
+```
+
+```rust
+use vtcode_llm::mock::StaticResponseClient;
+use vtcode_core::llm::types::{BackendKind, LLMResponse};
+
+let mut client = StaticResponseClient::new("gpt-4.1-mini", BackendKind::OpenAI)
+    .with_response(LLMResponse {
+        content: "Hello from a test".into(),
+        model: "gpt-4.1-mini".into(),
+        usage: None,
+        reasoning: None,
+    });
+
+let response = futures::executor::block_on(client.generate("ignored prompt"))?;
+assert_eq!(response.content, "Hello from a test");
+```
+
+Queue as many responses (or errors) as needed. When the queue runs dry, the client
+returns an `LLMError::InvalidRequest`, helping tests detect unexpected extra calls.
+
+## Next steps
+
+- Add additional provider-specific environment documentation as new integrations land.
+- Share runnable examples that combine `ProviderConfig` implementors with the mock
+  client to showcase end-to-end integration tests.

--- a/docs/vtcode_tools_policy.md
+++ b/docs/vtcode_tools_policy.md
@@ -1,0 +1,79 @@
+# vtcode-tools Policy Customization Guide
+
+This guide explains how to adopt the `vtcode-tools` crate while keeping tool
+policy configuration in your own application's storage hierarchy. The default
+VTCode implementation persists policy state inside a `.vtcode` directory, but
+external consumers often prefer to colocate policy files with their existing
+configuration tree.
+
+## 1. Enable the `policies` feature
+
+The policy management APIs are exported behind the optional `policies` feature
+flag. Enable it in your `Cargo.toml` to access `ToolPolicyManager` and related
+types:
+
+```toml
+[dependencies]
+vtcode-tools = { version = "0.0.1", features = ["policies"] }
+```
+
+## 2. Pick a custom storage location
+
+Decide where policy state should live inside your application. For example, you
+might align it with an existing configuration directory:
+
+```rust
+use std::path::PathBuf;
+
+fn policy_path(root: &PathBuf) -> PathBuf {
+    root.join("config").join("tool-policy.json")
+}
+```
+
+## 3. Construct a `ToolPolicyManager` with your path
+
+The `ToolPolicyManager::new_with_config_path` helper from `vtcode-core`
+initializes the policy store without touching VTCode's default directories:
+
+```rust
+use vtcode_tools::policies::ToolPolicyManager;
+
+let custom_manager = ToolPolicyManager::new_with_config_path(policy_path(&app_root))?;
+```
+
+The constructor ensures parent directories exist and loads (or creates) the JSON
+configuration file at the provided path.
+
+## 4. Inject the manager into the registry
+
+`ToolRegistry` exposes dedicated constructors for supplying a pre-built policy
+manager so the default VTCode wiring never executes:
+
+```rust
+use vtcode_tools::ToolRegistry;
+
+let mut registry = ToolRegistry::new_with_custom_policy(workspace_root, custom_manager);
+```
+
+If you need to configure PTY behaviour or toggle planner support, the
+`new_with_custom_policy_and_config` variant accepts the same knobs as the
+existing constructors.
+
+## 5. Apply your application's defaults
+
+Once the registry is created you can call the usual policy helpers to enforce
+your own defaults:
+
+```rust
+registry.allow_all_tools()?; // or selectively set policies per tool
+```
+
+Because the policy storage path is now under your control, the resulting JSON
+file can be versioned, synchronized, or otherwise managed according to your
+project's requirements.
+
+## Next steps
+
+See `docs/component_extraction_plan.md` for the broader roadmap, including the
+upcoming integration examples that will demonstrate headless usage of the tool
+registry with custom policy storage.

--- a/vtcode-core/src/tool_policy.rs
+++ b/vtcode-core/src/tool_policy.rs
@@ -360,6 +360,33 @@ impl ToolPolicyManager {
         })
     }
 
+    /// Create a new tool policy manager backed by a custom configuration path.
+    ///
+    /// This helper allows downstream consumers to store policy data alongside
+    /// their own configuration hierarchy instead of writing to the default
+    /// `.vtcode` directory.
+    pub fn new_with_config_path<P: Into<PathBuf>>(config_path: P) -> Result<Self> {
+        let config_path = config_path.into();
+
+        if let Some(parent) = config_path.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "Failed to create directory for tool policy config at {}",
+                        parent.display()
+                    )
+                })?;
+            }
+        }
+
+        let config = Self::load_or_create_config(&config_path)?;
+
+        Ok(Self {
+            config_path,
+            config,
+        })
+    }
+
     /// Get the path to the tool policy configuration file
     fn get_config_path() -> Result<PathBuf> {
         let home_dir = dirs::home_dir().context("Could not determine home directory")?;

--- a/vtcode-core/src/tools/registry/policy.rs
+++ b/vtcode-core/src/tools/registry/policy.rs
@@ -36,6 +36,14 @@ impl ToolPolicyGateway {
         }
     }
 
+    pub fn with_policy_manager(manager: ToolPolicyManager) -> Self {
+        Self {
+            tool_policy: Some(manager),
+            preapproved_tools: HashSet::new(),
+            full_auto_allowlist: None,
+        }
+    }
+
     pub fn sync_available_tools(&mut self, mut available: Vec<String>, mcp_keys: &[String]) {
         available.extend(mcp_keys.iter().cloned());
         available.sort();

--- a/vtcode-llm/Cargo.toml
+++ b/vtcode-llm/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "vtcode-llm"
+version = "0.0.1"
+edition = "2024"
+authors = ["vinhnx <vinhnx@users.noreply.github.com>"]
+description = "Prototype extraction of VTCode's unified LLM client layer"
+license = "MIT"
+publish = false
+
+[features]
+default = [
+    "anthropic",
+    "deepseek",
+    "google",
+    "moonshot",
+    "ollama",
+    "openai",
+    "openrouter",
+    "xai",
+    "zai",
+    "functions",
+]
+
+anthropic = []
+deepseek = []
+google = []
+moonshot = []
+ollama = []
+openai = []
+openrouter = []
+xai = []
+zai = []
+functions = []
+telemetry = []
+mock = ["dep:async-trait"]
+
+[dependencies]
+async-trait = { version = "0.1", optional = true }
+vtcode-core = { path = "../vtcode-core" }
+
+[dev-dependencies]
+futures = "0.3"

--- a/vtcode-llm/src/config.rs
+++ b/vtcode-llm/src/config.rs
@@ -1,0 +1,139 @@
+//! Provider configuration traits decoupled from VTCode's dot-config storage.
+//!
+//! Consumers can implement [`ProviderConfig`] for their own types and use the
+//! conversion helpers to build `vtcode_core` provider factories without
+//! depending on VTCode's internal configuration structs.
+
+use std::borrow::Cow;
+
+use vtcode_core::config::core::PromptCachingConfig;
+
+/// Trait describing the configuration required to instantiate an LLM provider.
+///
+/// The trait intentionally returns owned-friendly values so that consumers can
+/// back the configuration with environment variables, secret managers, or
+/// custom structs. The [`as_factory_config`] helper converts a trait object into
+/// the concrete configuration type expected by `vtcode_core`'s provider
+/// factory.
+pub trait ProviderConfig {
+    /// API key or bearer token used to authenticate with the provider.
+    fn api_key(&self) -> Option<Cow<'_, str>>;
+
+    /// Optional override for the provider's base URL.
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        None
+    }
+
+    /// Preferred model identifier for the provider.
+    fn model(&self) -> Option<Cow<'_, str>> {
+        None
+    }
+
+    /// Optional prompt cache configuration forwarded to providers that support
+    /// caching.
+    fn prompt_cache(&self) -> Option<Cow<'_, PromptCachingConfig>> {
+        None
+    }
+}
+
+/// Convert an implementor of [`ProviderConfig`] into the configuration used by
+/// the `vtcode_core` provider factory.
+pub fn as_factory_config(source: &dyn ProviderConfig) -> vtcode_core::llm::factory::ProviderConfig {
+    vtcode_core::llm::factory::ProviderConfig {
+        api_key: source.api_key().map(Cow::into_owned),
+        base_url: source.base_url().map(Cow::into_owned),
+        model: source.model().map(Cow::into_owned),
+        prompt_cache: source.prompt_cache().map(|cfg| cfg.into_owned()),
+    }
+}
+
+/// [`ProviderConfig`] implementation for VTCode's dot-config provider entries.
+impl ProviderConfig for vtcode_core::utils::dot_config::ProviderConfig {
+    fn api_key(&self) -> Option<Cow<'_, str>> {
+        self.api_key.as_deref().map(Cow::Borrowed)
+    }
+
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        self.base_url.as_deref().map(Cow::Borrowed)
+    }
+
+    fn model(&self) -> Option<Cow<'_, str>> {
+        self.model.as_deref().map(Cow::Borrowed)
+    }
+}
+
+/// [`ProviderConfig`] implementation for the concrete factory configuration.
+impl ProviderConfig for vtcode_core::llm::factory::ProviderConfig {
+    fn api_key(&self) -> Option<Cow<'_, str>> {
+        self.api_key.as_deref().map(Cow::Borrowed)
+    }
+
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        self.base_url.as_deref().map(Cow::Borrowed)
+    }
+
+    fn model(&self) -> Option<Cow<'_, str>> {
+        self.model.as_deref().map(Cow::Borrowed)
+    }
+
+    fn prompt_cache(&self) -> Option<Cow<'_, PromptCachingConfig>> {
+        self.prompt_cache
+            .as_ref()
+            .map(|cfg| Cow::Owned(cfg.clone()))
+    }
+}
+
+/// Simple builder-friendly provider configuration backed by owned values.
+#[derive(Clone, Debug, Default)]
+pub struct OwnedProviderConfig {
+    api_key: Option<String>,
+    base_url: Option<String>,
+    model: Option<String>,
+    prompt_cache: Option<PromptCachingConfig>,
+}
+
+impl OwnedProviderConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_api_key(mut self, value: impl Into<String>) -> Self {
+        self.api_key = Some(value.into());
+        self
+    }
+
+    pub fn with_base_url(mut self, value: impl Into<String>) -> Self {
+        self.base_url = Some(value.into());
+        self
+    }
+
+    pub fn with_model(mut self, value: impl Into<String>) -> Self {
+        self.model = Some(value.into());
+        self
+    }
+
+    pub fn with_prompt_cache(mut self, value: PromptCachingConfig) -> Self {
+        self.prompt_cache = Some(value);
+        self
+    }
+}
+
+impl ProviderConfig for OwnedProviderConfig {
+    fn api_key(&self) -> Option<Cow<'_, str>> {
+        self.api_key.as_deref().map(Cow::Borrowed)
+    }
+
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        self.base_url.as_deref().map(Cow::Borrowed)
+    }
+
+    fn model(&self) -> Option<Cow<'_, str>> {
+        self.model.as_deref().map(Cow::Borrowed)
+    }
+
+    fn prompt_cache(&self) -> Option<Cow<'_, PromptCachingConfig>> {
+        self.prompt_cache
+            .as_ref()
+            .map(|cfg| Cow::Owned(cfg.clone()))
+    }
+}

--- a/vtcode-llm/src/lib.rs
+++ b/vtcode-llm/src/lib.rs
@@ -1,0 +1,108 @@
+//! Prototype crate that re-exports VTCode's LLM integration layer while
+//! introducing decoupled configuration traits for downstream consumers.
+//!
+//! The goal is to let external applications supply their own configuration
+//! sources without depending on VTCode's dot-config structures. Consumers can
+//! implement [`config::ProviderConfig`] for their own types and then convert
+//! them into the factory configuration used internally by `vtcode-core`.
+//!
+//! This crate exposes feature flags so downstream projects can opt into
+//! provider-specific exports, function calling helpers, or streaming telemetry
+//! utilities without pulling additional API surface by default. Consult
+//! `docs/vtcode_llm_environment.md` for a full overview of environment
+//! variables, configuration patterns, and the optional mock client helpers.
+
+pub mod config;
+
+pub use vtcode_core::llm::client::{AnyClient, make_client};
+pub use vtcode_core::llm::error_display;
+pub use vtcode_core::llm::factory::{
+    ProviderConfig as CoreProviderConfig, create_provider_with_config, get_factory,
+};
+pub use vtcode_core::llm::rig_adapter;
+pub use vtcode_core::llm::types::{BackendKind, LLMError, LLMResponse, Usage};
+
+pub mod provider {
+    //! Re-export the provider abstraction and shared request/response types.
+    pub use vtcode_core::llm::provider::{
+        LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent, Message, MessageRole,
+        ParallelToolConfig,
+    };
+
+    #[cfg(feature = "functions")]
+    pub use vtcode_core::llm::provider::{
+        FunctionCall, FunctionDefinition, SpecificFunctionChoice, SpecificToolChoice, ToolCall,
+        ToolChoice, ToolDefinition,
+    };
+}
+
+pub use provider::{
+    LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent, Message, MessageRole,
+};
+
+#[cfg(feature = "functions")]
+pub use provider::{
+    FunctionCall, FunctionDefinition, SpecificFunctionChoice, SpecificToolChoice, ToolCall,
+    ToolChoice, ToolDefinition,
+};
+
+#[cfg(feature = "anthropic")]
+pub use vtcode_core::llm::providers::AnthropicProvider;
+#[cfg(feature = "deepseek")]
+pub use vtcode_core::llm::providers::DeepSeekProvider;
+#[cfg(feature = "google")]
+pub use vtcode_core::llm::providers::GeminiProvider;
+#[cfg(feature = "moonshot")]
+pub use vtcode_core::llm::providers::MoonshotProvider;
+#[cfg(feature = "ollama")]
+pub use vtcode_core::llm::providers::OllamaProvider;
+#[cfg(feature = "openai")]
+pub use vtcode_core::llm::providers::OpenAIProvider;
+#[cfg(feature = "openrouter")]
+pub use vtcode_core::llm::providers::OpenRouterProvider;
+#[cfg(feature = "xai")]
+pub use vtcode_core::llm::providers::XAIProvider;
+#[cfg(feature = "zai")]
+pub use vtcode_core::llm::providers::ZAIProvider;
+
+#[cfg(feature = "mock")]
+pub mod mock;
+
+#[cfg(feature = "mock")]
+pub use mock::StaticResponseClient;
+
+pub mod providers {
+    //! Provider-specific exports gated behind feature flags so consumers can
+    //! depend on a minimal surface when only a subset of providers is needed.
+    #[cfg(feature = "anthropic")]
+    pub use vtcode_core::llm::providers::anthropic::*;
+    #[cfg(feature = "deepseek")]
+    pub use vtcode_core::llm::providers::deepseek::*;
+    #[cfg(feature = "google")]
+    pub use vtcode_core::llm::providers::gemini::*;
+    #[cfg(feature = "moonshot")]
+    pub use vtcode_core::llm::providers::moonshot::*;
+    #[cfg(feature = "ollama")]
+    pub use vtcode_core::llm::providers::ollama::*;
+    #[cfg(feature = "openai")]
+    pub use vtcode_core::llm::providers::openai::*;
+    #[cfg(feature = "openrouter")]
+    pub use vtcode_core::llm::providers::openrouter::*;
+    #[cfg(feature = "xai")]
+    pub use vtcode_core::llm::providers::xai::*;
+    #[cfg(feature = "zai")]
+    pub use vtcode_core::llm::providers::zai::*;
+}
+
+#[cfg(feature = "telemetry")]
+pub mod telemetry {
+    //! Streaming telemetry helpers shared across provider implementations.
+    pub use vtcode_core::llm::providers::shared::{
+        NoopStreamTelemetry, StreamAssemblyError, StreamDelta, StreamFragment, StreamTelemetry,
+        ToolCallBuilder, append_reasoning_segments, append_text_with_reasoning,
+        finalize_tool_calls, update_tool_calls,
+    };
+}
+
+#[cfg(feature = "telemetry")]
+pub use telemetry::{NoopStreamTelemetry, StreamTelemetry};

--- a/vtcode-llm/src/mock.rs
+++ b/vtcode-llm/src/mock.rs
@@ -1,0 +1,118 @@
+//! Utilities for deterministic tests that need an `LLMClient` implementation
+//! without performing network calls.
+//!
+//! Enable the crate's `mock` feature to access the [`StaticResponseClient`],
+//! queue canned responses, and verify the interaction contract used by
+//! downstream integrations.
+
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+use vtcode_core::llm::client::LLMClient;
+use vtcode_core::llm::types::{BackendKind, LLMError, LLMResponse};
+
+/// Deterministic `LLMClient` that yields queued responses.
+#[derive(Debug)]
+pub struct StaticResponseClient {
+    backend: BackendKind,
+    model: String,
+    queue: VecDeque<Result<LLMResponse, LLMError>>,
+}
+
+impl StaticResponseClient {
+    /// Create a mock client for the provided model/backend combination.
+    pub fn new(model: impl Into<String>, backend: BackendKind) -> Self {
+        Self {
+            backend,
+            model: model.into(),
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Queue a successful response. Responses are returned in FIFO order.
+    pub fn enqueue_response(&mut self, response: LLMResponse) {
+        self.queue.push_back(Ok(response));
+    }
+
+    /// Queue a successful response and return the client for chaining.
+    pub fn with_response(mut self, response: LLMResponse) -> Self {
+        self.enqueue_response(response);
+        self
+    }
+
+    /// Queue an error result. Errors are returned in FIFO order alongside responses.
+    pub fn enqueue_error(&mut self, error: LLMError) {
+        self.queue.push_back(Err(error));
+    }
+
+    /// Queue an error result and return the client for chaining.
+    pub fn with_error(mut self, error: LLMError) -> Self {
+        self.enqueue_error(error);
+        self
+    }
+
+    /// Consume the client and return it as a boxed trait object.
+    pub fn into_client(self) -> vtcode_core::llm::client::AnyClient {
+        Box::new(self)
+    }
+}
+
+#[async_trait]
+impl LLMClient for StaticResponseClient {
+    async fn generate(&mut self, _prompt: &str) -> Result<LLMResponse, LLMError> {
+        self.queue.pop_front().unwrap_or_else(|| {
+            Err(LLMError::InvalidRequest(
+                "StaticResponseClient has no queued responses".to_string(),
+            ))
+        })
+    }
+
+    fn backend_kind(&self) -> BackendKind {
+        self.backend.clone()
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StaticResponseClient;
+    use vtcode_core::llm::types::{BackendKind, LLMError, LLMResponse};
+
+    #[test]
+    fn returns_responses_in_fifo_order() {
+        let response_one = LLMResponse {
+            content: "first".to_string(),
+            model: "test".to_string(),
+            usage: None,
+            reasoning: None,
+        };
+        let response_two = LLMResponse {
+            content: "second".to_string(),
+            model: "test".to_string(),
+            usage: None,
+            reasoning: None,
+        };
+
+        let mut client = StaticResponseClient::new("test", BackendKind::OpenAI);
+        client.enqueue_response(response_one.clone());
+        client.enqueue_response(response_two.clone());
+
+        let first = futures::executor::block_on(client.generate("prompt")).unwrap();
+        let second = futures::executor::block_on(client.generate("prompt")).unwrap();
+
+        assert_eq!(first.content, response_one.content);
+        assert_eq!(second.content, response_two.content);
+    }
+
+    #[test]
+    fn errors_when_queue_is_empty() {
+        let mut client = StaticResponseClient::new("test", BackendKind::Gemini);
+        let error = futures::executor::block_on(client.generate("prompt"))
+            .expect_err("expected error when queue is empty");
+
+        assert!(matches!(error, LLMError::InvalidRequest(_)));
+    }
+}

--- a/vtcode-tools/Cargo.toml
+++ b/vtcode-tools/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "vtcode-tools"
+version = "0.0.1"
+edition = "2024"
+authors = ["vinhnx <vinhnx@users.noreply.github.com>"]
+description = "Prototype extraction of VTCode's modular tool registry"
+license = "MIT"
+publish = false
+
+[features]
+default = ["bash", "search", "net", "planner"]
+
+bash = []
+search = []
+net = []
+planner = []
+policies = []
+examples = []
+
+[dependencies]
+vtcode-core = { path = "../vtcode-core" }

--- a/vtcode-tools/Cargo.toml
+++ b/vtcode-tools/Cargo.toml
@@ -19,3 +19,14 @@ examples = []
 
 [dependencies]
 vtcode-core = { path = "../vtcode-core" }
+
+[dev-dependencies]
+anyhow = "1.0"
+serde_json = "1.0"
+tempfile = "3.10"
+tokio = { version = "1.37", features = ["macros", "rt"] }
+
+[[example]]
+name = "headless_custom_policy"
+path = "examples/headless_custom_policy.rs"
+required-features = ["policies"]

--- a/vtcode-tools/examples/headless_custom_policy.rs
+++ b/vtcode-tools/examples/headless_custom_policy.rs
@@ -1,0 +1,87 @@
+//! Demonstrates running the tool registry in a headless context with a custom
+//! policy store and planning disabled for a lightweight deployment.
+//!
+//! ```bash
+//! cargo run -p vtcode-tools --example headless_custom_policy \
+//!     --no-default-features --features "policies"
+//! ```
+//!
+//! The example executes `list_files` and `read_file` using policies persisted in
+//! a workspace-local directory instead of the global `~/.vtcode` config.
+
+use std::fs;
+
+use anyhow::{Context, Result};
+use serde_json::{json, to_string_pretty};
+use tempfile::tempdir;
+use vtcode_core::config::{PtyConfig, constants::tools};
+use vtcode_tools::policies::{ToolPolicy, ToolPolicyManager};
+use vtcode_tools::registry::ToolRegistry;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let workspace = tempdir().context("failed to create temporary workspace")?;
+    let workspace_root = workspace.path().to_path_buf();
+
+    let sample_file = workspace_root.join("README.md");
+    fs::write(
+        &sample_file,
+        "# vtcode-tools headless demo\n\nPolicies live next to the project.\n",
+    )
+    .context("failed to write sample file")?;
+
+    let policy_path = workspace_root.join("policies").join("tool-policy.json");
+    let mut policy_manager = ToolPolicyManager::new_with_config_path(&policy_path)
+        .context("failed to initialize custom policy manager")?;
+
+    policy_manager
+        .set_policy(tools::LIST_FILES, ToolPolicy::Allow)
+        .context("failed to allow list_files")?;
+    policy_manager
+        .set_policy(tools::READ_FILE, ToolPolicy::Allow)
+        .context("failed to allow read_file")?;
+
+    let mut registry = ToolRegistry::new_with_custom_policy_and_config(
+        workspace_root.clone(),
+        PtyConfig::default(),
+        false, // Disable planning to demonstrate lightweight adoption.
+        policy_manager,
+    );
+
+    let available_tools = registry.available_tools();
+    println!(
+        "Registered tools (planning disabled): {}",
+        available_tools.join(", ")
+    );
+    println!("Policies stored at: {}", policy_path.display());
+    println!(
+        "Planning tool registered? {}",
+        available_tools
+            .iter()
+            .any(|tool| tool == tools::UPDATE_PLAN)
+    );
+
+    let listing = registry
+        .execute_tool(
+            tools::LIST_FILES,
+            json!({
+                "path": ".",
+                "response_format": "concise",
+            }),
+        )
+        .await?;
+    println!("list_files response:\n{}", to_string_pretty(&listing)?);
+
+    let read_file = registry
+        .execute_tool(
+            tools::READ_FILE,
+            json!({
+                "path": "README.md",
+                "response_format": "text",
+            }),
+        )
+        .await?;
+    println!("read_file response:\n{}", to_string_pretty(&read_file)?);
+
+    Ok(())
+}

--- a/vtcode-tools/src/lib.rs
+++ b/vtcode-tools/src/lib.rs
@@ -89,15 +89,15 @@ pub use planner::{
 
 #[cfg(feature = "policies")]
 pub mod policies {
+    //! Policy-related helpers for configuring the tool registry.
     pub use vtcode_core::tool_policy::{ToolPolicy, ToolPolicyManager};
-    pub use vtcode_core::tools::registry::policy::ToolPolicyGateway;
 }
 
 #[cfg(feature = "policies")]
-pub use policies::{ToolPolicy, ToolPolicyGateway, ToolPolicyManager};
+pub use policies::{ToolPolicy, ToolPolicyManager};
 
 #[cfg(feature = "examples")]
 pub mod examples {
-    //! Placeholder re-exports for upcoming headless examples.
-    pub use vtcode_core::tools::registry::legacy::*;
+    //! See `examples/headless_custom_policy.rs` for a headless registry demo
+    //! that wires a custom `ToolPolicyManager` into the extractor crate.
 }

--- a/vtcode-tools/src/lib.rs
+++ b/vtcode-tools/src/lib.rs
@@ -1,0 +1,99 @@
+//! Prototype crate that exposes VTCode's tool registry and built-in tools.
+//!
+//! The goal is to surface the current API surface to external consumers
+//! while we iterate on decoupling policies, configuration, and optional
+//! dependencies. By shipping this crate as a thin wrapper we can collect
+//! integration feedback and identify breaking changes early.
+//!
+//! Feature flags mirror the extraction plan so adopters can opt into only the
+//! tool categories they need.
+
+pub use vtcode_core::tools::command;
+pub use vtcode_core::tools::names;
+
+pub mod registry {
+    //! Registry exports shared across tool categories.
+    pub use vtcode_core::tools::registry::{
+        self, ToolPermissionDecision, ToolRegistration, ToolRegistry, build_function_declarations,
+        build_function_declarations_for_level, build_function_declarations_with_mode,
+    };
+}
+
+pub use registry::{
+    ToolPermissionDecision, ToolRegistration, ToolRegistry, build_function_declarations,
+    build_function_declarations_for_level, build_function_declarations_with_mode,
+};
+
+pub mod traits {
+    pub use vtcode_core::tools::traits::{Tool, ToolExecutor};
+}
+
+pub use traits::{Tool, ToolExecutor};
+
+pub mod types {
+    pub use vtcode_core::tools::types::*;
+}
+
+pub use types::*;
+
+#[cfg(feature = "bash")]
+pub mod bash {
+    pub use vtcode_core::tools::bash_tool::BashTool;
+    pub use vtcode_core::tools::pty::{PtyCommandRequest, PtyCommandResult, PtyManager};
+}
+
+#[cfg(feature = "bash")]
+pub use bash::{BashTool, PtyCommandRequest, PtyCommandResult, PtyManager};
+
+#[cfg(feature = "search")]
+pub mod search {
+    pub use vtcode_core::tools::advanced_search::*;
+    pub use vtcode_core::tools::ast_grep::*;
+    pub use vtcode_core::tools::ast_grep_tool::AstGrepTool;
+    pub use vtcode_core::tools::file_search::*;
+    pub use vtcode_core::tools::grep_file::GrepSearchManager;
+    pub use vtcode_core::tools::search::*;
+    pub use vtcode_core::tools::simple_search::SimpleSearchTool;
+    pub use vtcode_core::tools::srgn::SrgnTool;
+    pub use vtcode_core::tools::tree_sitter::*;
+}
+
+#[cfg(feature = "search")]
+pub use search::{AstGrepTool, GrepSearchManager, SimpleSearchTool, SrgnTool};
+
+#[cfg(feature = "net")]
+pub mod net {
+    pub use vtcode_core::tools::curl_tool::CurlTool;
+}
+
+#[cfg(feature = "net")]
+pub use net::CurlTool;
+
+#[cfg(feature = "planner")]
+pub mod planner {
+    pub use vtcode_core::tools::plan::{
+        PlanCompletionState, PlanManager, PlanStep, PlanSummary, PlanUpdateResult, StepStatus,
+        TaskPlan, UpdatePlanArgs,
+    };
+}
+
+#[cfg(feature = "planner")]
+pub use planner::{
+    PlanCompletionState, PlanManager, PlanStep, PlanSummary, PlanUpdateResult, StepStatus,
+    TaskPlan, UpdatePlanArgs,
+};
+
+#[cfg(feature = "policies")]
+pub mod policies {
+    pub use vtcode_core::tool_policy::{ToolPolicy, ToolPolicyManager};
+    pub use vtcode_core::tools::registry::policy::ToolPolicyGateway;
+}
+
+#[cfg(feature = "policies")]
+pub use policies::{ToolPolicy, ToolPolicyGateway, ToolPolicyManager};
+
+#[cfg(feature = "examples")]
+pub mod examples {
+    //! Placeholder re-exports for upcoming headless examples.
+    pub use vtcode_core::tools::registry::legacy::*;
+}

--- a/vtcode-tools/src/lib.rs
+++ b/vtcode-tools/src/lib.rs
@@ -7,6 +7,10 @@
 //!
 //! Feature flags mirror the extraction plan so adopters can opt into only the
 //! tool categories they need.
+//!
+//! See `docs/vtcode_tools_policy.md` for guidance on supplying a custom
+//! `ToolPolicyManager` when the `policies` feature is enabled, allowing
+//! consumers to store policy configuration outside of VTCode's defaults.
 
 pub use vtcode_core::tools::command;
 pub use vtcode_core::tools::names;


### PR DESCRIPTION
## Summary
- add a dedicated `vtcode-llm` environment configuration guide covering provider keys, `ProviderConfig` usage, and the new mock client helpers
- expose a `mock` feature in `vtcode-llm` with a `StaticResponseClient` test utility and optional dependency wiring
- record the completed environment-documentation milestone in the extraction plan and TODO tracker

## Testing
- cargo fmt
- cargo check
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f4e8dacfe48323a82484ea794a0b69