### PR TITLE
Address review feedback: restore Shift+Enter newline handling

### DIFF
--- a/vtcode-core/src/config/constants.rs
+++ b/vtcode-core/src/config/constants.rs
@@ -406,8 +406,7 @@ pub mod ui {
     pub const CHAT_INPUT_PLACEHOLDER_BOOTSTRAP: &str =
         "Describe your next task or run /init to rerun workspace setup.";
     pub const CHAT_INPUT_PLACEHOLDER_FOLLOW_UP: &str = "Next action?";
-    pub const HEADER_SHORTCUT_HINT: &str =
-        "Shortcuts: Ctrl+Enter to submit • Esc to cancel • Ctrl+C to interrupt";
+    pub const HEADER_SHORTCUT_HINT: &str = "Shortcuts: Enter to submit • Shift+Enter for newline • Ctrl/Cmd+Enter to queue • Esc to cancel • Ctrl+C to interrupt";
     pub const HEADER_META_SEPARATOR: &str = "   ";
     pub const WELCOME_TEXT_WIDTH: usize = 80;
     pub const WELCOME_SHORTCUT_SECTION_TITLE: &str = "Keyboard Shortcuts";

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -2607,6 +2607,12 @@ impl Session {
                     return None;
                 }
 
+                if has_shift && !has_control && !has_command {
+                    self.insert_char('\n');
+                    self.mark_dirty();
+                    return None;
+                }
+
                 let submitted = std::mem::take(&mut self.input);
                 self.cursor = 0;
                 self.scroll_offset = 0;
@@ -2615,7 +2621,7 @@ impl Session {
                 self.remember_submitted_input(&submitted);
                 self.mark_dirty();
 
-                if has_shift {
+                if has_control || has_command {
                     Some(InlineEvent::QueueSubmit(submitted))
                 } else {
                     Some(InlineEvent::Submit(submitted))

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -4266,13 +4266,37 @@ mod tests {
     }
 
     #[test]
-    fn shift_enter_queues_submission() {
+    fn shift_enter_inserts_newline() {
         let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS, true);
 
         session.input = "queued".to_string();
         session.cursor = session.input.len();
 
-        let queued = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+        let result = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+        assert!(result.is_none());
+        assert_eq!(session.input, "queued\n");
+        assert_eq!(session.cursor, session.input.len());
+    }
+
+    #[test]
+    fn control_enter_queues_submission() {
+        let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS, true);
+
+        session.input = "queued".to_string();
+        session.cursor = session.input.len();
+
+        let queued = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL));
+        assert!(matches!(queued, Some(InlineEvent::QueueSubmit(value)) if value == "queued"));
+    }
+
+    #[test]
+    fn command_enter_queues_submission() {
+        let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS, true);
+
+        session.input = "queued".to_string();
+        session.cursor = session.input.len();
+
+        let queued = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SUPER));
         assert!(matches!(queued, Some(InlineEvent::QueueSubmit(value)) if value == "queued"));
     }
 


### PR DESCRIPTION
## Summary
- restore Shift+Enter to insert a newline in the inline editor when composing prompts
- require Control/Command+Enter to queue inline submissions so the queue shortcut remains available

## Testing
- cargo fmt
- cargo test *(fails: missing helper functions such as `build_terminal_followup_message` in unrelated tests)*
- cargo test -p vtcode-core *(fails: existing compile errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68f506c7b7248323977add3c74024aa5