### PR TITLE
Show queued inputs at bottom of transcript

### DIFF
--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -478,11 +478,13 @@ pub(crate) async fn run_single_agent_loop_unified(
             handle.clear_input();
             handle.set_placeholder(default_placeholder.clone());
             queued_inputs.clear();
+            handle.set_queued_inputs(Vec::new());
             ctrl_c_state.clear_cancel();
             continue;
         }
 
         let mut input_owned = if let Some(queued) = queued_inputs.pop_front() {
+            handle.set_queued_inputs(queued_inputs.iter().cloned().collect());
             queued
         } else {
             let maybe_event = tokio::select! {
@@ -505,6 +507,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                 handle.clear_input();
                 handle.set_placeholder(default_placeholder.clone());
                 queued_inputs.clear();
+                handle.set_queued_inputs(Vec::new());
                 ctrl_c_state.clear_cancel();
                 continue;
             }
@@ -523,6 +526,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                         continue;
                     }
                     queued_inputs.push_back(trimmed);
+                    handle.set_queued_inputs(queued_inputs.iter().cloned().collect());
                     continue;
                 }
                 InlineEvent::ListModalSubmit(selection) => {

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -284,6 +284,7 @@ impl Session {
             }
             InlineCommand::SetQueuedInputs { entries } => {
                 self.queued_inputs = entries;
+                self.mark_dirty();
             }
             InlineCommand::SetCursorVisible(value) => {
                 self.cursor_visible = value;

--- a/vtcode-core/src/ui/tui/session.rs
+++ b/vtcode-core/src/ui/tui/session.rs
@@ -156,6 +156,7 @@ pub struct Session {
     cached_max_scroll_offset: usize,
     scroll_metrics_dirty: bool,
     transcript_cache: Option<TranscriptReflowCache>,
+    queued_inputs: Vec<String>,
     modal: Option<ModalState>,
     show_timeline_pane: bool,
     line_revision_counter: u64,
@@ -210,6 +211,7 @@ impl Session {
             cached_max_scroll_offset: 0,
             scroll_metrics_dirty: true,
             transcript_cache: None,
+            queued_inputs: Vec::new(),
             modal: None,
             show_timeline_pane,
             header_rows: initial_header_rows,
@@ -279,6 +281,9 @@ impl Session {
                 self.theme = theme;
                 self.ensure_prompt_style_color();
                 self.invalidate_transcript_cache();
+            }
+            InlineCommand::SetQueuedInputs { entries } => {
+                self.queued_inputs = entries;
             }
             InlineCommand::SetCursorVisible(value) => {
                 self.cursor_visible = value;
@@ -1151,6 +1156,7 @@ impl Session {
         if fill_count > 0 {
             visible_lines.extend((0..fill_count).map(|_| Line::default()));
         }
+        self.overlay_queue_lines(&mut visible_lines, content_width);
         let paragraph = Paragraph::new(visible_lines)
             .style(self.default_style())
             .wrap(Wrap { trim: false });
@@ -1166,6 +1172,117 @@ impl Session {
             );
             frame.render_widget(Clear, padding_area);
         }
+    }
+
+    fn overlay_queue_lines(&self, visible_lines: &mut Vec<Line<'static>>, content_width: u16) {
+        if visible_lines.is_empty() || content_width == 0 {
+            return;
+        }
+
+        if self.queued_inputs.is_empty() {
+            return;
+        }
+
+        let queue_lines = self.reflow_queue_lines(content_width);
+        if queue_lines.is_empty() {
+            return;
+        }
+
+        let queue_visible = queue_lines.len().min(visible_lines.len());
+        let start = visible_lines.len().saturating_sub(queue_visible);
+        let slice_start = queue_lines.len().saturating_sub(queue_visible);
+        let overlay = &queue_lines[slice_start..];
+        for (target, source) in visible_lines[start..].iter_mut().zip(overlay.iter()) {
+            *target = source.clone();
+        }
+    }
+
+    fn reflow_queue_lines(&self, width: u16) -> Vec<Line<'static>> {
+        if width == 0 || self.queued_inputs.is_empty() {
+            return Vec::new();
+        }
+
+        let max_width = width as usize;
+        let mut lines = Vec::new();
+        let mut header_style = self.accent_style();
+        header_style = header_style.add_modifier(Modifier::BOLD);
+        let message_style = self.default_style();
+
+        let header_text = if self.queued_inputs.len() == 1 {
+            "Queued message".to_string()
+        } else {
+            format!("Queued messages ({})", self.queued_inputs.len())
+        };
+
+        let mut header_lines = self.wrap_line(
+            Line::from(vec![Span::styled(header_text, header_style)]),
+            max_width,
+        );
+        if header_lines.is_empty() {
+            header_lines.push(Line::default());
+        }
+        lines.extend(header_lines);
+
+        for (index, entry) in self.queued_inputs.iter().enumerate() {
+            let label = format!("  {}. ", index + 1);
+            let mut message_lines =
+                self.wrap_queue_message(&label, entry, max_width, header_style, message_style);
+            if message_lines.is_empty() {
+                message_lines.push(Line::default());
+            }
+            lines.append(&mut message_lines);
+        }
+
+        lines
+    }
+
+    fn wrap_queue_message(
+        &self,
+        label: &str,
+        message: &str,
+        max_width: usize,
+        label_style: Style,
+        message_style: Style,
+    ) -> Vec<Line<'static>> {
+        if max_width == 0 {
+            return Vec::new();
+        }
+
+        let label_width = UnicodeWidthStr::width(label);
+        if max_width <= label_width {
+            let mut wrapped_label = self.wrap_line(
+                Line::from(vec![Span::styled(label.to_string(), label_style)]),
+                max_width,
+            );
+            if wrapped_label.is_empty() {
+                wrapped_label.push(Line::default());
+            }
+            return wrapped_label;
+        }
+
+        let available = max_width - label_width;
+        let mut wrapped = self.wrap_line(
+            Line::from(vec![Span::styled(message.to_string(), message_style)]),
+            available,
+        );
+        if wrapped.is_empty() {
+            wrapped.push(Line::default());
+        }
+
+        let mut lines = Vec::with_capacity(wrapped.len());
+        for (line_index, mut line) in wrapped.into_iter().enumerate() {
+            let prefix = if line_index == 0 {
+                label.to_string()
+            } else {
+                " ".repeat(label_width)
+            };
+            let mut spans = Vec::new();
+            spans.push(Span::styled(prefix, label_style));
+            spans.extend(line.spans.drain(..));
+            lines.push(Line::from(spans));
+        }
+
+        lines
     }
 
     fn render_slash_palette(&mut self, frame: &mut Frame<'_>, viewport: Rect) {
@@ -4182,10 +4299,16 @@ mod tests {
         let lines = session.reflow_transcript_lines(width);
 
         let start = offset.min(lines.len());
-        let mut collected: Vec<String> = lines
+        let mut visible: Vec<Line<'static>> =
+            lines.into_iter().skip(start).take(viewport).collect();
+        let filler = viewport.saturating_sub(visible.len());
+        if filler > 0 {
+            visible.extend((0..filler).map(|_| Line::default()));
+        }
+        session.overlay_queue_lines(&mut visible, width);
+
+        visible
             .into_iter()
-            .skip(start)
-            .take(viewport)
             .map(|line| {
                 line.spans
                     .into_iter()
@@ -4194,10 +4317,7 @@ mod tests {
                     .trim_end()
                     .to_string()
             })
-            .collect();
-        let filler = viewport.saturating_sub(collected.len());
-        collected.extend((0..filler).map(|_| String::new()));
-        collected
+            .collect()
     }
 
     fn line_text(line: &Line<'_>) -> String {
@@ -4977,6 +5097,40 @@ mod tests {
             .expect("failed to render session with hidden timeline");
 
         assert!(session.navigation_state.selected().is_none());
+    }
+
+    #[test]
+    fn queued_inputs_overlay_bottom_rows() {
+        let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS, true);
+        session.push_line(
+            InlineMessageKind::Agent,
+            vec![make_segment("Latest response from agent")],
+        );
+
+        session.handle_command(InlineCommand::SetQueuedInputs {
+            entries: vec![
+                "first queued message".to_string(),
+                "second queued message".to_string(),
+            ],
+        });
+
+        let view = visible_transcript(&mut session);
+        let footer: Vec<String> = view.iter().rev().take(3).cloned().collect();
+
+        assert!(
+            footer
+                .iter()
+                .any(|line| line.contains("Queued messages (2)")),
+            "queued header should be visible at the bottom of the transcript"
+        );
+        assert!(
+            footer.iter().any(|line| line.contains("1.")),
+            "first queued message label should be rendered"
+        );
+        assert!(
+            footer.iter().any(|line| line.contains("2.")),
+            "second queued message label should be rendered"
+        );
     }
 
     #[test]

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -193,6 +193,9 @@ pub enum InlineCommand {
     SetTheme {
         theme: InlineTheme,
     },
+    SetQueuedInputs {
+        entries: Vec<String>,
+    },
     SetCursorVisible(bool),
     SetInputEnabled(bool),
     SetInput(String),
@@ -298,6 +301,10 @@ impl InlineHandle {
 
     pub fn set_theme(&self, theme: InlineTheme) {
         let _ = self.sender.send(InlineCommand::SetTheme { theme });
+    }
+
+    pub fn set_queued_inputs(&self, entries: Vec<String>) {
+        let _ = self.sender.send(InlineCommand::SetQueuedInputs { entries });
     }
 
     pub fn set_cursor_visible(&self, visible: bool) {


### PR DESCRIPTION
## Summary
- expose a new `InlineCommand` for setting queued inputs and forward queued submissions from the run loop
- render queued input summaries anchored to the bottom of the transcript and keep them visible while scrolling
- cover the rendering behaviour with a regression test for queued inputs

## Testing
- cargo fmt
- cargo clippy
- cargo test queued_inputs_overlay_bottom_rows

------
https://chatgpt.com/codex/tasks/task_e_68f6342e1f208323b91444c06b7ecc28