### PR TITLE
Document vtcode-commons reference adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4696,6 +4696,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "vtcode-commons"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "vtcode-core"
 version = "0.29.1"
 dependencies = [
@@ -4778,6 +4785,31 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width 0.2.0",
  "walkdir",
+]
+
+[[package]]
+name = "vtcode-llm"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "tempfile",
+ "vtcode-commons",
+ "vtcode-core",
+]
+
+[[package]]
+name = "vtcode-tools"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "vtcode-commons",
+ "vtcode-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,13 @@ exclude = [
 default-run = "vtcode"
 
 [workspace]
-members = ["vtcode-acp-client", "vtcode-core"]
+members = [
+    "vtcode-acp-client",
+    "vtcode-core",
+    "vtcode-commons",
+    "vtcode-llm",
+    "vtcode-tools",
+]
 
 [workspace.lints]
 rust = {}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It supports multiple LLM providers: OpenAI, Anthropic, xAI, DeepSeek, Gemini, Op
 - [Zed IDE Integration](#zed-ide-integration)
 - [Command Line Interface](#command-line-interface)
 - [System Architecture](#system-architecture)
+- [Component Extraction Roadmap](#component-extraction-roadmap)
 - [Development](#development)
 - [References](#references)
 
@@ -143,6 +144,15 @@ The architecture divides into `vtcode-core` (reusable library) and `src/` (CLI e
 - **Observability**: Logs to file/console with structured format; metrics (e.g., cache hit rate, token usage) exposed via debug flags.
 
 Performance notes: Multi-threaded Tokio reduces latency for I/O-bound tasks (~20% faster than single-thread); context compression yields 50-80% token savings in long sessions. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for dependency graph and profiling data.
+
+## Component Extraction Roadmap
+
+We are in the process of extracting reusable subsystems from this workspace so other Rust agents can build on VT Code’s tooling without adopting the entire TUI. The initiative currently focuses on two prototype crates:
+
+- [`vtcode-llm`](vtcode-llm/): provider-agnostic client facade that unifies request/response handling across Gemini, OpenAI, Anthropic, xAI, DeepSeek, and Z.AI with streaming and function calling gated behind feature flags.
+- [`vtcode-tools`](vtcode-tools/): modular tool registry exposing sandboxed shell execution, AST/grep utilities, planners, and telemetry hooks with optional features for heavyweight dependencies.
+
+Progress, open tasks, and release checklists live in [docs/component_extraction_plan.md](docs/component_extraction_plan.md) and the companion [docs/component_extraction_todo.md](docs/component_extraction_todo.md) tracker. We will publish pre-release versions of these crates once the documentation and policy adapters are decoupled; in the meantime, community feedback on the roadmap and desired integration points is welcome via issues or discussions.
 
 ## Key Capabilities
 

--- a/docs/component_extraction_plan.md
+++ b/docs/component_extraction_plan.md
@@ -13,6 +13,7 @@ This document captures the results of a quick architectural survey of VTCode wit
 | --- | --- | --- | --- | --- |
 | `vtcode-llm` | `vtcode-core/src/llm` | Unified async client abstraction over Gemini, OpenAI, Anthropic, xAI, DeepSeek, and Z.AI providers (streaming, function calling, retries). | `anyhow`, `futures`, provider SDKs, config loader. | High – provides a ready-made multi-provider facade with streaming and function-call support.【F:vtcode-core/src/llm/mod.rs†L1-L160】|
 | `vtcode-tools` | `vtcode-core/src/tools` | Registry-driven tool execution framework with safety policies, PTY integration, AST/grep search utilities. | `async_trait`, `serde_json`, `tokio`, tree-sitter crates. | High – modular tool runtime could power other agents or CLI automation surfaces.【F:vtcode-core/src/tools/mod.rs†L1-L160】|
+| `vtcode-commons` | New shared crate | Foundational traits for workspace paths, telemetry sinks, and error reporting shared across extracted crates. | `anyhow`. | High – keeps downstream integrations consistent without depending on VTCode's binary or storage defaults. |
 | `vtcode-config` | `vtcode-core/src/config/loader/mod.rs` plus `config` submodules | Typed loader for TOML configuration with defaults covering agent, tools, security, UI, MCP/ACP, telemetry, syntax highlighting. | `serde`, `toml`, `anyhow`. | Medium – valuable for other terminal agents; requires separating VTCode-specific defaults and paths.【F:vtcode-core/src/config/loader/mod.rs†L1-L200】|
 | `vtcode-markdown-store` | `vtcode-core/src/markdown_storage.rs`, `project.rs` | Markdown-backed storage, project management, simple cache/kv utilities. | `serde_json`, `serde_yaml`, `indexmap`. | Medium – lightweight alternative to database-backed state useful for offline tooling.【F:vtcode-core/src/markdown_storage.rs†L1-L200】【F:vtcode-core/src/project.rs†L1-L200】|
 | `vtcode-indexer` | `vtcode-core/src/simple_indexer.rs` | Regex-powered file indexer with on-disk markdown snapshots and search helpers. | `regex`, filesystem APIs. | Medium – simple workspace index ideal for scripting or other agents.【F:vtcode-core/src/simple_indexer.rs†L1-L200】|
@@ -41,6 +42,16 @@ This document captures the results of a quick architectural survey of VTCode wit
 - Isolate tree-sitter parsers and heavy dependencies into optional features.
 - Move VTCode-specific policy wiring (config structs, telemetry hooks) into adapters so the crate exports clean traits.
 - Provide integration examples demonstrating registry setup and tool execution from a headless context.
+
+### `vtcode-commons`
+**What it offers:**
+- Shared contracts for resolving workspace paths, emitting telemetry, and reporting recoverable errors without depending on the CLI layer.
+- Default no-op implementations to unblock prototypes that do not yet integrate with observability stacks.
+
+**Decoupling tasks:**
+- Wire the new traits into `vtcode-llm` and `vtcode-tools` so consumers can optionally provide their own implementations.
+- Audit `vtcode-core` to identify additional utilities (path normalization, logging adapters) that belong in the shared crate.
+- Document recommended trait implementations and patterns for external adopters.
 
 ### `vtcode-config`
 **What it offers:**
@@ -96,8 +107,104 @@ This document captures the results of a quick architectural survey of VTCode wit
 - Adopt semantic versioning per crate and generate docs via `cargo doc` before publishing to crates.io.
 - Ensure all extracted crates include focused integration tests and, where applicable, minimal examples under `examples/` demonstrating standalone use.
 
+## Progress Update
+- Scaffolded prototype crates `vtcode-llm` and `vtcode-tools` that re-export the existing LLM layer and tool registry for experimentation while decoupling work proceeds.
+- Added `docs/component_extraction_todo.md` to track follow-up tasks for configuration traits, feature flags, documentation, and cross-cutting concerns.
+- Mapped external integration requirements for prospective consumers and drafted a feature flag matrix covering providers, heavyweight tools, and optional telemetry so the prototype crates can slim dependencies while staying configurable.
+- Introduced initial feature gates in both prototype crates so downstream consumers can opt into provider-specific exports, tool categories, telemetry helpers, and function-calling utilities without pulling the entire workspace surface by default.
+- Published dedicated environment configuration guidance for `vtcode-llm`, documenting provider API keys, configuration helper patterns, and the new mock client utilities for deterministic tests.
+- Documented how `vtcode-tools` adopters can supply their own policy storage by exposing constructors that accept custom `ToolPolicyManager` instances and publishing the `docs/vtcode_tools_policy.md` guide.
+- Published a headless integration example (`vtcode-tools/examples/headless_registry.rs`) that wires a custom policy manager into the registry while keeping crate features slimmed down to the `policies` toggle.
+- Introduced the `vtcode-commons` crate to host shared path, telemetry, and error-reporting traits so future extractions avoid reimplementing the same contracts.
+- Adopted the shared `WorkspacePaths`, telemetry sink, and error-reporting hooks inside `vtcode-llm`'s provider configuration adapters so consumers can resolve prompt caches and surface failures without relying on VTCode defaults.
+
+**Next milestone:** document reference implementations of the shared `vtcode-commons` traits so downstream adopters have ready-to-use examples.
+
+## Feature Flag Strategy
+
+### `vtcode-llm`
+- **Core API surface**: Keep `AnyClient` and shared request/response types in the default build.
+- **Provider features**:
+  - `openai`, `anthropic`, `google`, `xai`, `deepseek`, `zai` – each toggles the concrete client module and corresponding SDK dependency.
+  - `mock` – enables the deterministic fake provider used in integration tests and documentation snippets.
+- **Streaming/function-calling**: Expose a `functions` feature that wires in shared schema helpers and executor glue for function calls across providers.
+- **Telemetry hooks**: Gate optional tracing/metrics emitters behind a `telemetry` feature so downstream projects can integrate observability without extra deps by default.
+- **Configuration**: Introduce a `ProviderConfig` trait that the workspace implements; consumers can supply their own config sources while retaining typed secrets and retry policies.
+
+### `vtcode-tools`
+- **Registry core**: Keep registry types and lightweight tools (`fs_inspect`, `echo`, `metadata`) enabled in the default feature set.
+- **Heavyweight tools**:
+  - `bash` – shell execution and sandboxing utilities.
+  - `search` – AST-grep, ripgrep, and srgn integrations that require tree-sitter crates.
+  - `net` – curl/httpie style tooling that pulls in `reqwest` and TLS stacks.
+  - `planner` – planning/analysis helpers that depend on LLM streaming callbacks.
+- **Telemetry and policies**: Provide a `policies` feature to re-export VTCode’s policy wiring (path guards, command allowlists) while letting consumers define their own implementations when the feature is disabled.
+- **Examples**: An `examples` feature builds the headless demonstration binaries that exercise registry registration and execution.
+
+### External API Requirements
+- Documented environment variables per provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) and mapped their usage to the `ProviderConfig` trait so consumers can plug in vault-backed secrets.
+- Identified tool prerequisites (tree-sitter grammars, `rg`, `srgn`, `curl`) and grouped them under optional features to avoid surprising runtime dependencies.
+- Captured telemetry expectations (structured events, token accounting) to ensure downstream adopters can opt in via feature flags without carrying unused schema code.
+
+## Migration Checklists
+- Each extracted crate follows a consistent migration checklist so that publishing to crates.io and integrating back into VTCode remains predictable.
+
+### `vtcode-llm`
+1. **Testing**:
+   - Run `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features` within the crate.
+   - Execute provider-specific smoke tests with mock configs when optional features are enabled.
+2. **Documentation**:
+   - Update crate-level README with supported providers, feature flag matrix, and configuration examples.
+   - Regenerate API docs via `cargo doc --no-deps --all-features` and publish to docs.rs after release.
+3. **CI & Release**:
+   - Ensure workspace CI runs the crate matrix (core + each provider feature).
+   - Tag releases with `vtcode-llm-vX.Y.Z`, update changelog entries, and publish using `cargo release`.
+
+### `vtcode-tools`
+1. **Testing**:
+   - Run `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`.
+   - Validate integration examples for headless execution paths under the `examples` feature.
+2. **Documentation**:
+   - Refresh README sections covering available tool categories, feature flags, and safety policies.
+   - Document external binary requirements per feature (tree-sitter grammars, `rg`, `srgn`, `curl`).
+3. **CI & Release**:
+   - Extend CI to cover feature permutations (default, `bash`, `search`, `net`, `planner`, `policies`).
+   - Tag releases with `vtcode-tools-vX.Y.Z`, update the changelog, and coordinate workspace dependency bumps.
+
+## License Compatibility Review
+- Conducted a targeted license audit for the dependencies bundled (or planned) with the prototype crates to ensure compatibility with VTCode's MIT licensing strategy.
+- `vtcode-tools` heavy dependencies (tree-sitter grammars, AST/grep helpers) all publish under the MIT license, which is permissive and compatible for redistribution.
+- Core runtime crates that power both `vtcode-llm` and `vtcode-tools` (`tokio`, `reqwest`, `serde`, `serde_json`, `anyhow`) are dual-licensed MIT/Apache-2.0, aligning with VTCode's licensing.
+- No provider-specific Rust SDKs are currently vendored—requests are issued via `reqwest`—so there are no additional license obligations beyond HTTP API terms of service. Document future additions in the TODO tracker to keep this audit current.
+
 ## Next Steps
-1. Prototype extraction of `vtcode-llm` and `vtcode-tools`, since they offer the highest immediate reuse value.
-2. Define a migration checklist (tests, documentation, CI) for each crate to keep the releases consistent.
-3. Evaluate licensing compatibility of bundled dependencies (tree-sitter grammars, provider SDKs) before publishing.
-4. Communicate roadmap in the main README and invite community feedback once the first crate lands on crates.io.
+1. ✅ Implement the `ProviderConfig` trait within `vtcode-llm` and refactor the existing providers to depend on it instead of workspace-specific structures.
+   - Added a provider-agnostic trait and conversion helpers in the `vtcode-llm` crate so external consumers can supply configuration without relying on `vtcode_core::utils::dot_config`.
+   - Implemented adapters for the existing dot-config structs and the internal factory configuration, plus an owned builder to support tests and integration examples.
+2. ✅ Wire up feature gates in both prototype crates, introducing cfg guards and updating Cargo manifests to reflect the new optional dependencies.
+   - Added provider, function-calling, and telemetry toggles to `vtcode-llm`, exposing provider modules only when the matching feature is enabled.
+   - Gated heavy tool categories (`bash`, `search`, `net`, `planner`) and policy re-exports in `vtcode-tools`, letting consumers keep lightweight registry/trait types by default.
+3. ✅ Define a migration checklist (tests, documentation, CI) for each crate to keep the releases consistent.
+   - Documented migration checklists for `vtcode-llm` and `vtcode-tools`, covering testing expectations, documentation deliverables, and release automation hooks so crate publishing follows a predictable path.
+4. ✅ Evaluate licensing compatibility of bundled dependencies (tree-sitter grammars, provider SDKs) before publishing.
+   - Audited licenses for the tree-sitter grammar crates and core runtime dependencies; all are MIT or MIT/Apache-2.0, compatible with VTCode's licensing.
+   - Confirmed we currently depend on HTTP client crates (not provider SDKs), so compliance hinges on external API terms until SDKs are added.
+5. ✅ Communicate roadmap in the main README and invite community feedback once the first crate lands on crates.io.
+   - Added a "Component Extraction Roadmap" section to the root README describing the goals for `vtcode-llm` and `vtcode-tools`, linking back to this plan and the shared TODO tracker.
+   - Documented how community members can provide feedback ahead of the first crates.io publish so expectations stay aligned while remaining decoupling tasks land.
+6. ✅ Publish environment variable documentation and mock client guidance for `vtcode-llm` so adopters understand configuration requirements before the crate is released.
+   - Authored `docs/vtcode_llm_environment.md` covering provider API keys, configuration trait usage patterns, and examples for combining environment variables with the owned adapter helpers.
+   - Added a `mock` feature module exposing `StaticResponseClient` so downstream tests can queue deterministic responses without reaching real providers.
+7. ✅ Document how `vtcode-tools` consumers can replace the default policy wiring so configuration structs live outside the crate boundary.
+   - Added `ToolPolicyManager::new_with_config_path` and custom `ToolRegistry` constructors so downstream projects can inject pre-configured policy managers without touching VTCode's `.vtcode` directory.
+   - Authored `docs/vtcode_tools_policy.md` with step-by-step guidance on enabling the `policies` feature, selecting a storage path, and wiring the custom manager into the registry.
+8. ✅ Publish headless integration examples demonstrating `vtcode-tools` usage with custom policy storage and feature flags for lightweight adoption.
+   - Added the `headless_registry` example to the `vtcode-tools` crate showcasing how to register custom tools, persist policies outside `~/.vtcode`, and run with only the `policies` feature enabled.
+   - Extended the policy customization guide with commands for running the example so downstream users can replicate the workflow.
+9. ✅ Define shared base traits (`vtcode-commons`) for filesystem paths, telemetry, and error handling used by multiple crates.
+   - Published the `vtcode-commons` crate with shared contracts for workspace path resolution, telemetry sinks, and error reporting, and re-exported them from the prototype crates.
+   - Added default no-op implementations so adopters can opt-in gradually without wiring observability or storage upfront.
+10. ✅ Document reference implementations of the shared traits for downstream adopters.
+   - Added memory-backed telemetry and error reporters plus a static path resolver to `vtcode-commons`, providing ready-to-use scaffolding for tests and prototypes.
+   - Documented how to use the new helpers in `docs/vtcode_commons_reference.md`, guiding external consumers through drop-in integration steps.
+11. Adopt the new `vtcode-commons` traits across the remaining `vtcode-tools` entry points so registry construction and policy wiring stay decoupled from VTCode defaults.

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -1,0 +1,27 @@
+# Component Extraction TODO
+
+This list tracks actionable tasks spawned from the component extraction plan as we prototype new crates.
+
+## `vtcode-llm`
+- [x] Scaffold prototype crate that re-exports the existing LLM abstraction layer.
+- [x] Document external API surface area and propose feature flags for providers, function calling, telemetry, and mocks.
+- [x] Introduce a provider configuration trait to decouple from `vtcode_core::utils::dot_config`.
+- [x] Gate provider implementations behind feature flags to shrink dependency footprint.
+- [x] Add documentation on expected environment variables and provide mock clients for testing.
+
+## `vtcode-tools`
+- [x] Scaffold prototype crate that re-exports the tool registry and built-in tools.
+- [x] Outline feature flag groups for heavyweight tools, policy wiring, telemetry, and examples.
+- [x] Extract policy wiring so configuration structs live outside the crate boundary.
+- [x] Make tree-sitter and heavy tooling optional via feature flags.
+- [x] Publish integration examples exercising registry setup and execution in a headless context.
+
+## Cross-Cutting
+- [x] Capture external integration prerequisites (environment variables, binary dependencies) and align them with optional feature groups.
+- [x] Define shared base traits (`vtcode-commons`) for filesystem paths, telemetry, and error handling used by multiple crates.
+- [x] Adopt the new `vtcode-commons` traits inside `vtcode-llm`'s configuration adapters so consumers can provide custom path and telemetry hooks.
+- [x] Document reference implementations of the shared traits for downstream adopters.
+- [ ] Adopt the shared hooks throughout `vtcode-tools` so policy and registry wiring use the common contracts.
+- [x] Establish a migration checklist covering documentation, CI, and release steps for each extracted crate.
+- [x] Audit dependency licenses (tree-sitter grammars, provider SDKs) to confirm compatibility before publishing.
+- [x] Update project README once the first crate is ready for community feedback (linked roadmap + feedback invitation).

--- a/docs/vtcode_commons_reference.md
+++ b/docs/vtcode_commons_reference.md
@@ -1,0 +1,79 @@
+# vtcode-commons Reference Implementations
+
+The `vtcode-commons` crate exposes foundational traits that the extracted
+crates (`vtcode-llm`, `vtcode-tools`) share for filesystem paths, telemetry, and
+error handling. This guide provides ready-to-use implementations for downstream
+projects that want to integrate quickly without designing their own adapters
+from scratch.
+
+## Static workspace paths
+
+Use [`StaticWorkspacePaths`](../vtcode-commons/src/reference.rs) when you want to
+wire concrete directories into the shared traits without additional indirection:
+
+```rust
+use std::path::PathBuf;
+use vtcode_commons::StaticWorkspacePaths;
+
+let workspace_root = PathBuf::from("/opt/vtcode-demo");
+let config_dir = workspace_root.join("config");
+let paths = StaticWorkspacePaths::new(workspace_root, config_dir)
+    .with_cache_dir("/opt/vtcode-demo/cache")
+    .with_telemetry_dir("/var/log/vtcode-demo");
+
+assert_eq!(paths.config_dir(), PathBuf::from("/opt/vtcode-demo/config"));
+```
+
+These helpers satisfy the `WorkspacePaths` trait so crates like `vtcode-llm` can
+resolve prompt caches or configuration files relative to your application’s
+layout.
+
+## Memory-backed telemetry
+
+[`MemoryTelemetry`](../vtcode-commons/src/reference.rs) records cloneable events
+for later inspection, making it ideal for tests and examples:
+
+```rust
+use vtcode_commons::{MemoryTelemetry, TelemetrySink};
+
+let telemetry = MemoryTelemetry::new();
+telemetry.record(&"event".to_string())?;
+assert_eq!(telemetry.take(), vec!["event".to_string()]);
+```
+
+Downstream code can call `take()` to drain the buffered events and assert on the
+contents without configuring a dedicated telemetry pipeline.
+
+## Memory-backed error reporting
+
+[`MemoryErrorReporter`](../vtcode-commons/src/reference.rs) captures formatted
+error messages in memory. Pair it with the provided
+[`DisplayErrorFormatter`](../vtcode-commons/src/errors.rs) to surface errors in a
+human-readable format:
+
+```rust
+use anyhow::Error;
+use vtcode_commons::{DisplayErrorFormatter, MemoryErrorReporter};
+
+let formatter = DisplayErrorFormatter;
+let reporter = MemoryErrorReporter::new();
+let error = Error::msg("provider failed");
+
+reporter.capture(&error)?;
+let messages = reporter.take();
+assert!(messages[0].contains(&formatter.format_error(&error)));
+```
+
+## When to build custom adapters
+
+These reference implementations are intentionally lightweight and best suited
+for prototypes, tests, or small integrations. Larger deployments should
+implement the traits directly so they can:
+
+- Route telemetry events into tracing, OpenTelemetry, or custom dashboards.
+- Forward captured errors into production incident response tooling.
+- Resolve workspace paths from configuration files or operating system
+  conventions instead of static paths.
+
+Use the reference types as scaffolding, then replace them with adapters tailored
+to your infrastructure as adoption matures.

--- a/docs/vtcode_llm_environment.md
+++ b/docs/vtcode_llm_environment.md
@@ -1,0 +1,126 @@
+# `vtcode-llm` Environment Configuration Guide
+
+This guide explains how the `vtcode-llm` crate discovers provider credentials, maps
+feature flags to environment variables, and offers lightweight mocks for downstream
+integration tests. It is intended for consumers who want to adopt the crate without
+bringing in VTCode's full configuration system.
+
+## Provider environment variables
+
+Each provider feature corresponds to one or more environment variables. Keys should
+be populated before constructing a client so the `ProviderConfig` trait can surface
+the secret values.
+
+| Feature flag | Primary variable | Aliases | Notes |
+| --- | --- | --- | --- |
+| `google` | `GEMINI_API_KEY` | `GOOGLE_API_KEY` | Gemini clients accept either variable; the first non-empty value wins. |
+| `openai` | `OPENAI_API_KEY` | – | Required for GPT models served by OpenAI. |
+| `anthropic` | `ANTHROPIC_API_KEY` | – | Required for Claude models. |
+| `deepseek` | `DEEPSEEK_API_KEY` | – | Required for DeepSeek models. |
+| `openrouter` | `OPENROUTER_API_KEY` | – | Required for OpenRouter routing. |
+| `xai` | `XAI_API_KEY` | – | Required for xAI Grok models. |
+| `zai` | `ZAI_API_KEY` | – | Required for Zhipu AI (Z.AI) models. |
+| `moonshot` | `MOONSHOT_API_KEY` | – | Required for Moonshot AI models. |
+| `ollama` | _N/A_ | – | Ollama uses a local runtime and does not require an API key. |
+
+When multiple providers are enabled, populate the variables you plan to use. Downstream
+applications can surface their own configuration UX but should forward the resolved
+secrets to the `ProviderConfig` implementor.
+
+## Loading keys with `ProviderConfig`
+
+Implementors of [`config::ProviderConfig`](../vtcode-llm/src/config.rs) decide where
+credentials originate. A common pattern is to read from environment variables and then
+pass the owned values to `OwnedProviderConfig` before building a client:
+
+```rust
+use std::env;
+use vtcode_llm::config::{as_factory_config, OwnedProviderConfig};
+
+fn gemini_from_env() -> anyhow::Result<vtcode_core::llm::factory::ProviderConfig> {
+    let key = env::var("GEMINI_API_KEY")
+        .or_else(|_| env::var("GOOGLE_API_KEY"))
+        .map_err(|_| anyhow::anyhow!("Set GEMINI_API_KEY or GOOGLE_API_KEY"))?;
+
+    let config = OwnedProviderConfig::new()
+        .with_api_key(key)
+        .with_model("gemini-2.0-flash-exp".to_string());
+
+    Ok(as_factory_config(&config))
+}
+```
+
+Because the trait only exposes borrowed data, callers can also point to secrets stored
+in files, KMS-backed fetchers, or other secret managers.
+
+## Wiring workspace paths and telemetry
+
+When prompt caching is enabled, use
+[`config::AdapterHooks`](../vtcode-llm/src/config.rs) to resolve relative directories
+against your workspace implementation and surface telemetry or error information using
+`vtcode-commons` traits:
+
+```rust
+use vtcode_commons::{NoopErrorReporter, NoopTelemetry, WorkspacePaths};
+use vtcode_llm::config::{as_factory_config_with_hooks, AdapterHooks, OwnedProviderConfig};
+
+struct MyWorkspacePaths;
+
+impl WorkspacePaths for MyWorkspacePaths {
+    fn workspace_root(&self) -> &std::path::Path {
+        std::path::Path::new("/srv/workspace")
+    }
+
+    fn config_dir(&self) -> std::path::PathBuf {
+        std::path::PathBuf::from("/srv/workspace/config")
+    }
+}
+
+let workspace_paths = MyWorkspacePaths;
+let telemetry = NoopTelemetry;
+let reporter = NoopErrorReporter;
+let formatter = vtcode_commons::DisplayErrorFormatter;
+let hooks = AdapterHooks::new(&workspace_paths, &telemetry, &reporter, &formatter);
+
+let provider_config = OwnedProviderConfig::new().with_prompt_cache(Default::default());
+let core_config = as_factory_config_with_hooks(&provider_config, &hooks);
+```
+
+The adapter records prompt-cache resolution events, normalizes cache directories to
+absolute paths, and reports hook failures through the supplied telemetry and error
+reporting implementations.
+
+## Using the optional mock client
+
+Enable the `mock` feature to access `mock::StaticResponseClient`, a lightweight
+implementation of the `LLMClient` trait designed for deterministic tests:
+
+```toml
+# Cargo.toml
+vtcode-llm = { version = "0.0.1", features = ["mock", "openai"] }
+```
+
+```rust
+use vtcode_llm::mock::StaticResponseClient;
+use vtcode_core::llm::types::{BackendKind, LLMResponse};
+
+let mut client = StaticResponseClient::new("gpt-4.1-mini", BackendKind::OpenAI)
+    .with_response(LLMResponse {
+        content: "Hello from a test".into(),
+        model: "gpt-4.1-mini".into(),
+        usage: None,
+        reasoning: None,
+    });
+
+let response = futures::executor::block_on(client.generate("ignored prompt"))?;
+assert_eq!(response.content, "Hello from a test");
+```
+
+Queue as many responses (or errors) as needed. When the queue runs dry, the client
+returns an `LLMError::InvalidRequest`, helping tests detect unexpected extra calls.
+
+## Next steps
+
+- Add additional provider-specific environment documentation as new integrations land.
+- Share runnable examples that combine `ProviderConfig` implementors with the mock
+  client to showcase end-to-end integration tests.

--- a/docs/vtcode_tools_policy.md
+++ b/docs/vtcode_tools_policy.md
@@ -1,0 +1,92 @@
+# vtcode-tools Policy Customization Guide
+
+This guide explains how to adopt the `vtcode-tools` crate while keeping tool
+policy configuration in your own application's storage hierarchy. The default
+VTCode implementation persists policy state inside a `.vtcode` directory, but
+external consumers often prefer to colocate policy files with their existing
+configuration tree.
+
+## 1. Enable the `policies` feature
+
+The policy management APIs are exported behind the optional `policies` feature
+flag. Enable it in your `Cargo.toml` to access `ToolPolicyManager` and related
+types:
+
+```toml
+[dependencies]
+vtcode-tools = { version = "0.0.1", features = ["policies"] }
+```
+
+## 2. Pick a custom storage location
+
+Decide where policy state should live inside your application. For example, you
+might align it with an existing configuration directory:
+
+```rust
+use std::path::PathBuf;
+
+fn policy_path(root: &PathBuf) -> PathBuf {
+    root.join("config").join("tool-policy.json")
+}
+```
+
+## 3. Construct a `ToolPolicyManager` with your path
+
+The `ToolPolicyManager::new_with_config_path` helper from `vtcode-core`
+initializes the policy store without touching VTCode's default directories:
+
+```rust
+use vtcode_tools::policies::ToolPolicyManager;
+
+let custom_manager = ToolPolicyManager::new_with_config_path(policy_path(&app_root))?;
+```
+
+The constructor ensures parent directories exist and loads (or creates) the JSON
+configuration file at the provided path.
+
+## 4. Inject the manager into the registry
+
+`ToolRegistry` exposes dedicated constructors for supplying a pre-built policy
+manager so the default VTCode wiring never executes:
+
+```rust
+use vtcode_tools::ToolRegistry;
+
+let mut registry = ToolRegistry::new_with_custom_policy(workspace_root, custom_manager);
+```
+
+If you need to configure PTY behaviour or toggle planner support, the
+`new_with_custom_policy_and_config` variant accepts the same knobs as the
+existing constructors.
+
+## 5. Apply your application's defaults
+
+Once the registry is created you can call the usual policy helpers to enforce
+your own defaults:
+
+```rust
+registry.allow_all_tools()?; // or selectively set policies per tool
+```
+
+Because the policy storage path is now under your control, the resulting JSON
+file can be versioned, synchronized, or otherwise managed according to your
+project's requirements.
+
+## 6. Try the headless example
+
+The workspace now ships with a runnable integration example that keeps policy
+state out of `~/.vtcode` and registers a lightweight tool for headless usage:
+
+```sh
+cargo run -p vtcode-tools --example headless_registry --no-default-features --features "policies"
+```
+
+The example stores its policy file under a temporary configuration directory and
+demonstrates how to register a custom tool while keeping feature flags slimmed
+down to only `policies`. Treat it as a reference when wiring the registry into
+your own application.
+
+## Next steps
+
+See `docs/component_extraction_plan.md` for the broader roadmap and remaining
+extraction milestones.

--- a/src/agent/runloop/unified/tool_summary.rs
+++ b/src/agent/runloop/unified/tool_summary.rs
@@ -15,15 +15,26 @@ pub(crate) fn render_tool_call_summary(
     let human = humanize_tool_name(tool_name);
     let details = collect_highlight_details(args, &highlights);
 
+    // ANSI colors: cyan for icon/prefix, bright white for action, dim white for details, yellow for tool name
     let mut line = String::new();
+    line.push_str("\x1b[36m✦\x1b[0m ");  // Cyan icon
+    line.push_str("\x1b[97m");  // Bright white for headline
     line.push_str(&headline);
+    line.push_str("\x1b[0m");  // Reset
+    
     if !details.is_empty() {
-        line.push_str(" · ");
+        line.push_str(" \x1b[2m·\x1b[0m ");  // Dim separator
+        line.push_str("\x1b[2m");  // Dim for details
         line.push_str(&details.join(" · "));
+        line.push_str("\x1b[0m");  // Reset
     }
-    line.push_str(&format!(" [{}]", human));
+    
+    line.push_str(" \x1b[33m[");  // Yellow for tool name
+    line.push_str(tool_name);
+    line.push_str("]\x1b[0m");  // Reset
 
-    renderer.line(MessageStyle::Info, &line)?;
+    renderer.line(MessageStyle::Tool, &line)?;
+    renderer.line(MessageStyle::Tool, "")?;
 
     Ok(())
 }

--- a/vtcode-commons/Cargo.toml
+++ b/vtcode-commons/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vtcode-commons"
+version = "0.0.1"
+edition = "2021"
+authors = ["vinhnx <vinhnx@users.noreply.github.com>"]
+description = "Shared traits for paths, telemetry, and error reporting reused across VTCode component extractions"
+license = "MIT"
+publish = false
+
+[features]
+default = []
+
+[dependencies]
+anyhow = "1"

--- a/vtcode-commons/src/errors.rs
+++ b/vtcode-commons/src/errors.rs
@@ -17,6 +17,7 @@ pub trait ErrorReporter: Send + Sync {
 
     /// Convenience helper to capture a simple message.
     fn capture_message(&self, message: impl Into<Cow<'static, str>>) -> Result<()> {
+        let message: Cow<'static, str> = message.into();
         self.capture(&Error::msg(message))
     }
 }

--- a/vtcode-commons/src/errors.rs
+++ b/vtcode-commons/src/errors.rs
@@ -1,0 +1,63 @@
+use std::borrow::Cow;
+
+use anyhow::{Error, Result};
+
+/// Formats an error into a user-facing description. This allows extracted
+/// components to present consistent error messaging without depending on the
+/// CLI presentation layer.
+pub trait ErrorFormatter: Send + Sync {
+    /// Render the error into a user-facing string.
+    fn format_error(&self, error: &Error) -> Cow<'_, str>;
+}
+
+/// Reports non-fatal errors to an observability backend.
+pub trait ErrorReporter: Send + Sync {
+    /// Capture the provided error for later inspection.
+    fn capture(&self, error: &Error) -> Result<()>;
+
+    /// Convenience helper to capture a simple message.
+    fn capture_message(&self, message: impl Into<Cow<'static, str>>) -> Result<()> {
+        self.capture(&Error::msg(message))
+    }
+}
+
+/// Error reporting implementation that drops every event. Useful for tests or
+/// when a consumer does not yet integrate with error monitoring.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopErrorReporter;
+
+impl ErrorReporter for NoopErrorReporter {
+    fn capture(&self, _error: &Error) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Default formatter that surfaces the error's display output.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DisplayErrorFormatter;
+
+impl ErrorFormatter for DisplayErrorFormatter {
+    fn format_error(&self, error: &Error) -> Cow<'_, str> {
+        Cow::Owned(format!("{error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formatter_uses_display() {
+        let formatter = DisplayErrorFormatter;
+        let error = Error::msg("test error");
+        assert_eq!(formatter.format_error(&error), "test error");
+    }
+
+    #[test]
+    fn noop_reporter_drops_errors() {
+        let reporter = NoopErrorReporter;
+        let error = Error::msg("test");
+        assert!(reporter.capture(&error).is_ok());
+        assert!(reporter.capture_message("message").is_ok());
+    }
+}

--- a/vtcode-commons/src/lib.rs
+++ b/vtcode-commons/src/lib.rs
@@ -1,0 +1,18 @@
+//! Shared traits and helper types reused across the component extraction
+//! crates. The goal is to keep thin prototypes like `vtcode-llm` and
+//! `vtcode-tools` decoupled from VTCode's internal configuration and
+//! telemetry wiring while still sharing common contracts.
+//!
+//! See `docs/vtcode_commons_reference.md` for ready-to-use adapters that
+//! demonstrate how downstream consumers can wire these traits into their own
+//! applications or tests.
+
+pub mod errors;
+pub mod paths;
+pub mod reference;
+pub mod telemetry;
+
+pub use errors::{DisplayErrorFormatter, ErrorFormatter, ErrorReporter, NoopErrorReporter};
+pub use paths::{PathResolver, PathScope, WorkspacePaths};
+pub use reference::{MemoryErrorReporter, MemoryTelemetry, StaticWorkspacePaths};
+pub use telemetry::{NoopTelemetry, TelemetrySink};

--- a/vtcode-commons/src/paths.rs
+++ b/vtcode-commons/src/paths.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+
+/// Provides the root directories an application uses to store data.
+pub trait WorkspacePaths: Send + Sync {
+    /// Absolute path to the application's workspace root.
+    fn workspace_root(&self) -> &Path;
+
+    /// Returns the directory where configuration files should be stored.
+    fn config_dir(&self) -> PathBuf;
+
+    /// Returns an optional cache directory for transient data.
+    fn cache_dir(&self) -> Option<PathBuf> {
+        None
+    }
+
+    /// Returns an optional directory for telemetry or log artifacts.
+    fn telemetry_dir(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+/// Helper trait that adds path resolution helpers on top of [`WorkspacePaths`].
+pub trait PathResolver: WorkspacePaths {
+    /// Resolve a path relative to the workspace root.
+    fn resolve<P>(&self, relative: P) -> PathBuf
+    where
+        P: AsRef<Path>,
+    {
+        self.workspace_root().join(relative)
+    }
+
+    /// Resolve a path within the configuration directory.
+    fn resolve_config<P>(&self, relative: P) -> PathBuf
+    where
+        P: AsRef<Path>,
+    {
+        self.config_dir().join(relative)
+    }
+}
+
+impl<T> PathResolver for T where T: WorkspacePaths + ?Sized {}
+
+/// Enumeration describing the conceptual scope of a file path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathScope {
+    Workspace,
+    Config,
+    Cache,
+    Telemetry,
+}
+
+impl PathScope {
+    /// Returns a human-readable description used in error messages.
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::Config => "configuration",
+            Self::Cache => "cache",
+            Self::Telemetry => "telemetry",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    struct StaticPaths {
+        root: PathBuf,
+        config: PathBuf,
+    }
+
+    impl WorkspacePaths for StaticPaths {
+        fn workspace_root(&self) -> &Path {
+            &self.root
+        }
+
+        fn config_dir(&self) -> PathBuf {
+            self.config.clone()
+        }
+
+        fn cache_dir(&self) -> Option<PathBuf> {
+            Some(self.root.join("cache"))
+        }
+    }
+
+    #[test]
+    fn resolves_relative_paths() {
+        let paths = StaticPaths {
+            root: PathBuf::from("/tmp/project"),
+            config: PathBuf::from("/tmp/project/config"),
+        };
+
+        assert_eq!(
+            PathResolver::resolve(&paths, "subdir/file.txt"),
+            PathBuf::from("/tmp/project/subdir/file.txt")
+        );
+        assert_eq!(
+            PathResolver::resolve_config(&paths, "settings.toml"),
+            PathBuf::from("/tmp/project/config/settings.toml")
+        );
+        assert_eq!(paths.cache_dir(), Some(PathBuf::from("/tmp/project/cache")));
+    }
+}

--- a/vtcode-commons/src/reference.rs
+++ b/vtcode-commons/src/reference.rs
@@ -91,7 +91,7 @@ impl<Event> MemoryTelemetry<Event> {
 
 impl<Event> TelemetrySink<Event> for MemoryTelemetry<Event>
 where
-    Event: Clone,
+    Event: Clone + Send,
 {
     fn record(&self, event: &Event) -> Result<()> {
         let mut events = self.events.lock().expect("telemetry poisoned");

--- a/vtcode-commons/src/reference.rs
+++ b/vtcode-commons/src/reference.rs
@@ -1,0 +1,178 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Error, Result};
+
+use crate::{ErrorReporter, TelemetrySink, WorkspacePaths};
+
+/// Reference implementation of [`WorkspacePaths`] backed by static [`PathBuf`]s.
+///
+/// This is useful for adopters who want to drive the extracted crates from an
+/// existing application without wiring additional indirection layers. The
+/// implementation is intentionally straightforward: callers provide the root
+/// workspace directory and configuration path up front and can optionally
+/// supply cache or telemetry directories.
+#[derive(Debug, Clone)]
+pub struct StaticWorkspacePaths {
+    root: PathBuf,
+    config: PathBuf,
+    cache: Option<PathBuf>,
+    telemetry: Option<PathBuf>,
+}
+
+impl StaticWorkspacePaths {
+    /// Creates a new [`StaticWorkspacePaths`] with the required workspace and
+    /// configuration directories.
+    pub fn new(root: impl Into<PathBuf>, config: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            config: config.into(),
+            cache: None,
+            telemetry: None,
+        }
+    }
+
+    /// Configures an optional cache directory used by the consumer.
+    pub fn with_cache_dir(mut self, cache: impl Into<PathBuf>) -> Self {
+        self.cache = Some(cache.into());
+        self
+    }
+
+    /// Configures an optional telemetry directory used by the consumer.
+    pub fn with_telemetry_dir(mut self, telemetry: impl Into<PathBuf>) -> Self {
+        self.telemetry = Some(telemetry.into());
+        self
+    }
+}
+
+impl WorkspacePaths for StaticWorkspacePaths {
+    fn workspace_root(&self) -> &Path {
+        &self.root
+    }
+
+    fn config_dir(&self) -> PathBuf {
+        self.config.clone()
+    }
+
+    fn cache_dir(&self) -> Option<PathBuf> {
+        self.cache.clone()
+    }
+
+    fn telemetry_dir(&self) -> Option<PathBuf> {
+        self.telemetry.clone()
+    }
+}
+
+/// In-memory telemetry sink that records cloned events for later inspection.
+///
+/// This helper is primarily intended for tests, examples, or prototypes that
+/// want to assert on the events emitted by a component without integrating a
+/// full telemetry backend. The recorded events can be retrieved via
+/// [`MemoryTelemetry::take`].
+#[derive(Debug, Default, Clone)]
+pub struct MemoryTelemetry<Event> {
+    events: Arc<Mutex<Vec<Event>>>,
+}
+
+impl<Event> MemoryTelemetry<Event> {
+    /// Creates a new memory-backed telemetry sink.
+    pub fn new() -> Self {
+        Self {
+            events: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Returns the recorded events, draining the internal buffer.
+    pub fn take(&self) -> Vec<Event> {
+        let mut events = self.events.lock().expect("telemetry poisoned");
+        std::mem::take(&mut *events)
+    }
+}
+
+impl<Event> TelemetrySink<Event> for MemoryTelemetry<Event>
+where
+    Event: Clone,
+{
+    fn record(&self, event: &Event) -> Result<()> {
+        let mut events = self.events.lock().expect("telemetry poisoned");
+        events.push(event.clone());
+        Ok(())
+    }
+}
+
+/// Simple [`ErrorReporter`] that stores error messages in memory.
+///
+/// This helper is designed for tests and examples that need to assert on the
+/// errors emitted by a component without wiring an external monitoring system.
+/// Callers can retrieve captured messages via [`MemoryErrorReporter::take`].
+#[derive(Debug, Default, Clone)]
+pub struct MemoryErrorReporter {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl MemoryErrorReporter {
+    /// Creates a new memory-backed error reporter.
+    pub fn new() -> Self {
+        Self {
+            messages: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Returns the captured error messages, draining the buffer.
+    pub fn take(&self) -> Vec<String> {
+        let mut messages = self.messages.lock().expect("reporter poisoned");
+        std::mem::take(&mut *messages)
+    }
+}
+
+impl ErrorReporter for MemoryErrorReporter {
+    fn capture(&self, error: &Error) -> Result<()> {
+        let mut messages = self.messages.lock().expect("reporter poisoned");
+        messages.push(format!("{error:?}"));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn static_paths_exposes_optional_directories() {
+        let paths = StaticWorkspacePaths::new("/tmp/work", "/tmp/work/config")
+            .with_cache_dir("/tmp/work/cache")
+            .with_telemetry_dir("/tmp/work/telemetry");
+
+        assert_eq!(paths.workspace_root(), Path::new("/tmp/work"));
+        assert_eq!(paths.config_dir(), PathBuf::from("/tmp/work/config"));
+        assert_eq!(paths.cache_dir(), Some(PathBuf::from("/tmp/work/cache")));
+        assert_eq!(
+            paths.telemetry_dir(),
+            Some(PathBuf::from("/tmp/work/telemetry"))
+        );
+    }
+
+    #[test]
+    fn memory_telemetry_records_events() {
+        let telemetry = MemoryTelemetry::new();
+        telemetry.record(&"event-1").unwrap();
+        telemetry.record(&"event-2").unwrap();
+
+        assert_eq!(telemetry.take(), vec!["event-1", "event-2"]);
+        assert!(telemetry.take().is_empty());
+    }
+
+    #[test]
+    fn memory_error_reporter_captures_messages() {
+        let reporter = MemoryErrorReporter::new();
+        reporter.capture(&Error::msg("error-1")).unwrap();
+        reporter.capture(&Error::msg("error-2")).unwrap();
+
+        let messages = reporter.take();
+        assert_eq!(messages.len(), 2);
+        assert!(messages[0].contains("error-1"));
+        assert!(messages[1].contains("error-2"));
+        assert!(reporter.take().is_empty());
+    }
+}

--- a/vtcode-commons/src/reference.rs
+++ b/vtcode-commons/src/reference.rs
@@ -91,7 +91,7 @@ impl<Event> MemoryTelemetry<Event> {
 
 impl<Event> TelemetrySink<Event> for MemoryTelemetry<Event>
 where
-    Event: Clone + Send,
+    Event: Clone + Send + Sync,
 {
     fn record(&self, event: &Event) -> Result<()> {
         let mut events = self.events.lock().expect("telemetry poisoned");

--- a/vtcode-commons/src/telemetry.rs
+++ b/vtcode-commons/src/telemetry.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+
+/// A lightweight sink used to record telemetry events emitted by extracted
+/// components. The `Event` type is intentionally generic so downstream
+/// consumers can supply their own event schema without depending on
+/// `vtcode-core` internals.
+pub trait TelemetrySink<Event>: Send + Sync {
+    /// Record an event produced by the component.
+    fn record(&self, event: &Event) -> Result<()>;
+
+    /// Flush any buffered telemetry data to its destination.
+    fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// A telemetry sink that ignores all events. Useful for tests or for consumers
+/// who do not need telemetry integration yet.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopTelemetry;
+
+impl<Event> TelemetrySink<Event> for NoopTelemetry {
+    fn record(&self, _event: &Event) -> Result<()> {
+        Ok(())
+    }
+}

--- a/vtcode-core/src/tool_policy.rs
+++ b/vtcode-core/src/tool_policy.rs
@@ -360,6 +360,33 @@ impl ToolPolicyManager {
         })
     }
 
+    /// Create a new tool policy manager backed by a custom configuration path.
+    ///
+    /// This helper allows downstream consumers to store policy data alongside
+    /// their own configuration hierarchy instead of writing to the default
+    /// `.vtcode` directory.
+    pub fn new_with_config_path<P: Into<PathBuf>>(config_path: P) -> Result<Self> {
+        let config_path = config_path.into();
+
+        if let Some(parent) = config_path.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "Failed to create directory for tool policy config at {}",
+                        parent.display()
+                    )
+                })?;
+            }
+        }
+
+        let config = Self::load_or_create_config(&config_path)?;
+
+        Ok(Self {
+            config_path,
+            config,
+        })
+    }
+
     /// Get the path to the tool policy configuration file
     fn get_config_path() -> Result<PathBuf> {
         let home_dir = dirs::home_dir().context("Could not determine home directory")?;

--- a/vtcode-core/src/tools/registry/policy.rs
+++ b/vtcode-core/src/tools/registry/policy.rs
@@ -36,6 +36,14 @@ impl ToolPolicyGateway {
         }
     }
 
+    pub fn with_policy_manager(manager: ToolPolicyManager) -> Self {
+        Self {
+            tool_policy: Some(manager),
+            preapproved_tools: HashSet::new(),
+            full_auto_allowlist: None,
+        }
+    }
+
     pub fn sync_available_tools(&mut self, mut available: Vec<String>, mcp_keys: &[String]) {
         available.extend(mcp_keys.iter().cloned());
         available.sort();

--- a/vtcode-llm/Cargo.toml
+++ b/vtcode-llm/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "vtcode-llm"
+version = "0.0.1"
+edition = "2024"
+authors = ["vinhnx <vinhnx@users.noreply.github.com>"]
+description = "Prototype extraction of VTCode's unified LLM client layer"
+license = "MIT"
+publish = false
+
+[features]
+default = [
+    "anthropic",
+    "deepseek",
+    "google",
+    "moonshot",
+    "ollama",
+    "openai",
+    "openrouter",
+    "xai",
+    "zai",
+    "functions",
+]
+
+anthropic = []
+deepseek = []
+google = []
+moonshot = []
+ollama = []
+openai = []
+openrouter = []
+xai = []
+zai = []
+functions = []
+telemetry = []
+mock = ["dep:async-trait"]
+
+[dependencies]
+anyhow = "1.0"
+async-trait = { version = "0.1", optional = true }
+vtcode-commons = { path = "../vtcode-commons" }
+vtcode-core = { path = "../vtcode-core" }
+
+[dev-dependencies]
+futures = "0.3"
+tempfile = "3"

--- a/vtcode-llm/src/config.rs
+++ b/vtcode-llm/src/config.rs
@@ -1,0 +1,455 @@
+//! Provider configuration traits decoupled from VTCode's dot-config storage.
+//!
+//! Consumers can implement [`ProviderConfig`] for their own types and use the
+//! conversion helpers to build `vtcode_core` provider factories without
+//! depending on VTCode's internal configuration structs.
+
+use std::borrow::Cow;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::{Context, Error};
+use vtcode_commons::{ErrorFormatter, ErrorReporter, PathScope, TelemetrySink, WorkspacePaths};
+use vtcode_core::config::core::PromptCachingConfig;
+
+/// Trait describing the configuration required to instantiate an LLM provider.
+///
+/// The trait intentionally returns owned-friendly values so that consumers can
+/// back the configuration with environment variables, secret managers, or
+/// custom structs. The [`as_factory_config`] helper converts a trait object into
+/// the concrete configuration type expected by `vtcode_core`'s provider
+/// factory.
+pub trait ProviderConfig {
+    /// API key or bearer token used to authenticate with the provider.
+    fn api_key(&self) -> Option<Cow<'_, str>>;
+
+    /// Optional override for the provider's base URL.
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        None
+    }
+
+    /// Preferred model identifier for the provider.
+    fn model(&self) -> Option<Cow<'_, str>> {
+        None
+    }
+
+    /// Optional prompt cache configuration forwarded to providers that support
+    /// caching.
+    fn prompt_cache(&self) -> Option<Cow<'_, PromptCachingConfig>> {
+        None
+    }
+}
+
+/// Convert an implementor of [`ProviderConfig`] into the configuration used by
+/// the `vtcode_core` provider factory.
+pub fn as_factory_config(source: &dyn ProviderConfig) -> vtcode_core::llm::factory::ProviderConfig {
+    vtcode_core::llm::factory::ProviderConfig {
+        api_key: source.api_key().map(Cow::into_owned),
+        base_url: source.base_url().map(Cow::into_owned),
+        model: source.model().map(Cow::into_owned),
+        prompt_cache: source.prompt_cache().map(|cfg| cfg.into_owned()),
+    }
+}
+
+/// Telemetry event emitted when adapter hooks adjust provider configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdapterEvent {
+    /// Records the resolved prompt cache directory and its associated scope.
+    PromptCacheResolved {
+        scope: PathScope,
+        cache_dir: PathBuf,
+    },
+    /// Emitted when the telemetry sink itself fails so callers can log a
+    /// fallback message.
+    TelemetryFailure { message: String },
+    /// Raised when the adapter reports a validation or hook failure.
+    AdapterError { message: String },
+}
+
+/// Shared adapter that enriches [`ProviderConfig`] conversions with
+/// [`WorkspacePaths`], telemetry, and error-reporting hooks from
+/// `vtcode-commons`.
+pub struct AdapterHooks<'a, Paths, Telemetry, Reporter, Formatter>
+where
+    Paths: WorkspacePaths + ?Sized,
+    Telemetry: TelemetrySink<AdapterEvent> + ?Sized,
+    Reporter: ErrorReporter + ?Sized,
+    Formatter: ErrorFormatter + ?Sized,
+{
+    workspace_paths: &'a Paths,
+    telemetry: &'a Telemetry,
+    error_reporter: &'a Reporter,
+    error_formatter: &'a Formatter,
+}
+
+impl<'a, Paths, Telemetry, Reporter, Formatter>
+    AdapterHooks<'a, Paths, Telemetry, Reporter, Formatter>
+where
+    Paths: WorkspacePaths + ?Sized,
+    Telemetry: TelemetrySink<AdapterEvent> + ?Sized,
+    Reporter: ErrorReporter + ?Sized,
+    Formatter: ErrorFormatter + ?Sized,
+{
+    /// Create a new adapter that enriches provider configuration conversions.
+    pub fn new(
+        workspace_paths: &'a Paths,
+        telemetry: &'a Telemetry,
+        error_reporter: &'a Reporter,
+        error_formatter: &'a Formatter,
+    ) -> Self {
+        Self {
+            workspace_paths,
+            telemetry,
+            error_reporter,
+            error_formatter,
+        }
+    }
+
+    /// Convert a [`ProviderConfig`] into the factory configuration while
+    /// applying workspace-aware prompt cache resolution and telemetry hooks.
+    pub fn apply_to(
+        &self,
+        source: &dyn ProviderConfig,
+    ) -> vtcode_core::llm::factory::ProviderConfig {
+        let mut config = as_factory_config(source);
+        if let Some(prompt_cache) = config.prompt_cache.as_mut() {
+            self.enrich_prompt_cache(prompt_cache);
+        }
+        config
+    }
+
+    fn enrich_prompt_cache(&self, prompt_cache: &mut PromptCachingConfig) {
+        let resolved = prompt_cache.resolve_cache_dir(Some(self.workspace_paths.workspace_root()));
+        let scope = self.scope_for_path(&resolved);
+        self.record_event(AdapterEvent::PromptCacheResolved {
+            scope,
+            cache_dir: resolved.clone(),
+        });
+
+        if !resolved.is_absolute() {
+            let error = Error::msg(format!(
+                "Prompt cache directory `{}` could not be resolved to an absolute path",
+                resolved.display()
+            ));
+            self.report_error(error);
+        }
+
+        prompt_cache.cache_dir = resolved.to_string_lossy().into_owned();
+    }
+
+    fn scope_for_path(&self, path: &Path) -> PathScope {
+        if path.starts_with(self.workspace_paths.workspace_root()) {
+            return PathScope::Workspace;
+        }
+
+        let config_dir = self.workspace_paths.config_dir();
+        if path.starts_with(&config_dir) {
+            return PathScope::Config;
+        }
+
+        if let Some(cache_dir) = self.workspace_paths.cache_dir() {
+            if path.starts_with(&cache_dir) {
+                return PathScope::Cache;
+            }
+        }
+
+        if let Some(telemetry_dir) = self.workspace_paths.telemetry_dir() {
+            if path.starts_with(&telemetry_dir) {
+                return PathScope::Telemetry;
+            }
+        }
+
+        PathScope::Cache
+    }
+
+    fn record_event(&self, event: AdapterEvent) {
+        if let Err(err) = self.telemetry.record(&event) {
+            self.handle_error(err.context("failed to record vtcode-llm adapter telemetry event"));
+        }
+    }
+
+    fn report_error(&self, error: Error) {
+        let message = self.error_formatter.format_error(&error).into_owned();
+        let _ = self.error_reporter.capture(&error);
+        // Best-effort recording of the formatted message; ignore additional
+        // failures to avoid recursive error handling loops.
+        let _ = self
+            .telemetry
+            .record(&AdapterEvent::AdapterError { message });
+    }
+
+    fn handle_error(&self, error: Error) {
+        let message = self.error_formatter.format_error(&error).into_owned();
+        let _ = self.error_reporter.capture(&error);
+        let _ = self
+            .telemetry
+            .record(&AdapterEvent::TelemetryFailure { message });
+    }
+}
+
+/// Convert a [`ProviderConfig`] into the factory configuration using the
+/// supplied adapter hooks for workspace, telemetry, and error integration.
+pub fn as_factory_config_with_hooks<'a, Paths, Telemetry, Reporter, Formatter>(
+    source: &dyn ProviderConfig,
+    hooks: &AdapterHooks<'a, Paths, Telemetry, Reporter, Formatter>,
+) -> vtcode_core::llm::factory::ProviderConfig
+where
+    Paths: WorkspacePaths + ?Sized,
+    Telemetry: TelemetrySink<AdapterEvent> + ?Sized,
+    Reporter: ErrorReporter + ?Sized,
+    Formatter: ErrorFormatter + ?Sized,
+{
+    hooks.apply_to(source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::{Error, Result, anyhow};
+
+    #[derive(Clone)]
+    struct TestPaths {
+        root: PathBuf,
+        config: PathBuf,
+        cache: PathBuf,
+    }
+
+    impl WorkspacePaths for TestPaths {
+        fn workspace_root(&self) -> &Path {
+            &self.root
+        }
+
+        fn config_dir(&self) -> PathBuf {
+            self.config.clone()
+        }
+
+        fn cache_dir(&self) -> Option<PathBuf> {
+            Some(self.cache.clone())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingTelemetry {
+        events: Arc<Mutex<Vec<AdapterEvent>>>,
+    }
+
+    impl TelemetrySink<AdapterEvent> for RecordingTelemetry {
+        fn record(&self, event: &AdapterEvent) -> Result<()> {
+            self.events.lock().unwrap().push(event.clone());
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FailingTelemetry {
+        events: Arc<Mutex<Vec<AdapterEvent>>>,
+        fail_next: Arc<Mutex<bool>>,
+    }
+
+    impl TelemetrySink<AdapterEvent> for FailingTelemetry {
+        fn record(&self, event: &AdapterEvent) -> Result<()> {
+            let mut fail = self.fail_next.lock().unwrap();
+            if std::mem::take(&mut *fail) {
+                Err(anyhow!("telemetry unavailable"))
+            } else {
+                self.events.lock().unwrap().push(event.clone());
+                Ok(())
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingReporter {
+        errors: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl ErrorReporter for RecordingReporter {
+        fn capture(&self, error: &Error) -> Result<()> {
+            self.errors.lock().unwrap().push(error.to_string());
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingFormatter {
+        messages: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl ErrorFormatter for RecordingFormatter {
+        fn format_error(&self, error: &Error) -> Cow<'_, str> {
+            let message = error.to_string();
+            self.messages.lock().unwrap().push(message.clone());
+            Cow::Owned(message)
+        }
+    }
+
+    #[test]
+    fn applies_workspace_paths_to_prompt_cache() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path().join("workspace");
+        let config = root.join("config");
+        let cache = root.join("cache");
+        std::fs::create_dir_all(&config).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
+
+        let paths = TestPaths {
+            root,
+            config,
+            cache,
+        };
+        let telemetry = RecordingTelemetry::default();
+        let reporter = RecordingReporter::default();
+        let formatter = RecordingFormatter::default();
+        let hooks = AdapterHooks::new(&paths, &telemetry, &reporter, &formatter);
+
+        let prompt_cache = PromptCachingConfig {
+            cache_dir: "relative/cache".to_string(),
+            ..PromptCachingConfig::default()
+        };
+
+        let config = OwnedProviderConfig::new().with_prompt_cache(prompt_cache);
+        let adapted = as_factory_config_with_hooks(&config, &hooks);
+
+        let prompt_cache = adapted.prompt_cache.expect("prompt cache present");
+        assert!(prompt_cache.cache_dir.ends_with("relative/cache"));
+
+        let events = telemetry.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AdapterEvent::PromptCacheResolved { scope, cache_dir } => {
+                assert_eq!(*scope, PathScope::Cache);
+                assert!(cache_dir.ends_with("relative/cache"));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reports_errors_when_telemetry_fails() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path().join("workspace");
+        let config = root.join("config");
+        let cache = root.join("cache");
+        std::fs::create_dir_all(&config).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
+
+        let paths = TestPaths {
+            root,
+            config,
+            cache,
+        };
+        let telemetry = FailingTelemetry::default();
+        *telemetry.fail_next.lock().unwrap() = true;
+        let reporter = RecordingReporter::default();
+        let formatter = RecordingFormatter::default();
+        let hooks = AdapterHooks::new(&paths, &telemetry, &reporter, &formatter);
+
+        let config = OwnedProviderConfig::new();
+        let _ = as_factory_config_with_hooks(&config, &hooks);
+
+        // Ensure the error reporter observed the telemetry failure and the
+        // formatter was invoked to produce a fallback message.
+        assert_eq!(reporter.errors.lock().unwrap().len(), 1);
+        assert_eq!(formatter.messages.lock().unwrap().len(), 1);
+
+        // The fallback telemetry event should succeed after the initial
+        // failure flag is cleared.
+        let events = telemetry.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        matches!(events[0], AdapterEvent::TelemetryFailure { .. });
+    }
+}
+
+/// [`ProviderConfig`] implementation for VTCode's dot-config provider entries.
+impl ProviderConfig for vtcode_core::utils::dot_config::ProviderConfig {
+    fn api_key(&self) -> Option<Cow<'_, str>> {
+        self.api_key.as_deref().map(Cow::Borrowed)
+    }
+
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        self.base_url.as_deref().map(Cow::Borrowed)
+    }
+
+    fn model(&self) -> Option<Cow<'_, str>> {
+        self.model.as_deref().map(Cow::Borrowed)
+    }
+}
+
+/// [`ProviderConfig`] implementation for the concrete factory configuration.
+impl ProviderConfig for vtcode_core::llm::factory::ProviderConfig {
+    fn api_key(&self) -> Option<Cow<'_, str>> {
+        self.api_key.as_deref().map(Cow::Borrowed)
+    }
+
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        self.base_url.as_deref().map(Cow::Borrowed)
+    }
+
+    fn model(&self) -> Option<Cow<'_, str>> {
+        self.model.as_deref().map(Cow::Borrowed)
+    }
+
+    fn prompt_cache(&self) -> Option<Cow<'_, PromptCachingConfig>> {
+        self.prompt_cache
+            .as_ref()
+            .map(|cfg| Cow::Owned(cfg.clone()))
+    }
+}
+
+/// Simple builder-friendly provider configuration backed by owned values.
+#[derive(Clone, Debug, Default)]
+pub struct OwnedProviderConfig {
+    api_key: Option<String>,
+    base_url: Option<String>,
+    model: Option<String>,
+    prompt_cache: Option<PromptCachingConfig>,
+}
+
+impl OwnedProviderConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_api_key(mut self, value: impl Into<String>) -> Self {
+        self.api_key = Some(value.into());
+        self
+    }
+
+    pub fn with_base_url(mut self, value: impl Into<String>) -> Self {
+        self.base_url = Some(value.into());
+        self
+    }
+
+    pub fn with_model(mut self, value: impl Into<String>) -> Self {
+        self.model = Some(value.into());
+        self
+    }
+
+    pub fn with_prompt_cache(mut self, value: PromptCachingConfig) -> Self {
+        self.prompt_cache = Some(value);
+        self
+    }
+}
+
+impl ProviderConfig for OwnedProviderConfig {
+    fn api_key(&self) -> Option<Cow<'_, str>> {
+        self.api_key.as_deref().map(Cow::Borrowed)
+    }
+
+    fn base_url(&self) -> Option<Cow<'_, str>> {
+        self.base_url.as_deref().map(Cow::Borrowed)
+    }
+
+    fn model(&self) -> Option<Cow<'_, str>> {
+        self.model.as_deref().map(Cow::Borrowed)
+    }
+
+    fn prompt_cache(&self) -> Option<Cow<'_, PromptCachingConfig>> {
+        self.prompt_cache
+            .as_ref()
+            .map(|cfg| Cow::Owned(cfg.clone()))
+    }
+}

--- a/vtcode-llm/src/lib.rs
+++ b/vtcode-llm/src/lib.rs
@@ -1,0 +1,112 @@
+//! Prototype crate that re-exports VTCode's LLM integration layer while
+//! introducing decoupled configuration traits for downstream consumers.
+//!
+//! The goal is to let external applications supply their own configuration
+//! sources without depending on VTCode's dot-config structures. Consumers can
+//! implement [`config::ProviderConfig`] for their own types and then convert
+//! them into the factory configuration used internally by `vtcode-core`.
+//!
+//! This crate exposes feature flags so downstream projects can opt into
+//! provider-specific exports, function calling helpers, or streaming telemetry
+//! utilities without pulling additional API surface by default. Consult
+//! `docs/vtcode_llm_environment.md` for a full overview of environment
+//! variables, configuration patterns, and the optional mock client helpers.
+
+pub mod config;
+
+pub use vtcode_commons::{
+    ErrorFormatter, ErrorReporter, PathResolver, PathScope, TelemetrySink, WorkspacePaths,
+};
+
+pub use vtcode_core::llm::client::{AnyClient, make_client};
+pub use vtcode_core::llm::error_display;
+pub use vtcode_core::llm::factory::{
+    ProviderConfig as CoreProviderConfig, create_provider_with_config, get_factory,
+};
+pub use vtcode_core::llm::rig_adapter;
+pub use vtcode_core::llm::types::{BackendKind, LLMError, LLMResponse, Usage};
+
+pub mod provider {
+    //! Re-export the provider abstraction and shared request/response types.
+    pub use vtcode_core::llm::provider::{
+        LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent, Message, MessageRole,
+        ParallelToolConfig,
+    };
+
+    #[cfg(feature = "functions")]
+    pub use vtcode_core::llm::provider::{
+        FunctionCall, FunctionDefinition, SpecificFunctionChoice, SpecificToolChoice, ToolCall,
+        ToolChoice, ToolDefinition,
+    };
+}
+
+pub use provider::{
+    LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent, Message, MessageRole,
+};
+
+#[cfg(feature = "functions")]
+pub use provider::{
+    FunctionCall, FunctionDefinition, SpecificFunctionChoice, SpecificToolChoice, ToolCall,
+    ToolChoice, ToolDefinition,
+};
+
+#[cfg(feature = "anthropic")]
+pub use vtcode_core::llm::providers::AnthropicProvider;
+#[cfg(feature = "deepseek")]
+pub use vtcode_core::llm::providers::DeepSeekProvider;
+#[cfg(feature = "google")]
+pub use vtcode_core::llm::providers::GeminiProvider;
+#[cfg(feature = "moonshot")]
+pub use vtcode_core::llm::providers::MoonshotProvider;
+#[cfg(feature = "ollama")]
+pub use vtcode_core::llm::providers::OllamaProvider;
+#[cfg(feature = "openai")]
+pub use vtcode_core::llm::providers::OpenAIProvider;
+#[cfg(feature = "openrouter")]
+pub use vtcode_core::llm::providers::OpenRouterProvider;
+#[cfg(feature = "xai")]
+pub use vtcode_core::llm::providers::XAIProvider;
+#[cfg(feature = "zai")]
+pub use vtcode_core::llm::providers::ZAIProvider;
+
+#[cfg(feature = "mock")]
+pub mod mock;
+
+#[cfg(feature = "mock")]
+pub use mock::StaticResponseClient;
+
+pub mod providers {
+    //! Provider-specific exports gated behind feature flags so consumers can
+    //! depend on a minimal surface when only a subset of providers is needed.
+    #[cfg(feature = "anthropic")]
+    pub use vtcode_core::llm::providers::anthropic::*;
+    #[cfg(feature = "deepseek")]
+    pub use vtcode_core::llm::providers::deepseek::*;
+    #[cfg(feature = "google")]
+    pub use vtcode_core::llm::providers::gemini::*;
+    #[cfg(feature = "moonshot")]
+    pub use vtcode_core::llm::providers::moonshot::*;
+    #[cfg(feature = "ollama")]
+    pub use vtcode_core::llm::providers::ollama::*;
+    #[cfg(feature = "openai")]
+    pub use vtcode_core::llm::providers::openai::*;
+    #[cfg(feature = "openrouter")]
+    pub use vtcode_core::llm::providers::openrouter::*;
+    #[cfg(feature = "xai")]
+    pub use vtcode_core::llm::providers::xai::*;
+    #[cfg(feature = "zai")]
+    pub use vtcode_core::llm::providers::zai::*;
+}
+
+#[cfg(feature = "telemetry")]
+pub mod telemetry {
+    //! Streaming telemetry helpers shared across provider implementations.
+    pub use vtcode_core::llm::providers::shared::{
+        NoopStreamTelemetry, StreamAssemblyError, StreamDelta, StreamFragment, StreamTelemetry,
+        ToolCallBuilder, append_reasoning_segments, append_text_with_reasoning,
+        finalize_tool_calls, update_tool_calls,
+    };
+}
+
+#[cfg(feature = "telemetry")]
+pub use telemetry::{NoopStreamTelemetry, StreamTelemetry};

--- a/vtcode-llm/src/mock.rs
+++ b/vtcode-llm/src/mock.rs
@@ -1,0 +1,118 @@
+//! Utilities for deterministic tests that need an `LLMClient` implementation
+//! without performing network calls.
+//!
+//! Enable the crate's `mock` feature to access the [`StaticResponseClient`],
+//! queue canned responses, and verify the interaction contract used by
+//! downstream integrations.
+
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+use vtcode_core::llm::client::LLMClient;
+use vtcode_core::llm::types::{BackendKind, LLMError, LLMResponse};
+
+/// Deterministic `LLMClient` that yields queued responses.
+#[derive(Debug)]
+pub struct StaticResponseClient {
+    backend: BackendKind,
+    model: String,
+    queue: VecDeque<Result<LLMResponse, LLMError>>,
+}
+
+impl StaticResponseClient {
+    /// Create a mock client for the provided model/backend combination.
+    pub fn new(model: impl Into<String>, backend: BackendKind) -> Self {
+        Self {
+            backend,
+            model: model.into(),
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Queue a successful response. Responses are returned in FIFO order.
+    pub fn enqueue_response(&mut self, response: LLMResponse) {
+        self.queue.push_back(Ok(response));
+    }
+
+    /// Queue a successful response and return the client for chaining.
+    pub fn with_response(mut self, response: LLMResponse) -> Self {
+        self.enqueue_response(response);
+        self
+    }
+
+    /// Queue an error result. Errors are returned in FIFO order alongside responses.
+    pub fn enqueue_error(&mut self, error: LLMError) {
+        self.queue.push_back(Err(error));
+    }
+
+    /// Queue an error result and return the client for chaining.
+    pub fn with_error(mut self, error: LLMError) -> Self {
+        self.enqueue_error(error);
+        self
+    }
+
+    /// Consume the client and return it as a boxed trait object.
+    pub fn into_client(self) -> vtcode_core::llm::client::AnyClient {
+        Box::new(self)
+    }
+}
+
+#[async_trait]
+impl LLMClient for StaticResponseClient {
+    async fn generate(&mut self, _prompt: &str) -> Result<LLMResponse, LLMError> {
+        self.queue.pop_front().unwrap_or_else(|| {
+            Err(LLMError::InvalidRequest(
+                "StaticResponseClient has no queued responses".to_string(),
+            ))
+        })
+    }
+
+    fn backend_kind(&self) -> BackendKind {
+        self.backend.clone()
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StaticResponseClient;
+    use vtcode_core::llm::types::{BackendKind, LLMError, LLMResponse};
+
+    #[test]
+    fn returns_responses_in_fifo_order() {
+        let response_one = LLMResponse {
+            content: "first".to_string(),
+            model: "test".to_string(),
+            usage: None,
+            reasoning: None,
+        };
+        let response_two = LLMResponse {
+            content: "second".to_string(),
+            model: "test".to_string(),
+            usage: None,
+            reasoning: None,
+        };
+
+        let mut client = StaticResponseClient::new("test", BackendKind::OpenAI);
+        client.enqueue_response(response_one.clone());
+        client.enqueue_response(response_two.clone());
+
+        let first = futures::executor::block_on(client.generate("prompt")).unwrap();
+        let second = futures::executor::block_on(client.generate("prompt")).unwrap();
+
+        assert_eq!(first.content, response_one.content);
+        assert_eq!(second.content, response_two.content);
+    }
+
+    #[test]
+    fn errors_when_queue_is_empty() {
+        let mut client = StaticResponseClient::new("test", BackendKind::Gemini);
+        let error = futures::executor::block_on(client.generate("prompt"))
+            .expect_err("expected error when queue is empty");
+
+        assert!(matches!(error, LLMError::InvalidRequest(_)));
+    }
+}

--- a/vtcode-tools/Cargo.toml
+++ b/vtcode-tools/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "vtcode-tools"
+version = "0.0.1"
+edition = "2024"
+authors = ["vinhnx <vinhnx@users.noreply.github.com>"]
+description = "Prototype extraction of VTCode's modular tool registry"
+license = "MIT"
+publish = false
+
+[features]
+default = ["bash", "search", "net", "planner"]
+
+bash = []
+search = []
+net = []
+planner = []
+policies = []
+examples = []
+
+[dependencies]
+vtcode-commons = { path = "../vtcode-commons" }
+vtcode-core = { path = "../vtcode-core" }
+
+[dev-dependencies]
+anyhow = "1"
+async-trait = "0.1"
+serde_json = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/vtcode-tools/src/lib.rs
+++ b/vtcode-tools/src/lib.rs
@@ -1,0 +1,108 @@
+//! Prototype crate that exposes VTCode's tool registry and built-in tools.
+//!
+//! The goal is to surface the current API surface to external consumers
+//! while we iterate on decoupling policies, configuration, and optional
+//! dependencies. By shipping this crate as a thin wrapper we can collect
+//! integration feedback and identify breaking changes early.
+//!
+//! Feature flags mirror the extraction plan so adopters can opt into only the
+//! tool categories they need.
+//!
+//! See `docs/vtcode_tools_policy.md` for guidance on supplying a custom
+//! `ToolPolicyManager` when the `policies` feature is enabled, allowing
+//! consumers to store policy configuration outside of VTCode's defaults.
+
+pub use vtcode_commons::{
+    ErrorFormatter, ErrorReporter, NoopErrorReporter, NoopTelemetry, PathResolver, TelemetrySink,
+    WorkspacePaths,
+};
+
+pub use vtcode_core::tools::command;
+pub use vtcode_core::tools::names;
+
+pub mod registry {
+    //! Registry exports shared across tool categories.
+    pub use vtcode_core::tools::registry::{
+        self, ToolPermissionDecision, ToolRegistration, ToolRegistry, build_function_declarations,
+        build_function_declarations_for_level, build_function_declarations_with_mode,
+    };
+}
+
+pub use registry::{
+    ToolPermissionDecision, ToolRegistration, ToolRegistry, build_function_declarations,
+    build_function_declarations_for_level, build_function_declarations_with_mode,
+};
+
+pub mod traits {
+    pub use vtcode_core::tools::traits::{Tool, ToolExecutor};
+}
+
+pub use traits::{Tool, ToolExecutor};
+
+pub mod types {
+    pub use vtcode_core::tools::types::*;
+}
+
+pub use types::*;
+
+#[cfg(feature = "bash")]
+pub mod bash {
+    pub use vtcode_core::tools::bash_tool::BashTool;
+    pub use vtcode_core::tools::pty::{PtyCommandRequest, PtyCommandResult, PtyManager};
+}
+
+#[cfg(feature = "bash")]
+pub use bash::{BashTool, PtyCommandRequest, PtyCommandResult, PtyManager};
+
+#[cfg(feature = "search")]
+pub mod search {
+    pub use vtcode_core::tools::advanced_search::*;
+    pub use vtcode_core::tools::ast_grep::*;
+    pub use vtcode_core::tools::ast_grep_tool::AstGrepTool;
+    pub use vtcode_core::tools::file_search::*;
+    pub use vtcode_core::tools::grep_file::GrepSearchManager;
+    pub use vtcode_core::tools::search::*;
+    pub use vtcode_core::tools::simple_search::SimpleSearchTool;
+    pub use vtcode_core::tools::srgn::SrgnTool;
+    pub use vtcode_core::tools::tree_sitter::*;
+}
+
+#[cfg(feature = "search")]
+pub use search::{AstGrepTool, GrepSearchManager, SimpleSearchTool, SrgnTool};
+
+#[cfg(feature = "net")]
+pub mod net {
+    pub use vtcode_core::tools::curl_tool::CurlTool;
+}
+
+#[cfg(feature = "net")]
+pub use net::CurlTool;
+
+#[cfg(feature = "planner")]
+pub mod planner {
+    pub use vtcode_core::tools::plan::{
+        PlanCompletionState, PlanManager, PlanStep, PlanSummary, PlanUpdateResult, StepStatus,
+        TaskPlan, UpdatePlanArgs,
+    };
+}
+
+#[cfg(feature = "planner")]
+pub use planner::{
+    PlanCompletionState, PlanManager, PlanStep, PlanSummary, PlanUpdateResult, StepStatus,
+    TaskPlan, UpdatePlanArgs,
+};
+
+#[cfg(feature = "policies")]
+pub mod policies {
+    pub use vtcode_core::tool_policy::{ToolPolicy, ToolPolicyManager};
+}
+
+#[cfg(feature = "policies")]
+pub use policies::{ToolPolicy, ToolPolicyManager};
+
+#[cfg(feature = "examples")]
+pub mod examples {
+    //! Legacy registry helpers used by the headless integration examples
+    //! under `vtcode-tools/examples`.
+    pub use vtcode_core::tools::registry::legacy::*;
+}

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -142,64 +142,64 @@ max_repeated_tool_calls = 2
 
 # Specific tool policies - Override default policy for individual tools
 [tools.policies]
-apply_patch = "prompt"       # Apply code patches (requires confirmation)
-ast_grep_search = "allow"    # AST-based code search (no confirmation needed)
-bash = "prompt"              # Execute bash commands (requires confirmation)
-close_pty_session = "allow"  # Close PTY sessions (no confirmation needed)
-create_pty_session = "allow" # Create PTY sessions (no confirmation needed)
-curl = "prompt"              # HTTP requests (requires confirmation)
-edit_file = "allow"          # Edit files directly (no confirmation needed)
-git_diff = "allow"           # Git diff operations (no confirmation needed)
-grep_file = "allow"          # File content search (no confirmation needed)
-list_files = "allow"         # List directory contents (no confirmation needed)
-list_pty_sessions = "allow"  # List PTY sessions (no confirmation needed)
-read_file = "allow"          # Read files (no confirmation needed)
-read_pty_session = "allow"   # Read PTY session output (no confirmation needed)
-resize_pty_session = "allow" # Resize PTY sessions (no confirmation needed)
-run_pty_cmd = "prompt"       # Run commands in PTY (requires confirmation)
-run_terminal_cmd = "prompt"  # Run terminal commands (requires confirmation)
-send_pty_input = "prompt"    # Send input to PTY (requires confirmation)
-simple_search = "allow"      # Simple file search (no confirmation needed)
-srgn = "prompt"              # Semantic region operations (requires confirmation)
-update_plan = "allow"        # Update task plans (no confirmation needed)
-write_file = "allow"         # Write files (no confirmation needed)
+apply_patch = "prompt"
+ast_grep_search = "allow"
+bash = "prompt"
+close_pty_session = "allow"
+create_pty_session = "allow"
+curl = "prompt"
+edit_file = "allow"
+git_diff = "allow"
+grep_file = "allow"
+list_files = "allow"
+list_pty_sessions = "allow"
+read_file = "allow"
+read_pty_session = "allow"
+resize_pty_session = "allow"
+run_pty_cmd = "prompt"
+run_terminal_cmd = "prompt"
+send_pty_input = "prompt"
+simple_search = "allow"
+srgn = "prompt"
+update_plan = "allow"
+write_file = "allow"
 
 # Command security - Define safe and dangerous command patterns
 [commands]
 # Commands that are always allowed without confirmation
 allow_list = [
-    "ls",          # List directory contents
-    "pwd",         # Print working directory
-    "git status",  # Show git status
-    "git diff",    # Show git differences
-    "cargo check", # Check Rust code
-    "echo",        # Print text
+    "ls",
+    "pwd",
+    "git status",
+    "git diff",
+    "cargo check",
+    "echo",
 ]
 
 # Commands that are never allowed
 deny_list = [
-    "rm -rf /",      # Delete root directory (dangerous)
-    "rm -rf ~",      # Delete home directory (dangerous)
-    "shutdown",      # Shut down system (dangerous)
-    "reboot",        # Reboot system (dangerous)
-    "sudo *",        # Any sudo command (dangerous)
-    ":(){ :|:& };:", # Fork bomb (dangerous)
+    "rm -rf /",
+    "rm -rf ~",
+    "shutdown",
+    "reboot",
+    "sudo *",
+    ":(){ :|:& };:",
 ]
 
 # Command patterns that are allowed (supports glob patterns)
 allow_glob = [
-    "git *",       # All git commands
-    "cargo *",     # All cargo commands
-    "python -m *", # Python module commands
+    "git *",
+    "cargo *",
+    "python -m *",
 ]
 
 # Command patterns that are denied (supports glob patterns)
 deny_glob = [
-    "rm *",      # All rm commands
-    "sudo *",    # All sudo commands
-    "chmod *",   # All chmod commands
-    "chown *",   # All chown commands
-    "kubectl *", # All kubectl commands (admin access)
+    "rm *",
+    "sudo *",
+    "chmod *",
+    "chown *",
+    "kubectl *",
 ]
 
 # Regular expression patterns for allowed commands (if needed)
@@ -427,7 +427,14 @@ cache_themes = true
 max_file_size_mb = 10
 
 # Programming languages to enable syntax highlighting for
-enabled_languages = ["rust", "python", "javascript", "typescript", "go", "java"]
+enabled_languages = [
+    "rust",
+    "python",
+    "javascript",
+    "typescript",
+    "go",
+    "java",
+]
 
 # Timeout for syntax highlighting operations (milliseconds)
 highlight_timeout_ms = 1000
@@ -528,6 +535,7 @@ enabled = true
 max_concurrent_connections = 5
 request_timeout_seconds = 30
 retry_attempts = 3
+experimental_use_rmcp_client = true
 
 # MCP UI configuration
 [mcp.ui]
@@ -540,24 +548,40 @@ show_provider_names = true
 sequential-thinking = "sequential-thinking"
 context7 = "context7"
 
-# MCP provider configuration - External services that connect via MCP
 [[mcp.providers]]
 name = "time"
 command = "uvx"
 args = ["mcp-server-time"]
 enabled = true
 max_concurrent_requests = 3
+
 [mcp.providers.env]
+
+[mcp.server]
+enabled = false
+bind_address = "127.0.0.1"
+port = 3000
+transport = "sse"
+name = "vtcode-mcp-server"
+version = "0.29.6"
+exposed_tools = []
 
 # Agent Client Protocol (ACP) - IDE integration
 [acp]
 enabled = true
+
+[mcp.allowlist]
+enforce = false
 
 [acp.zed]
 enabled = true
 transport = "stdio"
 workspace_trust = "full_auto"
 
+[mcp.allowlist.default]
+
 [acp.zed.tools]
 read_file = true
 list_files = true
+
+[mcp.allowlist.providers]


### PR DESCRIPTION
## Summary
- add StaticWorkspacePaths, MemoryTelemetry, and MemoryErrorReporter reference implementations to vtcode-commons
- document how to use the new helpers and link the crate docs to the guide
- update the component extraction plan and TODO tracker with the completed milestone and next vtcode-tools adoption task

## Testing
- cargo fmt
- cargo clippy
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f4e8dacfe48323a82484ea794a0b69