### PR TITLE
Allow vtcode prompt positional task fallback

### DIFF
--- a/vtcode-core/prompts/custom/vtcode.md
+++ b/vtcode-core/prompts/custom/vtcode.md
@@ -1,6 +1,6 @@
 ---
 description: Kick off a VT Code session with shared context and next steps
-argument-hint: TASK="<goal summary>"
+argument-hint: "<goal summary>"
 ---
 You are collaborating inside VT Code on $TASK.
 

--- a/vtcode-core/src/prompts/custom.rs
+++ b/vtcode-core/src/prompts/custom.rs
@@ -339,6 +339,12 @@ impl PromptInvocation {
             Some(positional.join(" "))
         };
 
+        if !named.contains_key("TASK") {
+            if let Some(all) = all_arguments.clone() {
+                named.insert("TASK".to_string(), all);
+            }
+        }
+
         Ok(Self {
             positional,
             named,
@@ -565,6 +571,7 @@ mod tests {
         assert_eq!(invocation.named().get("FILE").unwrap(), "path");
         assert_eq!(invocation.named().get("focus").unwrap(), "main");
         assert_eq!(invocation.all_arguments().unwrap(), "one two");
+        assert_eq!(invocation.named().get("TASK").unwrap(), "one two");
     }
 
     #[test]
@@ -611,7 +618,7 @@ mod tests {
         let registry = CustomPromptRegistry::load(None, temp.path()).expect("load registry");
         let prompt = registry.get("vtcode").expect("builtin prompt available");
 
-        let invocation = PromptInvocation::parse("TASK=\"Add integration tests\"").unwrap();
+        let invocation = PromptInvocation::parse("\"Add integration tests\"").unwrap();
         let expanded = prompt.expand(&invocation).unwrap();
         assert!(expanded.contains("Add integration tests"));
     }


### PR DESCRIPTION
## Summary
- allow custom prompt invocations to populate the TASK argument from positional text
- adjust the builtin vtcode custom prompt hint and tests to reflect the simplified syntax

## Testing
- `cargo fmt`
- `cargo test custom_prompt`


------
https://chatgpt.com/codex/tasks/task_e_68f637a4d23083239955619b55b3444d