### PR TITLE
Add sandbox runtime integration for bash tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5372,6 +5372,7 @@ dependencies = [
  "vtcode-acp-client",
  "vtcode-core",
  "walkdir",
+ "which",
  "windows-sys 0.59.0",
 ]
 
@@ -5672,6 +5673,19 @@ name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
+name = "which"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ shell-words = "1.1"
 dialoguer = "0.11"
 crossterm = "0.27"
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+which = "5.0"
 
 [features]
 default = ["tool-chat"]

--- a/src/agent/runloop/mod.rs
+++ b/src/agent/runloop/mod.rs
@@ -11,6 +11,7 @@ mod git;
 mod mcp_events;
 mod model_picker;
 mod prompt;
+mod sandbox;
 mod slash_commands;
 mod telemetry;
 mod text_tools;

--- a/src/agent/runloop/sandbox.rs
+++ b/src/agent/runloop/sandbox.rs
@@ -1,0 +1,347 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::json;
+use vtcode_core::sandbox::SandboxProfile;
+use vtcode_core::tools::ToolRegistry;
+use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
+use which::which;
+
+use super::slash_commands::SandboxAction;
+
+const DEFAULT_DENY_RULES: &[&str] = &[
+    "Read(~/.ssh)",
+    "Read(/etc/ssh)",
+    "Read(/root)",
+    "Read(/etc/shadow)",
+];
+
+/// Coordinates runtime sandbox configuration for the Bash tool.
+pub(crate) struct SandboxCoordinator {
+    workspace_root: PathBuf,
+    settings_path: PathBuf,
+    allowed_domains: BTreeSet<String>,
+    deny_rules: BTreeSet<String>,
+    profile: Option<SandboxProfile>,
+    runtime_path: Option<PathBuf>,
+}
+
+impl SandboxCoordinator {
+    pub(crate) fn new(workspace_root: PathBuf) -> Self {
+        let settings_path = workspace_root
+            .join(".vtcode")
+            .join("sandbox")
+            .join("settings.json");
+        let deny_rules = DEFAULT_DENY_RULES
+            .iter()
+            .map(|entry| entry.to_string())
+            .collect();
+        Self {
+            workspace_root,
+            settings_path,
+            allowed_domains: BTreeSet::new(),
+            deny_rules,
+            profile: None,
+            runtime_path: None,
+        }
+    }
+
+    pub(crate) fn handle_action(
+        &mut self,
+        action: SandboxAction,
+        renderer: &mut AnsiRenderer,
+        registry: &mut ToolRegistry,
+    ) -> Result<()> {
+        match action {
+            SandboxAction::Toggle => {
+                if self.is_enabled() {
+                    self.disable(registry, renderer)?;
+                } else {
+                    self.enable(registry, renderer)?;
+                }
+            }
+            SandboxAction::Enable => {
+                if self.is_enabled() {
+                    renderer.line(
+                        MessageStyle::Info,
+                        "Sandbox is already enabled for bash commands.",
+                    )?;
+                } else {
+                    self.enable(registry, renderer)?;
+                }
+            }
+            SandboxAction::Disable => {
+                if self.is_enabled() {
+                    self.disable(registry, renderer)?;
+                } else {
+                    renderer.line(MessageStyle::Info, "Sandbox is already disabled.")?;
+                }
+            }
+            SandboxAction::Status => {
+                self.render_status(renderer)?;
+            }
+            SandboxAction::AllowDomain(domain) => {
+                self.add_domain(&domain, renderer)?;
+                self.sync_settings()?;
+                if self.is_enabled() {
+                    registry.set_bash_sandbox(self.profile.clone());
+                    renderer.line(
+                        MessageStyle::Info,
+                        "Sandbox configuration updated; the allowlist change applies to the next command.",
+                    )?;
+                }
+            }
+            SandboxAction::RemoveDomain(domain) => {
+                self.remove_domain(&domain, renderer)?;
+                self.sync_settings()?;
+                if self.is_enabled() {
+                    registry.set_bash_sandbox(self.profile.clone());
+                    renderer.line(
+                        MessageStyle::Info,
+                        "Sandbox configuration updated; the allowlist change applies to the next command.",
+                    )?;
+                }
+            }
+            SandboxAction::Help => {
+                self.render_help(renderer)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn enable(&mut self, registry: &mut ToolRegistry, renderer: &mut AnsiRenderer) -> Result<()> {
+        self.sync_settings()?;
+        let binary_path = self.resolve_runtime()?;
+        let profile = SandboxProfile::new(binary_path.clone(), self.settings_path.clone());
+        self.profile = Some(profile);
+        self.runtime_path = Some(binary_path);
+        registry.set_bash_sandbox(self.profile.clone());
+        renderer.line(
+            MessageStyle::Info,
+            "Sandboxing enabled for bash tool. Network access now requires /sandbox allow-domain <domain>.",
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            &format!("Sandbox settings: {}", self.settings_path.display()),
+        )?;
+        if let Some(runtime) = &self.runtime_path {
+            renderer.line(
+                MessageStyle::Info,
+                &format!("Sandbox runtime: {}", runtime.display()),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn disable(&mut self, registry: &mut ToolRegistry, renderer: &mut AnsiRenderer) -> Result<()> {
+        self.profile = None;
+        registry.set_bash_sandbox(None);
+        renderer.line(MessageStyle::Info, "Sandboxing disabled for bash tool.")?;
+        Ok(())
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.profile.is_some()
+    }
+
+    fn resolve_runtime(&self) -> Result<PathBuf> {
+        if let Some(path) = std::env::var_os("SRT_PATH") {
+            let candidate = PathBuf::from(path);
+            return Ok(candidate);
+        }
+        which("srt").context("Anthropic sandbox runtime 'srt' was not found in PATH. Install via `npm install -g @anthropic-ai/sandbox-runtime`." )
+            .map(PathBuf::from)
+    }
+
+    fn add_domain(&mut self, domain: &str, renderer: &mut AnsiRenderer) -> Result<()> {
+        let normalized = domain.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            return Err(anyhow!("Domain cannot be empty."));
+        }
+        if normalized.chars().any(char::is_whitespace) {
+            return Err(anyhow!("Domain names cannot contain whitespace."));
+        }
+        if self.allowed_domains.insert(normalized.clone()) {
+            renderer.line(
+                MessageStyle::Info,
+                &format!("Added '{}' to sandbox network allowlist.", normalized),
+            )?;
+        } else {
+            renderer.line(
+                MessageStyle::Info,
+                &format!("Domain '{}' is already permitted.", normalized),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn remove_domain(&mut self, domain: &str, renderer: &mut AnsiRenderer) -> Result<()> {
+        let normalized = domain.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            return Err(anyhow!("Domain cannot be empty."));
+        }
+        if self.allowed_domains.remove(&normalized) {
+            renderer.line(
+                MessageStyle::Info,
+                &format!("Removed '{}' from sandbox network allowlist.", normalized),
+            )?;
+        } else {
+            renderer.line(
+                MessageStyle::Info,
+                &format!("Domain '{}' was not present in the allowlist.", normalized),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn render_status(&self, renderer: &mut AnsiRenderer) -> Result<()> {
+        renderer.line(
+            MessageStyle::Info,
+            &format!(
+                "Sandbox status: {}",
+                if self.is_enabled() {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            ),
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            &format!("Settings file: {}", self.settings_path.display()),
+        )?;
+        if let Some(path) = &self.runtime_path {
+            renderer.line(
+                MessageStyle::Info,
+                &format!("Runtime binary: {}", path.display()),
+            )?;
+        } else {
+            renderer.line(
+                MessageStyle::Info,
+                "Runtime binary: pending detection (enable sandbox to resolve)",
+            )?;
+        }
+        if self.allowed_domains.is_empty() {
+            renderer.line(
+                MessageStyle::Info,
+                "Network allowlist: none (all outbound requests blocked)",
+            )?;
+        } else {
+            renderer.line(
+                MessageStyle::Info,
+                &format!(
+                    "Network allowlist: {}",
+                    self.allowed_domains
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            )?;
+        }
+        renderer.line(
+            MessageStyle::Info,
+            &format!(
+                "Default read restrictions: {}",
+                self.deny_rules
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            "Use /sandbox allow-domain <domain> or /sandbox remove-domain <domain> to manage network access.",
+        )?;
+        Ok(())
+    }
+
+    fn render_help(&self, renderer: &mut AnsiRenderer) -> Result<()> {
+        renderer.line(MessageStyle::Info, "Sandbox command usage:")?;
+        renderer.line(
+            MessageStyle::Info,
+            "  /sandbox                 Toggle sandboxing on or off",
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            "  /sandbox status          Show current sandbox configuration",
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            "  /sandbox enable          Enable sandboxing explicitly",
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            "  /sandbox disable         Disable sandboxing",
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            "  /sandbox allow-domain <domain>   Permit outbound requests to a domain",
+        )?;
+        renderer.line(
+            MessageStyle::Info,
+            "  /sandbox remove-domain <domain>  Revoke previously allowed domain",
+        )?;
+        Ok(())
+    }
+
+    fn sync_settings(&self) -> Result<()> {
+        let parent = self
+            .settings_path
+            .parent()
+            .context("sandbox settings path missing parent directory")?;
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create sandbox configuration directory at {}",
+                parent.display()
+            )
+        })?;
+        let allow_rules = self.build_allow_rules();
+        let deny_rules = self.build_deny_rules();
+        let config = json!({
+            "sandbox": {
+                "enabled": true,
+            },
+            "permissions": {
+                "allow": allow_rules,
+                "deny": deny_rules,
+            },
+        });
+        fs::write(&self.settings_path, serde_json::to_string_pretty(&config)?).with_context(
+            || {
+                format!(
+                    "failed to write sandbox settings to {}",
+                    self.settings_path.display()
+                )
+            },
+        )?;
+        Ok(())
+    }
+
+    fn build_allow_rules(&self) -> Vec<String> {
+        let mut rules: BTreeSet<String> = BTreeSet::new();
+        let workspace = self.canonical_workspace();
+        rules.insert(format!("Edit({})", workspace.display()));
+        rules.insert(format!("Read({})", workspace.display()));
+        rules.insert("Read(.)".to_string());
+        for domain in &self.allowed_domains {
+            rules.insert(format!("WebFetch(domain:{})", domain));
+        }
+        rules.into_iter().collect()
+    }
+
+    fn build_deny_rules(&self) -> Vec<String> {
+        self.deny_rules.iter().cloned().collect()
+    }
+
+    fn canonical_workspace(&self) -> PathBuf {
+        match self.workspace_root.canonicalize() {
+            Ok(path) => path,
+            Err(_) => self.workspace_root.clone(),
+        }
+    }
+}

--- a/src/agent/runloop/sandbox.rs
+++ b/src/agent/runloop/sandbox.rs
@@ -152,7 +152,9 @@ impl SandboxCoordinator {
             let candidate = PathBuf::from(path);
             return Ok(candidate);
         }
-        which("srt").context("Anthropic sandbox runtime 'srt' was not found in PATH. Install via `npm install -g @anthropic-ai/sandbox-runtime`." )
+        which("srt").context(
+            "Anthropic sandbox runtime 'srt' was not found in PATH. Install via `npm install -g @anthropic-ai/sandbox-runtime`.",
+        )
             .map(PathBuf::from)
     }
 

--- a/src/agent/runloop/slash_commands.rs
+++ b/src/agent/runloop/slash_commands.rs
@@ -51,6 +51,9 @@ pub enum SlashCommandOutcome {
     ManageWorkspaceDirectories {
         command: WorkspaceDirectoryCommand,
     },
+    ManageSandbox {
+        action: SandboxAction,
+    },
     SubmitPrompt {
         prompt: String,
     },
@@ -71,6 +74,17 @@ pub enum WorkspaceDirectoryCommand {
     Add(Vec<String>),
     List,
     Remove(Vec<String>),
+}
+
+#[derive(Clone, Debug)]
+pub enum SandboxAction {
+    Toggle,
+    Enable,
+    Disable,
+    Status,
+    AllowDomain(String),
+    RemoveDomain(String),
+    Help,
 }
 
 pub fn handle_slash_command(
@@ -96,6 +110,13 @@ pub fn handle_slash_command(
             render_custom_prompt_list(renderer, custom_prompts)?;
             Ok(SlashCommandOutcome::Handled)
         }
+        "sandbox" => match parse_sandbox_action(args) {
+            Ok(action) => Ok(SlashCommandOutcome::ManageSandbox { action }),
+            Err(message) => {
+                renderer.line(MessageStyle::Error, &message)?;
+                Ok(SlashCommandOutcome::Handled)
+            }
+        },
         "theme" => {
             let mut tokens = args.split_whitespace();
             if let Some(next_theme) = tokens.next() {
@@ -606,6 +627,42 @@ fn render_prompt_summary(renderer: &mut AnsiRenderer, prompt: &CustomPrompt) -> 
     }
 
     Ok(())
+}
+
+fn parse_sandbox_action(args: &str) -> std::result::Result<SandboxAction, String> {
+    let trimmed = args.trim();
+    if trimmed.is_empty() {
+        return Ok(SandboxAction::Toggle);
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    let keyword = parts.next().unwrap_or_default();
+    let remainder = trimmed[keyword.len()..].trim();
+
+    match keyword {
+        "status" | "--status" => Ok(SandboxAction::Status),
+        "enable" | "on" => Ok(SandboxAction::Enable),
+        "disable" | "off" => Ok(SandboxAction::Disable),
+        "help" | "--help" => Ok(SandboxAction::Help),
+        "allow-domain" | "allow" => {
+            if remainder.is_empty() {
+                Err("Usage: /sandbox allow-domain <domain>".to_string())
+            } else {
+                Ok(SandboxAction::AllowDomain(remainder.to_string()))
+            }
+        }
+        "remove-domain" | "deny-domain" | "revoke-domain" => {
+            if remainder.is_empty() {
+                Err("Usage: /sandbox remove-domain <domain>".to_string())
+            } else {
+                Ok(SandboxAction::RemoveDomain(remainder.to_string()))
+            }
+        }
+        _ => Err(format!(
+            "Unknown sandbox subcommand '{}'. Type /sandbox help for usage.",
+            keyword
+        )),
+    }
 }
 
 fn split_command_and_args(input: &str) -> (&str, &str) {

--- a/src/agent/runloop/tool_output.rs
+++ b/src/agent/runloop/tool_output.rs
@@ -485,8 +485,7 @@ fn render_plan_panel(renderer: &mut AnsiRenderer, plan: &TaskPlan) -> Result<()>
     let mut lines = Vec::new();
     let progress = format!(
         "  Progress: {}/{} completed",
-        plan.summary.completed_steps,
-        plan.summary.total_steps
+        plan.summary.completed_steps, plan.summary.total_steps
     );
     lines.push(PanelContentLine::new(
         clamp_panel_text(&progress, content_width),

--- a/src/agent/runloop/unified/session_setup.rs
+++ b/src/agent/runloop/unified/session_setup.rs
@@ -22,6 +22,7 @@ use crate::agent::runloop::ResumeSession;
 use crate::agent::runloop::context::ContextTrimConfig;
 use crate::agent::runloop::context::load_context_trim_config;
 use crate::agent::runloop::mcp_events;
+use crate::agent::runloop::sandbox::SandboxCoordinator;
 use crate::agent::runloop::telemetry::build_trajectory_logger;
 use crate::agent::runloop::welcome::{SessionBootstrap, prepare_session_bootstrap};
 use std::sync::Arc;
@@ -45,6 +46,7 @@ pub(crate) struct SessionState {
     pub token_budget_enabled: bool,
     pub curator: ContextCurator,
     pub custom_prompts: CustomPromptRegistry,
+    pub sandbox: SandboxCoordinator,
 }
 
 pub(crate) async fn initialize_session(
@@ -272,6 +274,8 @@ pub(crate) async fn initialize_session(
         CustomPromptRegistry::default()
     });
 
+    let sandbox = SandboxCoordinator::new(config.workspace.clone());
+
     Ok(SessionState {
         session_bootstrap,
         provider_client,
@@ -289,5 +293,6 @@ pub(crate) async fn initialize_session(
         token_budget_enabled,
         curator,
         custom_prompts,
+        sandbox,
     })
 }

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -225,6 +225,7 @@ pub(crate) async fn run_single_agent_loop_unified(
         token_budget_enabled,
         curator,
         custom_prompts,
+        mut sandbox,
     } = initialize_session(&config, vt_cfg.as_ref(), full_auto, resume_ref).await?;
 
     let curator_tool_catalog = build_curator_tools(&tools);
@@ -502,7 +503,6 @@ pub(crate) async fn run_single_agent_loop_unified(
             }
 
             if ctrl_c_state.is_cancel_requested() {
-
                 renderer.line_if_not_empty(MessageStyle::Output)?;
                 renderer.line(
                     MessageStyle::Info,
@@ -716,6 +716,17 @@ pub(crate) async fn run_single_agent_loop_unified(
                                 SLASH_COMMANDS.iter().collect();
                             if show_help_palette(&mut renderer, &commands)? {
                                 palette_state = Some(ActivePalette::Help);
+                            }
+                            continue;
+                        }
+                        SlashCommandOutcome::ManageSandbox { action } => {
+                            if let Err(err) =
+                                sandbox.handle_action(action, &mut renderer, &mut tool_registry)
+                            {
+                                renderer.line(
+                                    MessageStyle::Error,
+                                    &format!("Sandbox error: {}", err),
+                                )?;
                             }
                             continue;
                         }

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -142,6 +142,7 @@ pub mod project;
 pub mod project_doc;
 pub mod prompts;
 pub mod safety;
+pub mod sandbox;
 pub mod simple_indexer;
 pub mod tool_policy;
 pub mod tools;
@@ -187,6 +188,7 @@ pub use project::{SimpleCache, SimpleProjectManager};
 pub use prompts::{
     generate_lightweight_instruction, generate_specialized_instruction, generate_system_instruction,
 };
+pub use sandbox::SandboxProfile;
 pub use simple_indexer::SimpleIndexer;
 pub use tool_policy::{ToolPolicy, ToolPolicyManager};
 pub use tools::advanced_search::{AdvancedSearchTool, SearchOptions};

--- a/vtcode-core/src/sandbox.rs
+++ b/vtcode-core/src/sandbox.rs
@@ -1,0 +1,33 @@
+use std::path::{Path, PathBuf};
+
+/// Configuration required to launch commands inside the Anthropic sandbox runtime.
+///
+/// This is a lightweight holder for the sandbox CLI binary (`srt`) and the
+/// resolved settings file that encodes filesystem and network policies. Tool
+/// implementations clone this struct and translate regular command invocations
+/// into sandboxed executions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SandboxProfile {
+    binary_path: PathBuf,
+    settings_path: PathBuf,
+}
+
+impl SandboxProfile {
+    /// Create a new sandbox profile using the provided binary and settings paths.
+    pub fn new(binary_path: PathBuf, settings_path: PathBuf) -> Self {
+        Self {
+            binary_path,
+            settings_path,
+        }
+    }
+
+    /// Path to the sandbox CLI (`srt`).
+    pub fn binary(&self) -> &Path {
+        &self.binary_path
+    }
+
+    /// Path to the JSON settings file that configures sandbox permissions.
+    pub fn settings(&self) -> &Path {
+        &self.settings_path
+    }
+}

--- a/vtcode-core/src/tools/registry/inventory.rs
+++ b/vtcode-core/src/tools/registry/inventory.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::sandbox::SandboxProfile;
 use crate::tools::ast_grep::AstGrepEngine;
 use crate::tools::bash_tool::BashTool;
 use crate::tools::command::CommandTool;
@@ -89,6 +90,10 @@ impl ToolInventory {
 
     pub fn bash_tool(&self) -> &BashTool {
         &self.bash_tool
+    }
+
+    pub fn set_bash_sandbox(&mut self, profile: Option<SandboxProfile>) {
+        self.bash_tool.set_sandbox_profile(profile);
     }
 
     pub fn set_pty_manager(&mut self, manager: PtyManager) {

--- a/vtcode-core/src/tools/registry/mod.rs
+++ b/vtcode-core/src/tools/registry/mod.rs
@@ -30,6 +30,7 @@ use crate::config::PtyConfig;
 use crate::config::ToolsConfig;
 #[cfg(test)]
 use crate::config::constants::tools;
+use crate::sandbox::SandboxProfile;
 use crate::tool_policy::{ToolPolicy, ToolPolicyManager};
 use crate::tools::ast_grep::AstGrepEngine;
 use crate::tools::file_ops::FileOpsTool;
@@ -283,6 +284,11 @@ impl ToolRegistry {
 
     pub fn reset_tool_policies(&mut self) -> Result<()> {
         self.policy_gateway.reset_tool_policies()
+    }
+
+    pub fn set_bash_sandbox(&mut self, profile: Option<SandboxProfile>) {
+        self.inventory.set_bash_sandbox(profile.clone());
+        self.pty_sessions.manager().set_sandbox_profile(profile);
     }
 
     pub fn allow_all_tools(&mut self) -> Result<()> {

--- a/vtcode-core/src/ui/slash.rs
+++ b/vtcode-core/src/ui/slash.rs
@@ -41,6 +41,10 @@ pub static SLASH_COMMANDS: Lazy<Vec<SlashCommandInfo>> = Lazy::new(|| {
             description: "List all available UI themes",
         },
         SlashCommandInfo {
+            name: "sandbox",
+            description: "Toggle and configure bash sandboxing (usage: /sandbox [status|enable|disable|allow-domain <domain>])",
+        },
+        SlashCommandInfo {
             name: "command",
             description: "Run a terminal command (usage: /command <program> [args...])",
         },


### PR DESCRIPTION
## Summary
- add a SandboxProfile type and propagate sandbox configuration through the bash tool, PTY manager, and registry
- implement a sandbox coordinator with a /sandbox slash command to toggle isolation and manage allowed domains
- surface the sandbox command in the slash catalogue and detect the Anthropic srt binary via the which crate

## Testing
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f6d592ee3883239a4469c7730b0617