### PR TITLE
Refactor tool output rendering to use Ratatui panels

### DIFF
--- a/.vtcode/prompts/generate-agent-file.md
+++ b/.vtcode/prompts/generate-agent-file.md
@@ -1,0 +1,10 @@
+# Generate Agent File
+
+Please analyze this codebase and create an AGENTS.md file containing:
+1. Build/lint/test commands - especially for running a single test
+2. Architecture and codebase structure information, including important subprojects, internal APIs, databases, etc.
+3. Code style guidelines, including imports, conventions, formatting, types, naming conventions, error handling, etc.
+
+The file you create will be given to agentic coding tools (such as yourself) that operate in this repository. Make it about 20 lines long.
+
+If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLAUDE.md), Windsurf rules (.windsurfrules), Cline rules (.clinerules), Goose rules (.goosehints), or Copilot rules (in .github/copilot-instructions.md), make sure to include them. Also, first check if there is an existing AGENTS.md or AGENT.md file, and if so, update it instead of overwriting it.

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -13,6 +13,8 @@ use vtcode_core::ui::{InlineListItem, InlineListSearchConfig, InlineListSelectio
 use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
 use vtcode_core::utils::dot_config::update_model_preference;
 
+use vtcode::interactive_list::{SelectionEntry, SelectionInterrupted, run_interactive_selection};
+
 #[derive(Clone, Copy)]
 struct ModelOption {
     provider: Provider,
@@ -109,20 +111,27 @@ pub struct ModelPickerState {
     workspace: Option<PathBuf>,
 }
 
+pub enum ModelPickerStart {
+    Completed {
+        state: ModelPickerState,
+        selection: ModelSelectionResult,
+    },
+    InProgress(ModelPickerState),
+}
+
 impl ModelPickerState {
     pub fn new(
         renderer: &mut AnsiRenderer,
         current_reasoning: ReasoningEffortLevel,
         workspace: Option<PathBuf>,
-    ) -> Result<Self> {
+    ) -> Result<ModelPickerStart> {
         let options = MODEL_OPTIONS.as_slice();
         let inline_enabled = renderer.supports_inline_ui();
         if inline_enabled {
             render_step_one_inline(renderer, options, current_reasoning)?;
-        } else {
-            render_step_one_plain(renderer, options)?;
         }
-        Ok(Self {
+
+        let mut state = Self {
             options,
             step: PickerStep::AwaitModel,
             inline_enabled,
@@ -131,7 +140,53 @@ impl ModelPickerState {
             selected_reasoning: None,
             pending_api_key: None,
             workspace,
-        })
+        };
+
+        if !inline_enabled {
+            match select_model_with_ratatui_list(options, current_reasoning) {
+                Ok(ModelSelectionListOutcome::Predefined(detail)) => {
+                    match state.process_model_selection(renderer, detail)? {
+                        ModelPickerProgress::Completed(result) => {
+                            return Ok(ModelPickerStart::Completed {
+                                state,
+                                selection: result,
+                            });
+                        }
+                        ModelPickerProgress::InProgress => {
+                            return Ok(ModelPickerStart::InProgress(state));
+                        }
+                        ModelPickerProgress::Cancelled => {
+                            renderer.line(MessageStyle::Info, "Model picker cancelled.")?;
+                            return Ok(ModelPickerStart::InProgress(state));
+                        }
+                    }
+                }
+                Ok(ModelSelectionListOutcome::Manual) => {
+                    render_step_one_plain(renderer, options)?;
+                    prompt_custom_model_entry(renderer)?;
+                }
+                Ok(ModelSelectionListOutcome::Cancelled) => {
+                    render_step_one_plain(renderer, options)?;
+                    prompt_custom_model_entry(renderer)?;
+                }
+                Err(err) => {
+                    if err.is::<SelectionInterrupted>() {
+                        return Err(err);
+                    }
+                    renderer.line(
+                        MessageStyle::Info,
+                        &format!(
+                            "Interactive model picker unavailable ({}). Falling back to manual input.",
+                            err
+                        ),
+                    )?;
+                    render_step_one_plain(renderer, options)?;
+                    prompt_custom_model_entry(renderer)?;
+                }
+            }
+        }
+
+        Ok(ModelPickerStart::InProgress(state))
     }
 
     pub fn handle_input(
@@ -304,7 +359,9 @@ impl ModelPickerState {
                 MessageStyle::Error,
                 "Unknown reasoning level. Use easy, medium, hard, or skip.",
             )?;
-            self.prompt_reasoning_step(renderer)?;
+            if let Some(progress) = self.prompt_reasoning_step(renderer)? {
+                return Ok(progress);
+            }
             return Ok(ModelPickerProgress::InProgress);
         };
 
@@ -449,7 +506,9 @@ impl ModelPickerState {
             .unwrap_or(false)
         {
             self.step = PickerStep::AwaitReasoning;
-            self.prompt_reasoning_step(renderer)?;
+            if let Some(progress) = self.prompt_reasoning_step(renderer)? {
+                return Ok(progress);
+            }
             return Ok(ModelPickerProgress::InProgress);
         }
 
@@ -468,16 +527,39 @@ impl ModelPickerState {
         Ok(ModelPickerProgress::Completed(result?))
     }
 
-    fn prompt_reasoning_step(&mut self, renderer: &mut AnsiRenderer) -> Result<()> {
+    fn prompt_reasoning_step(
+        &mut self,
+        renderer: &mut AnsiRenderer,
+    ) -> Result<Option<ModelPickerProgress>> {
         let Some(selection) = self.selection.as_ref() else {
             return Err(anyhow!("Reasoning requested before selecting a model"));
         };
         if self.inline_enabled {
             render_reasoning_inline(renderer, selection, self.current_reasoning)?;
-        } else {
-            prompt_reasoning_plain(renderer, selection, self.current_reasoning)?;
+            return Ok(None);
         }
-        Ok(())
+
+        match select_reasoning_with_ratatui(selection, self.current_reasoning) {
+            Ok(Some(level)) => self.apply_reasoning_choice(renderer, level).map(Some),
+            Ok(None) => {
+                prompt_reasoning_plain(renderer, selection, self.current_reasoning)?;
+                Ok(None)
+            }
+            Err(err) => {
+                if err.is::<SelectionInterrupted>() {
+                    return Err(err);
+                }
+                renderer.line(
+                    MessageStyle::Info,
+                    &format!(
+                        "Interactive reasoning selector unavailable ({}). Falling back to manual input.",
+                        err
+                    ),
+                )?;
+                prompt_reasoning_plain(renderer, selection, self.current_reasoning)?;
+                Ok(None)
+            }
+        }
     }
 
     fn prompt_api_key_step(&mut self, renderer: &mut AnsiRenderer) -> Result<()> {
@@ -673,6 +755,93 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
     Ok(())
 }
 
+#[derive(Clone)]
+struct ModelSelectionChoice {
+    entry: SelectionEntry,
+    outcome: ModelSelectionChoiceOutcome,
+}
+
+#[derive(Clone)]
+enum ModelSelectionChoiceOutcome {
+    Predefined(SelectionDetail),
+    Manual,
+}
+
+enum ModelSelectionListOutcome {
+    Predefined(SelectionDetail),
+    Manual,
+    Cancelled,
+}
+
+fn select_model_with_ratatui_list(
+    options: &[ModelOption],
+    current_reasoning: ReasoningEffortLevel,
+) -> Result<ModelSelectionListOutcome> {
+    if options.is_empty() {
+        return Err(anyhow!("No models available for selection"));
+    }
+
+    let mut choices = Vec::new();
+    for provider in Provider::all_providers() {
+        let provider_models: Vec<&ModelOption> = options
+            .iter()
+            .filter(|option| option.provider == provider)
+            .collect();
+        for option in provider_models {
+            let mut title = format!("{} • {}", provider.label(), option.display);
+            if option.supports_reasoning {
+                title.push_str(" [Reasoning]");
+            }
+            let description = format!("ID: {} — {}", option.id, option.description);
+            choices.push(ModelSelectionChoice {
+                entry: SelectionEntry::new(title, Some(description)),
+                outcome: ModelSelectionChoiceOutcome::Predefined(selection_from_option(option)),
+            });
+        }
+
+        if provider == Provider::Ollama {
+            choices.push(ModelSelectionChoice {
+                entry: SelectionEntry::new(
+                    "Custom Ollama model",
+                    Some(
+                        "Type 'ollama <model>' to use any local model (e.g., qwen3:1.7b, llama3:8b)."
+                            .to_string(),
+                    ),
+                ),
+                outcome: ModelSelectionChoiceOutcome::Manual,
+            });
+        }
+    }
+
+    choices.push(ModelSelectionChoice {
+        entry: SelectionEntry::new(
+            CUSTOM_PROVIDER_TITLE,
+            Some(CUSTOM_PROVIDER_SUBTITLE.to_string()),
+        ),
+        outcome: ModelSelectionChoiceOutcome::Manual,
+    });
+
+    let entries: Vec<SelectionEntry> = choices.iter().map(|choice| choice.entry.clone()).collect();
+
+    let instructions = format!(
+        "Current reasoning effort: {}. Models marked with [Reasoning] support adjustable reasoning.",
+        current_reasoning
+    );
+
+    let selection = run_interactive_selection("Models", &instructions, &entries, 0)?;
+    let selected_index = match selection {
+        Some(index) => index,
+        None => return Ok(ModelSelectionListOutcome::Cancelled),
+    };
+
+    match &choices[selected_index].outcome {
+        ModelSelectionChoiceOutcome::Predefined(detail) => {
+            Ok(ModelSelectionListOutcome::Predefined(detail.clone()))
+        }
+        ModelSelectionChoiceOutcome::Manual => Ok(ModelSelectionListOutcome::Manual),
+    }
+}
+
 fn prompt_reasoning_plain(
     renderer: &mut AnsiRenderer,
     selection: &SelectionDetail,
@@ -741,6 +910,52 @@ fn render_reasoning_inline(
         None,
     );
     Ok(())
+}
+
+fn select_reasoning_with_ratatui(
+    selection: &SelectionDetail,
+    current: ReasoningEffortLevel,
+) -> Result<Option<ReasoningEffortLevel>> {
+    let entries = vec![
+        SelectionEntry::new(
+            format!("Keep current ({})", reasoning_level_label(current)),
+            Some(KEEP_CURRENT_DESCRIPTION.to_string()),
+        ),
+        SelectionEntry::new(
+            reasoning_level_label(ReasoningEffortLevel::Low),
+            Some(reasoning_level_description(ReasoningEffortLevel::Low).to_string()),
+        ),
+        SelectionEntry::new(
+            reasoning_level_label(ReasoningEffortLevel::Medium),
+            Some(reasoning_level_description(ReasoningEffortLevel::Medium).to_string()),
+        ),
+        SelectionEntry::new(
+            reasoning_level_label(ReasoningEffortLevel::High),
+            Some(reasoning_level_description(ReasoningEffortLevel::High).to_string()),
+        ),
+    ];
+
+    let instructions = format!(
+        "Select reasoning effort for {}. Esc keeps the current level ({}).",
+        selection.model_display,
+        reasoning_level_label(current),
+    );
+
+    let selection_index =
+        run_interactive_selection("Reasoning effort", &instructions, &entries, 0)?;
+
+    let Some(index) = selection_index else {
+        return Ok(None);
+    };
+
+    let choice = match index {
+        0 => current,
+        1 => ReasoningEffortLevel::Low,
+        2 => ReasoningEffortLevel::Medium,
+        3 => ReasoningEffortLevel::High,
+        _ => current,
+    };
+    Ok(Some(choice))
 }
 
 fn prompt_api_key_plain(

--- a/src/agent/runloop/slash_commands.rs
+++ b/src/agent/runloop/slash_commands.rs
@@ -23,12 +23,14 @@ pub enum SlashCommandOutcome {
         name: String,
         args: Value,
     },
-    InitializeWorkspace {
-        force: bool,
-    },
+    #[allow(dead_code)]
     GenerateAgentFile {
         overwrite: bool,
     },
+    InitializeWorkspace {
+        force: bool,
+    },
+
     ShowConfig,
     Exit,
     StartModelSelection,
@@ -219,25 +221,7 @@ pub fn handle_slash_command(
             Ok(SlashCommandOutcome::InitializeWorkspace { force })
         }
         "generate-agent-file" => {
-            let mut overwrite = false;
-            for flag in args.split_whitespace() {
-                match flag {
-                    "--force" | "-f" | "--overwrite" => overwrite = true,
-                    "--help" | "help" => {
-                        render_generate_agent_file_usage(renderer)?;
-                        return Ok(SlashCommandOutcome::Handled);
-                    }
-                    unknown => {
-                        renderer.line(
-                            MessageStyle::Error,
-                            &format!("Unknown flag '{}' for /generate-agent-file", unknown),
-                        )?;
-                        render_generate_agent_file_usage(renderer)?;
-                        return Ok(SlashCommandOutcome::Handled);
-                    }
-                }
-            }
-            Ok(SlashCommandOutcome::GenerateAgentFile { overwrite })
+            return handle_custom_prompt("generate-agent-file", "", renderer, custom_prompts);
         }
         "config" => Ok(SlashCommandOutcome::ShowConfig),
         "clear" => {
@@ -665,14 +649,6 @@ fn render_add_dir_usage(renderer: &mut AnsiRenderer) -> Result<()> {
     Ok(())
 }
 
-fn render_generate_agent_file_usage(renderer: &mut AnsiRenderer) -> Result<()> {
-    renderer.line(MessageStyle::Info, "Usage: /generate-agent-file [--force]")?;
-    renderer.line(
-        MessageStyle::Info,
-        "  --force  Overwrite an existing AGENTS.md with regenerated content.",
-    )?;
-    Ok(())
-}
 
 fn format_duration_label(duration: Duration) -> String {
     let total_seconds = duration.as_secs();

--- a/src/agent/runloop/slash_commands.rs
+++ b/src/agent/runloop/slash_commands.rs
@@ -221,7 +221,25 @@ pub fn handle_slash_command(
             Ok(SlashCommandOutcome::InitializeWorkspace { force })
         }
         "generate-agent-file" => {
-            return handle_custom_prompt("generate-agent-file", "", renderer, custom_prompts);
+            let mut overwrite = false;
+            for flag in args.split_whitespace() {
+                match flag {
+                    "--force" | "-f" | "--overwrite" => overwrite = true,
+                    "--help" | "help" => {
+                        render_generate_agent_file_usage(renderer)?;
+                        return Ok(SlashCommandOutcome::Handled);
+                    }
+                    unknown => {
+                        renderer.line(
+                            MessageStyle::Error,
+                            &format!("Unknown flag '{}' for /generate-agent-file", unknown),
+                        )?;
+                        render_generate_agent_file_usage(renderer)?;
+                        return Ok(SlashCommandOutcome::Handled);
+                    }
+                }
+            }
+            Ok(SlashCommandOutcome::GenerateAgentFile { overwrite })
         }
         "config" => Ok(SlashCommandOutcome::ShowConfig),
         "clear" => {
@@ -649,6 +667,14 @@ fn render_add_dir_usage(renderer: &mut AnsiRenderer) -> Result<()> {
     Ok(())
 }
 
+fn render_generate_agent_file_usage(renderer: &mut AnsiRenderer) -> Result<()> {
+    renderer.line(MessageStyle::Info, "Usage: /generate-agent-file [--force]")?;
+    renderer.line(
+        MessageStyle::Info,
+        "  --force  Overwrite an existing AGENTS.md with regenerated content.",
+    )?;
+    Ok(())
+}
 
 fn format_duration_label(duration: Duration) -> String {
     let total_seconds = duration.as_secs();

--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -484,10 +484,9 @@ fn render_plan_panel(renderer: &mut AnsiRenderer, plan: &TaskPlan) -> Result<()>
 
     let mut lines = Vec::new();
     let progress = format!(
-        "Progress: {}/{} · {}",
+        "  Progress: {}/{} completed",
         plan.summary.completed_steps,
-        plan.summary.total_steps,
-        plan.summary.status.description()
+        plan.summary.total_steps
     );
     lines.push(PanelContentLine::new(
         clamp_panel_text(&progress, content_width),
@@ -514,10 +513,10 @@ fn render_plan_panel(renderer: &mut AnsiRenderer, plan: &TaskPlan) -> Result<()>
     }
 
     for (index, step) in plan.steps.iter().enumerate() {
-        let checkbox = match step.status {
-            StepStatus::Pending => "[ ]",
-            StepStatus::InProgress => "[▸]",
-            StepStatus::Completed => "[✓]",
+        let (checkbox, _style) = match step.status {
+            StepStatus::Pending => ("[ ]", MessageStyle::Info),
+            StepStatus::InProgress => ("[>]", MessageStyle::Tool),
+            StepStatus::Completed => ("[✓]", MessageStyle::Response),
         };
         let step_number = index + 1;
         let header = format!("{step_number}. {checkbox}");

--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -479,7 +479,7 @@ fn resolve_mcp_renderer_profile(
 }
 
 fn render_plan_panel(renderer: &mut AnsiRenderer, plan: &TaskPlan) -> Result<()> {
-    const PANEL_WIDTH: u16 = 96;
+    const PANEL_WIDTH: u16 = 60;
     let content_width = PANEL_WIDTH.saturating_sub(4) as usize;
 
     let mut lines = Vec::new();
@@ -518,34 +518,11 @@ fn render_plan_panel(renderer: &mut AnsiRenderer, plan: &TaskPlan) -> Result<()>
             StepStatus::InProgress => ("[>]", MessageStyle::Tool),
             StepStatus::Completed => ("[✓]", MessageStyle::Response),
         };
-        let step_number = index + 1;
-        let header = format!("{step_number}. {checkbox}");
-        lines.push(PanelContentLine::new(
-            clamp_panel_text(&header, content_width),
-            MessageStyle::Info,
-        ));
-
         let step_text = step.step.trim();
-        if step_text.is_empty() {
-            lines.push(PanelContentLine::new(
-                clamp_panel_text("    (no description provided)", content_width),
-                MessageStyle::Info,
-            ));
-            continue;
-        }
-
-        for detail_line in step_text.lines() {
-            let trimmed = detail_line.trim();
-            let display = if trimmed.is_empty() {
-                String::new()
-            } else {
-                format!("    {}", trimmed)
-            };
-            lines.push(PanelContentLine::new(
-                clamp_panel_text(&display, content_width),
-                MessageStyle::Info,
-            ));
-        }
+        let step_number = index + 1;
+        let content = format!("{step_number}. {checkbox} {step_text}");
+        let truncated = clamp_panel_text(&content, content_width);
+        lines.push(PanelContentLine::new(truncated, MessageStyle::Info));
     }
 
     render_panel(
@@ -886,7 +863,7 @@ fn render_terminal_command_panel(
     _git_styles: &GitStyles,
     _ls_styles: &LsStyles,
 ) -> Result<()> {
-    const PANEL_WIDTH: u16 = 96;
+    const PANEL_WIDTH: u16 = 70;
     let output_mode = ToolOutputMode::Compact;
     let tail_limit = defaults::DEFAULT_PTY_STDOUT_TAIL_LINES;
     let prefer_full = renderer.prefers_untruncated_output();

--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -12,7 +12,7 @@ use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color as RatColor, Modifier as RatModifier, Style as RatStyle};
-use ratatui::widgets::{Block, Borders, Widget};
+use ratatui::widgets::{Block, BorderType, Padding, Widget};
 use unicode_width::UnicodeWidthStr;
 
 use crate::agent::runloop::text_tools::CodeFenceBlock;
@@ -49,9 +49,10 @@ impl ToolPanel {
 
 impl Widget for ToolPanel {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(self.border_style);
+        let mut block = Block::bordered()
+            .border_style(self.border_style)
+            .border_type(BorderType::Rounded)
+            .padding(Padding::new(1, 1, 0, 0));
         if let Some(title) = self.title {
             block = block.title(title);
         }
@@ -823,11 +824,6 @@ pub(crate) fn render_code_fence_blocks(
         let header = describe_code_fence_header(block.language.as_deref());
 
         let mut lines = Vec::new();
-        lines.push(PanelContentLine::new(
-            clamp_panel_text(&header, content_limit),
-            MessageStyle::Info,
-        ));
-        lines.push(PanelContentLine::new(String::new(), MessageStyle::Response));
 
         if block.lines.is_empty() {
             lines.push(PanelContentLine::new(
@@ -835,6 +831,7 @@ pub(crate) fn render_code_fence_blocks(
                 MessageStyle::Info,
             ));
         } else {
+            lines.push(PanelContentLine::new(String::new(), MessageStyle::Response));
             for line in &block.lines {
                 let display = format!("    {}", line);
                 lines.push(PanelContentLine::new(
@@ -846,7 +843,7 @@ pub(crate) fn render_code_fence_blocks(
 
         render_panel(
             renderer,
-            None,
+            Some(clamp_panel_text(&header, content_limit)),
             lines,
             MessageStyle::Response,
             MIN_WIDTH,
@@ -970,7 +967,7 @@ fn render_terminal_command_panel(
 
     render_panel(
         renderer,
-        None,
+        Some("[cmd] run_terminal_cmd".to_string()),
         lines,
         header_style,
         PANEL_WIDTH,

--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -881,18 +881,21 @@ fn render_terminal_command_panel(
 
     let exit_code = payload.get("exit_code").and_then(|value| value.as_i64());
 
-    let shell_label = match payload.get("mode").and_then(|value| value.as_str()) {
-        Some("pty") => "pty",
-        _ => "cmd",
+    let mode_label = match payload.get("mode").and_then(|value| value.as_str()) {
+        Some("pty") => "PTY session",
+        _ => "Terminal command",
     };
 
-    // Header
     let status_icon = if success { "✓" } else { "✗" };
-    let mut header = format!("{} [{}] {}", status_icon, shell_label, command_display);
+    let mut header = if success {
+        format!("{status_icon} Completed")
+    } else {
+        format!("{status_icon} Failed")
+    };
 
     if !success {
         if let Some(code) = exit_code {
-            header.push_str(&format!(" (exit {})", code));
+            header.push_str(&format!(" (exit {code})"));
         }
     }
 
@@ -904,11 +907,41 @@ fn render_terminal_command_panel(
 
     let content_limit = PANEL_WIDTH.saturating_sub(4) as usize;
 
+    let stdin_content = payload
+        .get("stdin")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(command_display);
+
     let mut lines = Vec::new();
     lines.push(PanelContentLine::new(
         clamp_panel_text(&header, content_limit),
         header_style,
     ));
+
+    if let Some(workdir) = payload
+        .get("working_dir")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        let cwd_line = format!("  cwd  {}", workdir);
+        lines.push(PanelContentLine::new(
+            clamp_panel_text(&cwd_line, content_limit),
+            MessageStyle::Info,
+        ));
+    }
+
+    if !stdin_content.is_empty() {
+        lines.push(PanelContentLine::new(String::new(), MessageStyle::Info));
+        lines.push(PanelContentLine::new("STDIN", MessageStyle::Tool));
+        for line in stdin_content.lines() {
+            let display = format!("  {}", line);
+            lines.push(PanelContentLine::new(
+                clamp_panel_text(&display, content_limit),
+                MessageStyle::Tool,
+            ));
+        }
+    }
 
     let stdout = payload.get("stdout").and_then(Value::as_str).unwrap_or("");
     let (stdout_lines, stdout_total, stdout_truncated) =
@@ -918,15 +951,14 @@ fn render_terminal_command_panel(
     let (stderr_lines, stderr_total, stderr_truncated) =
         select_stream_lines(stderr, output_mode, tail_limit, prefer_full);
 
-    if !stdout_lines.is_empty() || !stderr_lines.is_empty() {
-        lines.push(PanelContentLine::new(String::new(), MessageStyle::Info));
-    }
-
     if !stdout_lines.is_empty() {
+        lines.push(PanelContentLine::new(String::new(), MessageStyle::Info));
+        lines.push(PanelContentLine::new("STDOUT", MessageStyle::Output));
+
         if stdout_truncated {
             let hidden = stdout_total.saturating_sub(stdout_lines.len());
             if hidden > 0 {
-                let msg = format!("    ... first {hidden} lines hidden ...");
+                let msg = format!("  ... first {hidden} lines hidden ...");
                 lines.push(PanelContentLine::new(
                     clamp_panel_text(&msg, content_limit),
                     MessageStyle::Info,
@@ -935,19 +967,20 @@ fn render_terminal_command_panel(
         }
 
         for &line in stdout_lines.iter().take(10) {
-            let truncated = clamp_panel_text(line, content_limit);
-            lines.push(PanelContentLine::new(truncated, MessageStyle::Info));
+            let display = format!("  {}", line);
+            let truncated = clamp_panel_text(&display, content_limit);
+            lines.push(PanelContentLine::new(truncated, MessageStyle::Output));
         }
     }
 
     if !stderr_lines.is_empty() {
-        if !stdout_lines.is_empty() {
-            lines.push(PanelContentLine::new(String::new(), MessageStyle::Info));
-        }
+        lines.push(PanelContentLine::new(String::new(), MessageStyle::Info));
+        lines.push(PanelContentLine::new("STDERR", MessageStyle::Error));
+
         if stderr_truncated {
             let hidden = stderr_total.saturating_sub(stderr_lines.len());
             if hidden > 0 {
-                let msg = format!("    ... first {hidden} lines hidden ...");
+                let msg = format!("  ... first {hidden} lines hidden ...");
                 lines.push(PanelContentLine::new(
                     clamp_panel_text(&msg, content_limit),
                     MessageStyle::Info,
@@ -956,18 +989,19 @@ fn render_terminal_command_panel(
         }
 
         for &line in stderr_lines.iter().take(5) {
-            let truncated = clamp_panel_text(line, content_limit);
+            let display = format!("  {}", line);
+            let truncated = clamp_panel_text(&display, content_limit);
             lines.push(PanelContentLine::new(truncated, MessageStyle::Error));
         }
     }
 
     if stdout_lines.is_empty() && stderr_lines.is_empty() {
-        lines.push(PanelContentLine::new("(no output)", MessageStyle::Info));
+        lines.push(PanelContentLine::new("  (no output)", MessageStyle::Info));
     }
 
     render_panel(
         renderer,
-        Some("[cmd] run_terminal_cmd".to_string()),
+        Some(mode_label.to_string()),
         lines,
         header_style,
         PANEL_WIDTH,

--- a/src/agent/runloop/unified/tool_summary.rs
+++ b/src/agent/runloop/unified/tool_summary.rs
@@ -12,7 +12,7 @@ pub(crate) fn render_tool_call_summary(
     args: &Value,
 ) -> Result<()> {
     let (headline, highlights) = describe_tool_action(tool_name, args);
-    let human = humanize_tool_name(tool_name);
+    let _human = humanize_tool_name(tool_name);
     let details = collect_highlight_details(args, &highlights);
 
     // ANSI colors: cyan for icon/prefix, bright white for action, dim white for details, yellow for tool name

--- a/src/agent/runloop/unified/tool_summary.rs
+++ b/src/agent/runloop/unified/tool_summary.rs
@@ -17,21 +17,21 @@ pub(crate) fn render_tool_call_summary(
 
     // ANSI colors: cyan for icon/prefix, bright white for action, dim white for details, yellow for tool name
     let mut line = String::new();
-    line.push_str("\x1b[36m✦\x1b[0m ");  // Cyan icon
-    line.push_str("\x1b[97m");  // Bright white for headline
+    line.push_str("\x1b[36m✦\x1b[0m "); // Cyan icon
+    line.push_str("\x1b[97m"); // Bright white for headline
     line.push_str(&headline);
-    line.push_str("\x1b[0m");  // Reset
-    
+    line.push_str("\x1b[0m"); // Reset
+
     if !details.is_empty() {
-        line.push_str(" \x1b[2m·\x1b[0m ");  // Dim separator
-        line.push_str("\x1b[2m");  // Dim for details
+        line.push_str(" \x1b[2m·\x1b[0m "); // Dim separator
+        line.push_str("\x1b[2m"); // Dim for details
         line.push_str(&details.join(" · "));
-        line.push_str("\x1b[0m");  // Reset
+        line.push_str("\x1b[0m"); // Reset
     }
-    
-    line.push_str(" \x1b[33m[");  // Yellow for tool name
+
+    line.push_str(" \x1b[33m["); // Yellow for tool name
     line.push_str(tool_name);
-    line.push_str("]\x1b[0m");  // Reset
+    line.push_str("]\x1b[0m"); // Reset
 
     renderer.line(MessageStyle::Tool, &line)?;
     renderer.line(MessageStyle::Tool, "")?;

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -497,10 +497,11 @@ pub(crate) async fn run_single_agent_loop_unified(
                 event = session.next_event() => event,
             };
 
+            if ctrl_c_state.is_exit_requested() {
+                break;
+            }
+
             if ctrl_c_state.is_cancel_requested() {
-                if ctrl_c_state.is_exit_requested() {
-                    break;
-                }
 
                 renderer.line_if_not_empty(MessageStyle::Output)?;
                 renderer.line(

--- a/src/interactive_list.rs
+++ b/src/interactive_list.rs
@@ -1,0 +1,354 @@
+use std::fmt;
+use std::io::{self, IsTerminal};
+
+use anyhow::{Context, Result, anyhow};
+use crossterm::cursor::Show;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{
+    Block, BorderType, Borders, List, ListDirection, ListItem, ListState, Paragraph, Wrap,
+};
+
+const CONTROLS_HINT: &str =
+    "Use ↑/↓ or j/k to move • Home/End to jump • Enter to confirm • Esc to cancel";
+const NUMBER_JUMP_HINT: &str = "Tip: type a number to jump directly to an option.";
+
+#[derive(Debug, Clone)]
+pub struct SelectionEntry {
+    pub title: String,
+    pub description: Option<String>,
+}
+
+impl SelectionEntry {
+    pub fn new(title: impl Into<String>, description: Option<String>) -> Self {
+        Self {
+            title: title.into(),
+            description,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SelectionInterrupted;
+
+impl fmt::Display for SelectionInterrupted {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("selection interrupted by Ctrl+C")
+    }
+}
+
+impl std::error::Error for SelectionInterrupted {}
+
+pub fn run_interactive_selection(
+    title: &str,
+    instructions: &str,
+    entries: &[SelectionEntry],
+    default_index: usize,
+) -> Result<Option<usize>> {
+    if entries.is_empty() {
+        return Err(anyhow!("No options available for selection"));
+    }
+
+    if !io::stdout().is_terminal() {
+        return Err(anyhow!("Terminal UI is unavailable"));
+    }
+
+    let mut stdout = io::stdout();
+    let mut terminal_guard = TerminalModeGuard::new(title);
+    terminal_guard.enable_raw_mode()?;
+    terminal_guard.enter_alternate_screen(&mut stdout)?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)
+        .with_context(|| format!("Failed to initialize Ratatui terminal for {title} selector"))?;
+    terminal_guard.hide_cursor(&mut terminal)?;
+
+    let selection_result = (|| -> Result<Option<usize>> {
+        let total = entries.len();
+        let mut selected_index = default_index.min(total.saturating_sub(1));
+        let mut number_buffer = String::new();
+        let mut list_state = ListState::default();
+        list_state.select(Some(selected_index));
+
+        loop {
+            list_state.select(Some(selected_index));
+            terminal
+                .draw(|frame| {
+                    let area = frame.area();
+                    let instruction_lines = instructions.lines().count().max(1) as u16;
+                    let instruction_height = instruction_lines.saturating_add(2);
+                    let footer_height: u16 = 4;
+                    let layout = Layout::default()
+                        .direction(Direction::Vertical)
+                        .margin(1)
+                        .constraints([
+                            Constraint::Length(
+                                instruction_height
+                                    .min(area.height.saturating_sub(footer_height + 3)),
+                            ),
+                            Constraint::Min(5),
+                            Constraint::Length(footer_height),
+                        ])
+                        .split(area);
+
+                    let instructions_widget = Paragraph::new(instructions)
+                        .block(
+                            Block::default()
+                                .title("Instructions")
+                                .borders(Borders::ALL)
+                                .border_type(BorderType::Rounded),
+                        )
+                        .wrap(Wrap { trim: true });
+                    frame.render_widget(instructions_widget, layout[0]);
+
+                    let items: Vec<ListItem> = entries
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, entry)| {
+                            let mut lines = vec![Line::from(vec![
+                                Span::styled(
+                                    format!("{:>2}. ", idx + 1),
+                                    Style::default()
+                                        .fg(Color::LightBlue)
+                                        .add_modifier(Modifier::BOLD),
+                                ),
+                                Span::raw(entry.title.clone()),
+                            ])];
+                            if let Some(description) = entry.description.as_ref() {
+                                if !description.is_empty() && description != &entry.title {
+                                    lines.push(Line::from(Span::styled(
+                                        description.clone(),
+                                        Style::default().fg(Color::Gray),
+                                    )));
+                                }
+                            }
+                            ListItem::new(lines)
+                        })
+                        .collect();
+
+                    let list = List::new(items)
+                        .block(
+                            Block::default()
+                                .title(title)
+                                .borders(Borders::ALL)
+                                .border_type(BorderType::Rounded),
+                        )
+                        .style(Style::default().fg(Color::White))
+                        .highlight_style(
+                            Style::default()
+                                .fg(Color::Cyan)
+                                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+                        )
+                        .highlight_symbol("> ")
+                        .repeat_highlight_symbol(true)
+                        .direction(ListDirection::TopToBottom)
+                        .scroll_padding(1);
+
+                    frame.render_stateful_widget(list, layout[1], &mut list_state);
+
+                    let current = &entries[selected_index];
+                    let mut summary_lines = vec![Line::from(Span::styled(
+                        format!("Selected: {}", current.title),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ))];
+                    if let Some(description) = current.description.as_ref() {
+                        if !description.is_empty() && description != &current.title {
+                            summary_lines.push(Line::from(Span::styled(
+                                description.clone(),
+                                Style::default().fg(Color::Gray),
+                            )));
+                        }
+                    }
+                    summary_lines.push(Line::from(Span::raw(CONTROLS_HINT)));
+                    summary_lines.push(Line::from(Span::styled(
+                        NUMBER_JUMP_HINT,
+                        Style::default().fg(Color::Gray),
+                    )));
+
+                    let footer = Paragraph::new(summary_lines)
+                        .block(
+                            Block::default()
+                                .title("Selection")
+                                .borders(Borders::ALL)
+                                .border_type(BorderType::Rounded),
+                        )
+                        .wrap(Wrap { trim: true });
+                    frame.render_widget(footer, layout[2]);
+                })
+                .with_context(|| format!("Failed to draw {title} selector UI"))?;
+
+            match event::read()
+                .with_context(|| format!("Failed to read terminal input for {title} selector"))?
+            {
+                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        if selected_index == 0 {
+                            selected_index = total - 1;
+                        } else {
+                            selected_index -= 1;
+                        }
+                        number_buffer.clear();
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        selected_index = (selected_index + 1) % total;
+                        number_buffer.clear();
+                    }
+                    KeyCode::Home => {
+                        selected_index = 0;
+                        number_buffer.clear();
+                    }
+                    KeyCode::End => {
+                        selected_index = total - 1;
+                        number_buffer.clear();
+                    }
+                    KeyCode::PageUp => {
+                        let step = 5.min(total - 1);
+                        if selected_index < step {
+                            selected_index = 0;
+                        } else {
+                            selected_index -= step;
+                        }
+                        number_buffer.clear();
+                    }
+                    KeyCode::PageDown => {
+                        let step = 5.min(total - 1);
+                        selected_index = (selected_index + step).min(total - 1);
+                        number_buffer.clear();
+                    }
+                    KeyCode::Enter => return Ok(Some(selected_index)),
+                    KeyCode::Esc => return Ok(None),
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        return Err(SelectionInterrupted.into());
+                    }
+                    KeyCode::Char(c) if c.is_ascii_digit() => {
+                        number_buffer.push(c);
+                        if let Ok(index) = number_buffer.parse::<usize>() {
+                            if (1..=total).contains(&index) {
+                                selected_index = index - 1;
+                            }
+                        }
+                        if number_buffer.len() >= total.to_string().len() {
+                            number_buffer.clear();
+                        }
+                    }
+                    KeyCode::Backspace => {
+                        number_buffer.pop();
+                    }
+                    _ => {}
+                },
+                Event::Resize(_, _) => {
+                    number_buffer.clear();
+                }
+                _ => {}
+            }
+        }
+    })();
+
+    let cleanup_result = terminal_guard.restore_with_terminal(&mut terminal);
+    cleanup_result?;
+    selection_result
+}
+
+struct TerminalModeGuard {
+    label: String,
+    raw_mode_enabled: bool,
+    alternate_screen: bool,
+    cursor_hidden: bool,
+}
+
+impl TerminalModeGuard {
+    fn new(label: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            raw_mode_enabled: false,
+            alternate_screen: false,
+            cursor_hidden: false,
+        }
+    }
+
+    fn enable_raw_mode(&mut self) -> Result<()> {
+        enable_raw_mode()
+            .with_context(|| format!("Failed to enable raw mode for {} selector", self.label))?;
+        self.raw_mode_enabled = true;
+        Ok(())
+    }
+
+    fn enter_alternate_screen(&mut self, stdout: &mut io::Stdout) -> Result<()> {
+        execute!(stdout, EnterAlternateScreen).with_context(|| {
+            format!(
+                "Failed to enter alternate screen for {} selector",
+                self.label
+            )
+        })?;
+        self.alternate_screen = true;
+        Ok(())
+    }
+
+    fn hide_cursor(&mut self, terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+        terminal
+            .hide_cursor()
+            .with_context(|| format!("Failed to hide cursor for {} selector", self.label))?;
+        self.cursor_hidden = true;
+        Ok(())
+    }
+
+    fn restore_with_terminal(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    ) -> Result<()> {
+        if self.raw_mode_enabled {
+            disable_raw_mode().with_context(|| {
+                format!("Failed to disable raw mode after {} selector", self.label)
+            })?;
+            self.raw_mode_enabled = false;
+        }
+
+        if self.alternate_screen {
+            execute!(terminal.backend_mut(), LeaveAlternateScreen).with_context(|| {
+                format!(
+                    "Failed to leave alternate screen after {} selector",
+                    self.label
+                )
+            })?;
+            self.alternate_screen = false;
+        }
+
+        if self.cursor_hidden {
+            terminal
+                .show_cursor()
+                .with_context(|| format!("Failed to show cursor after {} selector", self.label))?;
+            self.cursor_hidden = false;
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for TerminalModeGuard {
+    fn drop(&mut self) {
+        if self.raw_mode_enabled {
+            let _ = disable_raw_mode();
+            self.raw_mode_enabled = false;
+        }
+
+        if self.alternate_screen {
+            let mut stdout = io::stdout();
+            let _ = execute!(stdout, LeaveAlternateScreen);
+            self.alternate_screen = false;
+        }
+
+        if self.cursor_hidden {
+            let mut stdout = io::stdout();
+            let _ = execute!(stdout, Show);
+            self.cursor_hidden = false;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@
 //! For the core library functionality, see [`vtcode-core`](https://docs.rs/vtcode-core).
 
 pub mod acp;
+pub mod interactive_list;
 mod workspace_trust;
 
 pub mod startup;

--- a/src/startup/first_run.rs
+++ b/src/startup/first_run.rs
@@ -1,23 +1,11 @@
 use std::collections::HashSet;
 use std::fmt;
 use std::fs;
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, Write};
 use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow};
-use crossterm::cursor::Show;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
-use crossterm::execute;
-use crossterm::terminal::{
-    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
-};
-use ratatui::Terminal;
-use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Direction, Layout};
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph, Wrap};
 use std::time::{SystemTime, UNIX_EPOCH};
 use vtcode_core::cli::args::{Cli, Commands};
 use vtcode_core::config::constants::{model_helpers, models};
@@ -27,6 +15,8 @@ use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
 
 use vtcode_core::utils::dot_config::{WorkspaceTrustLevel, WorkspaceTrustRecord, get_dot_manager};
 use vtcode_core::{initialize_dot_folder, update_model_preference};
+
+use crate::interactive_list::{SelectionEntry, SelectionInterrupted, run_interactive_selection};
 
 /// Drive the first-run interactive setup wizard when a workspace lacks VT Code artifacts.
 pub fn maybe_run_first_run_setup(
@@ -284,10 +274,7 @@ fn select_provider_with_ratatui(providers: &[Provider], default: Provider) -> Re
         .iter()
         .enumerate()
         .map(|(index, provider)| {
-            SelectionEntry::new(
-                format!("{:>2}. {}", index + 1, provider.label()),
-                provider.label().to_string(),
-            )
+            SelectionEntry::new(format!("{:>2}. {}", index + 1, provider.label()), None)
         })
         .collect();
 
@@ -301,8 +288,17 @@ fn select_provider_with_ratatui(providers: &[Provider], default: Provider) -> Re
         default.label()
     );
 
-    let selected_index =
-        run_ratatui_selection("Providers", &instructions, &entries, default_index)?;
+    let selection = run_interactive_selection("Providers", &instructions, &entries, default_index);
+    let selected_index = match selection {
+        Ok(Some(index)) => index,
+        Ok(None) => default_index.min(entries.len() - 1),
+        Err(err) => {
+            if err.is::<SelectionInterrupted>() {
+                return Err(SetupInterrupted.into());
+            }
+            return Err(err);
+        }
+    };
     Ok(providers[selected_index])
 }
 
@@ -316,276 +312,6 @@ impl fmt::Display for SetupInterrupted {
 }
 
 impl std::error::Error for SetupInterrupted {}
-
-#[derive(Debug, Clone)]
-struct SelectionEntry {
-    display: String,
-    summary: String,
-}
-
-impl SelectionEntry {
-    fn new(display: String, summary: String) -> Self {
-        Self { display, summary }
-    }
-}
-
-fn run_ratatui_selection(
-    title: &str,
-    instructions: &str,
-    entries: &[SelectionEntry],
-    default_index: usize,
-) -> Result<usize> {
-    if entries.is_empty() {
-        return Err(anyhow!("No options available for selection"));
-    }
-
-    if !io::stdout().is_terminal() {
-        return Err(anyhow!("Terminal UI is unavailable"));
-    }
-
-    let mut stdout = io::stdout();
-    let mut terminal_guard = TerminalModeGuard::new(title);
-    terminal_guard.enable_raw_mode()?;
-    terminal_guard.enter_alternate_screen(&mut stdout)?;
-
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)
-        .with_context(|| format!("Failed to initialize Ratatui terminal for {title} selector"))?;
-    terminal_guard.hide_cursor(&mut terminal)?;
-
-    let selection_result = (|| -> Result<usize> {
-        let total = entries.len();
-        let mut selected_index = default_index.min(total.saturating_sub(1));
-
-        loop {
-            terminal
-                .draw(|frame| {
-                    let area = frame.area();
-                    let instruction_lines = instructions.lines().count().max(1) as u16;
-                    let instruction_height = instruction_lines.saturating_add(2);
-                    let footer_height: u16 = 4;
-                    let layout = Layout::default()
-                        .direction(Direction::Vertical)
-                        .margin(1)
-                        .constraints([
-                            Constraint::Length(instruction_height.min(
-                                area.height.saturating_sub(footer_height + 3)
-                            )),
-                            Constraint::Min(5),
-                            Constraint::Length(footer_height),
-                        ])
-                        .split(area);
-
-                    let instructions = Paragraph::new(instructions)
-                        .block(
-                            Block::default()
-                                .title("Instructions")
-                                .borders(Borders::ALL)
-                                .border_type(BorderType::Rounded),
-                        )
-                        .wrap(Wrap { trim: true });
-                    frame.render_widget(instructions, layout[0]);
-
-                    let items: Vec<ListItem> = entries
-                        .iter()
-                        .map(|entry| {
-                            let mut lines = vec![Line::from(entry.display.clone())];
-                            if entry.summary != entry.display && !entry.summary.is_empty() {
-                                lines.push(Line::from(Span::styled(
-                                    entry.summary.clone(),
-                                    Style::default().fg(Color::Gray),
-                                )));
-                            }
-                            ListItem::new(lines)
-                        })
-                        .collect();
-
-                    let list = List::new(items)
-                        .block(
-                            Block::default()
-                                .title(title)
-                                .borders(Borders::ALL)
-                                .border_type(BorderType::Rounded),
-                        )
-                        .highlight_style(
-                            Style::default()
-                                .fg(Color::Cyan)
-                                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
-                        )
-                        .highlight_symbol("▸ ")
-                        .repeat_highlight_symbol(true);
-
-                    let mut state = ListState::default();
-                    state.select(Some(selected_index));
-                    frame.render_stateful_widget(list, layout[1], &mut state);
-
-                    let current = &entries[selected_index];
-                    let mut summary_lines = vec![Line::from(Span::styled(
-                        format!("Selected: {}", current.display),
-                        Style::default().add_modifier(Modifier::BOLD),
-                    ))];
-                    if current.summary != current.display && !current.summary.is_empty() {
-                        summary_lines.push(Line::from(Span::styled(
-                            current.summary.clone(),
-                            Style::default().fg(Color::Gray),
-                        )));
-                    }
-                    summary_lines.push(Line::from(Span::raw(
-                        "Controls: ↑/↓ or j/k to move • Enter to confirm • Esc to cancel • Type a number to jump",
-                    )));
-                    let footer = Paragraph::new(summary_lines)
-                        .block(
-                            Block::default()
-                                .title("Selection")
-                                .borders(Borders::ALL)
-                                .border_type(BorderType::Rounded),
-                        )
-                        .wrap(Wrap { trim: true });
-                    frame.render_widget(footer, layout[2]);
-                })
-                .with_context(|| format!("Failed to draw {title} selector UI"))?;
-
-            match event::read()
-                .with_context(|| format!("Failed to read terminal input for {title} selector"))?
-            {
-                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        if selected_index == 0 {
-                            selected_index = total - 1;
-                        } else {
-                            selected_index -= 1;
-                        }
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        selected_index = (selected_index + 1) % total;
-                    }
-                    KeyCode::Home => selected_index = 0,
-                    KeyCode::End => selected_index = total - 1,
-                    KeyCode::Enter => return Ok(selected_index),
-                    KeyCode::Esc => return Ok(default_index.min(total - 1)),
-                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        return Err(SetupInterrupted.into());
-                    }
-                    KeyCode::Char(c) => {
-                        if let Some(index) = c
-                            .to_digit(10)
-                            .map(|digit| digit as usize)
-                            .filter(|index| (1..=total).contains(index))
-                        {
-                            selected_index = index - 1;
-                        }
-                    }
-                    _ => {}
-                },
-                _ => {}
-            }
-        }
-    })();
-
-    let cleanup_result = terminal_guard.restore_with_terminal(&mut terminal);
-    cleanup_result?;
-    selection_result
-}
-
-struct TerminalModeGuard {
-    label: String,
-    raw_mode_enabled: bool,
-    alternate_screen: bool,
-    cursor_hidden: bool,
-}
-
-impl TerminalModeGuard {
-    fn new(label: &str) -> Self {
-        Self {
-            label: label.to_string(),
-            raw_mode_enabled: false,
-            alternate_screen: false,
-            cursor_hidden: false,
-        }
-    }
-
-    fn enable_raw_mode(&mut self) -> Result<()> {
-        enable_raw_mode()
-            .with_context(|| format!("Failed to enable raw mode for {} selector", self.label))?;
-        self.raw_mode_enabled = true;
-        Ok(())
-    }
-
-    fn enter_alternate_screen(&mut self, stdout: &mut io::Stdout) -> Result<()> {
-        execute!(stdout, EnterAlternateScreen).with_context(|| {
-            format!(
-                "Failed to enter alternate screen for {} selector",
-                self.label
-            )
-        })?;
-        self.alternate_screen = true;
-        Ok(())
-    }
-
-    fn hide_cursor(&mut self, terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
-        terminal
-            .hide_cursor()
-            .with_context(|| format!("Failed to hide cursor for {} selector", self.label))?;
-        self.cursor_hidden = true;
-        Ok(())
-    }
-
-    fn restore_with_terminal(
-        &mut self,
-        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    ) -> Result<()> {
-        if self.raw_mode_enabled {
-            disable_raw_mode().with_context(|| {
-                format!("Failed to disable raw mode after {} selector", self.label)
-            })?;
-            self.raw_mode_enabled = false;
-        }
-
-        if self.alternate_screen {
-            execute!(terminal.backend_mut(), LeaveAlternateScreen).with_context(|| {
-                format!(
-                    "Failed to leave alternate screen after {} selector",
-                    self.label
-                )
-            })?;
-            self.alternate_screen = false;
-        }
-
-        if self.cursor_hidden {
-            terminal
-                .show_cursor()
-                .with_context(|| format!("Failed to show cursor after {} selector", self.label))?;
-            self.cursor_hidden = false;
-        }
-
-        Ok(())
-    }
-
-    fn restore_without_terminal(&mut self) {
-        if self.raw_mode_enabled {
-            let _ = disable_raw_mode();
-            self.raw_mode_enabled = false;
-        }
-
-        if self.alternate_screen {
-            let mut stdout = io::stdout();
-            let _ = execute!(stdout, LeaveAlternateScreen);
-            self.alternate_screen = false;
-        }
-
-        if self.cursor_hidden {
-            let mut stdout = io::stdout();
-            let _ = execute!(stdout, Show);
-            self.cursor_hidden = false;
-        }
-    }
-}
-
-impl Drop for TerminalModeGuard {
-    fn drop(&mut self) {
-        self.restore_without_terminal();
-    }
-}
 
 fn prompt_model(
     renderer: &mut AnsiRenderer,
@@ -690,9 +416,7 @@ fn select_model_with_ratatui(options: &[String], default_model: &'static str) ->
     let entries: Vec<SelectionEntry> = options
         .iter()
         .enumerate()
-        .map(|(index, model)| {
-            SelectionEntry::new(format!("{:>2}. {}", index + 1, model), model.clone())
-        })
+        .map(|(index, model)| SelectionEntry::new(format!("{:>2}. {}", index + 1, model), None))
         .collect();
 
     let default_index = options
@@ -705,8 +429,19 @@ fn select_model_with_ratatui(options: &[String], default_model: &'static str) ->
         default_model
     );
 
-    let selected_index = run_ratatui_selection("Models", &instructions, &entries, default_index)?;
-    Ok(entries[selected_index].summary.clone())
+    let selection = run_interactive_selection("Models", &instructions, &entries, default_index);
+    let selected_index = match selection {
+        Ok(Some(index)) => index,
+        Ok(None) => default_index.min(entries.len() - 1),
+        Err(err) => {
+            if err.is::<SelectionInterrupted>() {
+                return Err(SetupInterrupted.into());
+            }
+            return Err(err);
+        }
+    };
+
+    Ok(options[selected_index].clone())
 }
 
 fn prompt_model_text(
@@ -782,14 +517,17 @@ fn select_trust_with_ratatui(default: WorkspaceTrustLevel) -> Result<WorkspaceTr
             SelectionEntry::new(
                 " 1. Tools policy – prompts before running elevated actions (recommended)"
                     .to_string(),
-                "Tools policy – prompts before running elevated actions (recommended)".to_string(),
+                Some(
+                    "Tools policy – prompts before running elevated actions (recommended)"
+                        .to_string(),
+                ),
             ),
         ),
         (
             WorkspaceTrustLevel::FullAuto,
             SelectionEntry::new(
                 " 2. Full auto – allow unattended execution without prompts".to_string(),
-                "Full auto – allow unattended execution without prompts".to_string(),
+                Some("Full auto – allow unattended execution without prompts".to_string()),
             ),
         ),
     ]);
@@ -801,18 +539,32 @@ fn select_trust_with_ratatui(default: WorkspaceTrustLevel) -> Result<WorkspaceTr
 
     let selection_entries: Vec<SelectionEntry> =
         entries.iter().map(|(_, entry)| entry.clone()).collect();
-    let default_summary = &selection_entries[default_index].summary;
+    let default_entry = &selection_entries[default_index];
+    let default_summary = default_entry
+        .description
+        .as_deref()
+        .unwrap_or(default_entry.title.as_str());
     let instructions = format!(
         "Default: {}. Use ↑/↓ or j/k to choose, Enter to confirm, Esc to keep the default.",
         default_summary
     );
 
-    let selected_index = run_ratatui_selection(
+    let selection = run_interactive_selection(
         "Workspace trust",
         &instructions,
         &selection_entries,
         default_index,
-    )?;
+    );
+    let selected_index = match selection {
+        Ok(Some(index)) => index,
+        Ok(None) => default_index,
+        Err(err) => {
+            if err.is::<SelectionInterrupted>() {
+                return Err(SetupInterrupted.into());
+            }
+            return Err(err);
+        }
+    };
     Ok(entries[selected_index].0)
 }
 

--- a/vtcode-core/prompts/custom/generate-agent-file.md
+++ b/vtcode-core/prompts/custom/generate-agent-file.md
@@ -1,0 +1,10 @@
+# Generate Agent File
+
+Please analyze this codebase and create an AGENTS.md file containing:
+1. Build/lint/test commands - especially for running a single test
+2. Architecture and codebase structure information, including important subprojects, internal APIs, databases, etc.
+3. Code style guidelines, including imports, conventions, formatting, types, naming conventions, error handling, etc.
+
+The file you create will be given to agentic coding tools (such as yourself) that operate in this repository. Make it about 20 lines long.
+
+If there are Cursor rules (in .cursor/rules/ or .cursorrules), Claude rules (CLAUDE.md), Windsurf rules (.windsurfrules), Cline rules (.clinerules), Goose rules (.goosehints), or Copilot rules (in .github/copilot-instructions.md), make sure to include them. Also, first check if there is an existing AGENTS.md or AGENT.md file, and if so, update it instead of overwriting it.

--- a/vtcode-core/src/config/loader/mod.rs
+++ b/vtcode-core/src/config/loader/mod.rs
@@ -1023,37 +1023,39 @@ impl ConfigManager {
     /// Persist configuration to a specific path, preserving comments
     pub fn save_config_to_path(path: impl AsRef<Path>, config: &VTCodeConfig) -> Result<()> {
         let path = path.as_ref();
-        
+
         // If file exists, preserve comments by using toml_edit
         if path.exists() {
             let original_content = fs::read_to_string(path)
                 .with_context(|| format!("Failed to read existing config: {}", path.display()))?;
-            
-            let mut doc = original_content.parse::<toml_edit::DocumentMut>()
+
+            let mut doc = original_content
+                .parse::<toml_edit::DocumentMut>()
                 .with_context(|| format!("Failed to parse existing config: {}", path.display()))?;
-            
+
             // Serialize new config to TOML value
-            let new_value = toml::to_string_pretty(config)
-                .context("Failed to serialize configuration")?;
-            let new_doc: toml_edit::DocumentMut = new_value.parse()
+            let new_value =
+                toml::to_string_pretty(config).context("Failed to serialize configuration")?;
+            let new_doc: toml_edit::DocumentMut = new_value
+                .parse()
                 .context("Failed to parse serialized configuration")?;
-            
+
             // Update values while preserving structure and comments
             Self::merge_toml_documents(&mut doc, &new_doc);
-            
+
             fs::write(path, doc.to_string())
                 .with_context(|| format!("Failed to write config file: {}", path.display()))?;
         } else {
             // New file, just write normally
-            let content = toml::to_string_pretty(config)
-                .context("Failed to serialize configuration")?;
+            let content =
+                toml::to_string_pretty(config).context("Failed to serialize configuration")?;
             fs::write(path, content)
                 .with_context(|| format!("Failed to write config file: {}", path.display()))?;
         }
-        
+
         Ok(())
     }
-    
+
     /// Merge TOML documents, preserving comments and structure from original
     fn merge_toml_documents(original: &mut toml_edit::DocumentMut, new: &toml_edit::DocumentMut) {
         for (key, new_value) in new.iter() {
@@ -1064,7 +1066,7 @@ impl ConfigManager {
             }
         }
     }
-    
+
     /// Recursively merge TOML items
     fn merge_toml_items(original: &mut toml_edit::Item, new: &toml_edit::Item) {
         match (original, new) {
@@ -1150,7 +1152,7 @@ mod tests {
     #[test]
     fn save_config_preserves_comments() {
         use std::io::Write;
-        
+
         let mut temp_file = NamedTempFile::new().expect("failed to create temp file");
         let config_with_comments = r#"# This is a test comment
 [agent]
@@ -1162,32 +1164,40 @@ default_model = "gpt-5-nano"
 [tools]
 default_policy = "prompt"
 "#;
-        
+
         write!(temp_file, "{}", config_with_comments).expect("failed to write temp config");
         temp_file.flush().expect("failed to flush");
-        
+
         // Load config
-        let manager = ConfigManager::load_from_file(temp_file.path())
-            .expect("failed to load config");
-        
+        let manager =
+            ConfigManager::load_from_file(temp_file.path()).expect("failed to load config");
+
         // Modify and save
         let mut modified_config = manager.config().clone();
         modified_config.agent.default_model = "gpt-5".to_string();
-        
+
         ConfigManager::save_config_to_path(temp_file.path(), &modified_config)
             .expect("failed to save config");
-        
+
         // Read back and verify comments are preserved
-        let saved_content = fs::read_to_string(temp_file.path())
-            .expect("failed to read saved config");
-        
-        assert!(saved_content.contains("# This is a test comment"), 
-            "top-level comment should be preserved");
-        assert!(saved_content.contains("# Provider comment"), 
-            "inline comment should be preserved");
-        assert!(saved_content.contains("# Tools section comment"), 
-            "section comment should be preserved");
-        assert!(saved_content.contains("gpt-5"), 
-            "modified value should be present");
+        let saved_content =
+            fs::read_to_string(temp_file.path()).expect("failed to read saved config");
+
+        assert!(
+            saved_content.contains("# This is a test comment"),
+            "top-level comment should be preserved"
+        );
+        assert!(
+            saved_content.contains("# Provider comment"),
+            "inline comment should be preserved"
+        );
+        assert!(
+            saved_content.contains("# Tools section comment"),
+            "section comment should be preserved"
+        );
+        assert!(
+            saved_content.contains("gpt-5"),
+            "modified value should be present"
+        );
     }
 }

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -548,8 +548,12 @@ impl ModelId {
             ModelId::GPT5Mini => "Latest efficient OpenAI model, great for most tasks",
             ModelId::GPT5Nano => "Latest most cost-effective OpenAI model",
             ModelId::CodexMiniLatest => "Latest Codex model optimized for code generation",
-            ModelId::OpenAIGptOss20b => "OpenAI's open-source 20B parameter GPT-OSS model using harmony tokenization",
-            ModelId::OpenAIGptOss120b => "OpenAI's open-source 120B parameter GPT-OSS model using harmony tokenization",
+            ModelId::OpenAIGptOss20b => {
+                "OpenAI's open-source 20B parameter GPT-OSS model using harmony tokenization"
+            }
+            ModelId::OpenAIGptOss120b => {
+                "OpenAI's open-source 120B parameter GPT-OSS model using harmony tokenization"
+            }
             // Anthropic models
             ModelId::ClaudeOpus41 => "Latest most capable Anthropic model with advanced reasoning",
             ModelId::ClaudeSonnet45 => "Latest balanced Anthropic model for general tasks",
@@ -1495,7 +1499,7 @@ mod tests {
 
         for entry in openrouter_generated::ENTRIES {
             assert_eq!(entry.variant.generation(), entry.generation);
-               }
+        }
     }
 
     #[test]

--- a/vtcode.toml
+++ b/vtcode.toml
@@ -100,7 +100,7 @@ recommended_actions = [
 enabled = true
 
 # Directory where custom prompt files are stored
-directory = "~/.vtcode/prompts"
+directory = ".vtcode/prompts"
 
 # Additional directories to search for custom prompts
 extra_directories = []


### PR DESCRIPTION
## Summary
- introduce Ratatui-backed helper widgets for tool output rendering
- render plan, code block, and terminal panels using the new panel pipeline
- convert MessageStyle colors into Ratatui styles for terminal rendering

## Testing
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f64fb453048323b05bfee31846e08f