### PR TITLE
Add loader tests and crate docs for vtcode-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,6 +3823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +3908,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -4083,6 +4098,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5404,6 +5444,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "toml 0.9.7",
  "toml_edit 0.22.27",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,6 +3838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
+ "indexmap 1.9.3",
  "schemars_derive 0.8.22",
  "serde",
  "serde_json",
@@ -5400,6 +5401,7 @@ dependencies = [
  "indexmap 2.11.4",
  "once_cell",
  "regex",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "tempfile",

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -23,7 +23,7 @@ This list tracks actionable tasks spawned from the component extraction plan as 
 - [x] Document migration steps for downstream consumers adopting the new crate structure.
 - [x] Scaffold the standalone crate layout and migrate defaults/bootstrap helpers while leaving compatibility re-exports in `vtcode-core`.
 - [x] Move the `VTCodeConfig` loader and `ConfigManager` into the new crate while maintaining temporary re-exports in `vtcode-core`.
-- [ ] Backfill `vtcode-config` with loader-focused tests and crate-level documentation updates ahead of publishing.
+- [x] Backfill `vtcode-config` with loader-focused tests and crate-level documentation updates ahead of publishing.
 
 ## Cross-Cutting
 - [x] Capture external integration prerequisites (environment variables, binary dependencies) and align them with optional feature groups.

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -24,6 +24,8 @@ This list tracks actionable tasks spawned from the component extraction plan as 
 - [x] Scaffold the standalone crate layout and migrate defaults/bootstrap helpers while leaving compatibility re-exports in `vtcode-core`.
 - [x] Move the `VTCodeConfig` loader and `ConfigManager` into the new crate while maintaining temporary re-exports in `vtcode-core`.
 - [x] Backfill `vtcode-config` with loader-focused tests and crate-level documentation updates ahead of publishing.
+- [x] Gate bootstrap helpers behind an optional crate feature so parsing-only consumers can disable filesystem scaffolding.
+
 
 ## Cross-Cutting
 - [x] Capture external integration prerequisites (environment variables, binary dependencies) and align them with optional feature groups.

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -25,6 +25,7 @@ This list tracks actionable tasks spawned from the component extraction plan as 
 - [x] Move the `VTCodeConfig` loader and `ConfigManager` into the new crate while maintaining temporary re-exports in `vtcode-core`.
 - [x] Backfill `vtcode-config` with loader-focused tests and crate-level documentation updates ahead of publishing.
 - [x] Gate bootstrap helpers behind an optional crate feature so parsing-only consumers can disable filesystem scaffolding.
+- [x] Expose JSON Schema export helpers under an optional feature flag for downstream documentation tooling.
 
 
 ## Cross-Cutting

--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -26,6 +26,7 @@ This list tracks actionable tasks spawned from the component extraction plan as 
 - [x] Backfill `vtcode-config` with loader-focused tests and crate-level documentation updates ahead of publishing.
 - [x] Gate bootstrap helpers behind an optional crate feature so parsing-only consumers can disable filesystem scaffolding.
 - [x] Expose JSON Schema export helpers under an optional feature flag for downstream documentation tooling.
+- [x] Publish a runnable example that demonstrates installing custom defaults providers when loading configuration outside `.vtcode` directories.
 
 
 ## Cross-Cutting

--- a/docs/vtcode_config_extraction.md
+++ b/docs/vtcode_config_extraction.md
@@ -8,7 +8,7 @@
 ## Current State Snapshot
 - `VTCodeConfig` and `ConfigManager` now live in `vtcode-config/src/loader/mod.rs`, with `vtcode-core` exposing compatibility re-exports so existing downstream crates continue to compile without immediate code changes.
 - Default values still live in `vtcode-config/src/defaults` (re-exported through `vtcode-core`), continuing to include baked-in paths like `.vtcode/context` and theme caches until further decoupled.
-- Bootstrap helpers (`VTCodeConfig::bootstrap_project` and `bootstrap_project_with_options`) delegate directory selection to the installed defaults provider while continuing to default to `.vtcode` paths via the bundled adapter.
+- Bootstrap helpers (`VTCodeConfig::bootstrap_project` and `bootstrap_project_with_options`) delegate directory selection to the installed defaults provider while continuing to default to `.vtcode` paths via the bundled adapter. They now compile behind an optional `bootstrap` feature so parsing-only consumers can disable filesystem scaffolding.
 - Bootstrap path selection utilities (`determine_bootstrap_targets`, parent-dir creation, and gitignore helpers) were moved into `vtcode-config/src/loader/bootstrap.rs` so downstream adopters can use them without depending on `vtcode-core` internals.
 - OpenRouter metadata generation moved into `vtcode-config/build.rs`, keeping the new crate self-contained and allowing `vtcode-core` to drop its bespoke build script.
 
@@ -63,7 +63,7 @@ vtcode-config/
 - **Completed:** Move path construction responsibilities into `vtcode-config::loader::bootstrap`, exposing helper functions that `vtcode-core` now consumes via re-exports.
 - **Completed:** Migrate the remaining loader logic (`ConfigManager`, serde helpers) into the crate with compatibility re-exports for VTCode and retire the old `vtcode-core` build script in favour of `vtcode-config/build.rs`.
 - **Upcoming:** Add crate-focused tests (unit and integration) that exercise the loader with custom defaults to ensure the extraction remains stable outside the monorepo.
-- **Upcoming:** Allow downstream consumers to disable bootstrap entirely via a feature flag when they only need parsing/validation.
+- **Completed:** Gate bootstrap scaffolding behind an optional crate feature so consumers focused on parsing/validation can disable filesystem helpers.
 
 ## Migration Plan
 1. **Internal refactor:** introduce the trait and builder within the monorepo, updating existing call sites to pass `WorkspacePaths`.

--- a/docs/vtcode_config_extraction.md
+++ b/docs/vtcode_config_extraction.md
@@ -11,6 +11,7 @@
 - Bootstrap helpers (`VTCodeConfig::bootstrap_project` and `bootstrap_project_with_options`) delegate directory selection to the installed defaults provider while continuing to default to `.vtcode` paths via the bundled adapter. They now compile behind an optional `bootstrap` feature so parsing-only consumers can disable filesystem scaffolding.
 - Bootstrap path selection utilities (`determine_bootstrap_targets`, parent-dir creation, and gitignore helpers) were moved into `vtcode-config/src/loader/bootstrap.rs` so downstream adopters can use them without depending on `vtcode-core` internals.
 - OpenRouter metadata generation moved into `vtcode-config/build.rs`, keeping the new crate self-contained and allowing `vtcode-core` to drop its bespoke build script.
+- JSON Schema export helpers live behind the optional `schema` feature, exposing `vtcode_config::schema::*` functions for downstream automation to inspect the configuration surface.
 
 ## Proposed Crate Layout
 ```
@@ -62,7 +63,8 @@ vtcode-config/
 - **Completed:** Refactor `VTCodeConfig::bootstrap_project` so it accepts a `ConfigDefaultsProvider`, enabling callers to inject workspace-aware defaults.
 - **Completed:** Move path construction responsibilities into `vtcode-config::loader::bootstrap`, exposing helper functions that `vtcode-core` now consumes via re-exports.
 - **Completed:** Migrate the remaining loader logic (`ConfigManager`, serde helpers) into the crate with compatibility re-exports for VTCode and retire the old `vtcode-core` build script in favour of `vtcode-config/build.rs`.
-- **Upcoming:** Add crate-focused tests (unit and integration) that exercise the loader with custom defaults to ensure the extraction remains stable outside the monorepo.
+- **Completed:** Add crate-focused tests (unit and integration) that exercise the loader with custom defaults to ensure the extraction remains stable outside the monorepo.
+- **Completed:** Expose JSON Schema generation helpers under a `schema` feature flag so documentation tooling can consume the crate without pulling in bootstrap dependencies.
 - **Completed:** Gate bootstrap scaffolding behind an optional crate feature so consumers focused on parsing/validation can disable filesystem helpers.
 
 ## Migration Plan
@@ -71,7 +73,7 @@ vtcode-config/
 3. **Documentation:** add migration notes covering trait implementations, new feature flags, and examples for headless services.
 4. **Release prep:** publish serde schema helpers (optional) and ensure `cargo doc` highlights the new extension points.
 
-**Status:** Steps 1–3 are complete, the new [`vtcode_config_migration.md`](./vtcode_config_migration.md) guide captures the documentation milestone, and the crate now owns defaults, bootstrap helpers, and the full loader/manager stack. The next phase focuses on hardening the crate with dedicated tests, documentation polish, and feature gates for slimmer adopters.
+**Status:** Steps 1–3 are complete, the new [`vtcode_config_migration.md`](./vtcode_config_migration.md) guide captures the documentation milestone, and the crate now owns defaults, bootstrap helpers, the loader/manager stack, and schema export helpers. The next phase focuses on hardening the crate with dedicated tests, documentation polish, and feature gates for slimmer adopters.
 
 ## Dependencies & Feature Flags
 - Hard dependencies: `serde`, `serde_json`, `toml`, `anyhow`.

--- a/docs/vtcode_config_extraction.md
+++ b/docs/vtcode_config_extraction.md
@@ -12,6 +12,7 @@
 - Bootstrap path selection utilities (`determine_bootstrap_targets`, parent-dir creation, and gitignore helpers) were moved into `vtcode-config/src/loader/bootstrap.rs` so downstream adopters can use them without depending on `vtcode-core` internals.
 - OpenRouter metadata generation moved into `vtcode-config/build.rs`, keeping the new crate self-contained and allowing `vtcode-core` to drop its bespoke build script.
 - JSON Schema export helpers live behind the optional `schema` feature, exposing `vtcode_config::schema::*` functions for downstream automation to inspect the configuration surface.
+- A runnable `examples/minimal.rs` illustrates how to install custom `WorkspacePathsDefaults` providers so headless services can resolve configuration from non-`.vtcode` directories while reusing syntax highlighting preferences.
 
 ## Proposed Crate Layout
 ```

--- a/docs/vtcode_config_migration.md
+++ b/docs/vtcode_config_migration.md
@@ -15,6 +15,8 @@ This guide walks through updating existing VTCode integrations to rely on the st
   - `bootstrap` (default) for filesystem scaffolding helpers.
   - `schema` when exporting JSON Schema definitions of the config surface.
   - `vtcode-commons` to reuse the shared `WorkspacePaths` adapters for defaults resolution.
+- Consumers that only need parsing/validation can disable default features and opt out of the `bootstrap` helpers to avoid pulling in filesystem scaffolding code.
+
 
 ### 2. Implement or Select a Defaults Provider
 - The loader expects a `ConfigDefaultsProvider` implementation. Most integrations can reuse the bundled `WorkspacePathsDefaults` adapter:

--- a/docs/vtcode_config_migration.md
+++ b/docs/vtcode_config_migration.md
@@ -13,7 +13,7 @@ This guide walks through updating existing VTCode integrations to rely on the st
 - **Workspace consumers:** add `vtcode-config = { path = "../vtcode-config", features = ["bootstrap", "vtcode-commons"] }` to the member using the loader.
 - **External adopters:** depend on the published crate (version TBD) and enable the feature flags you need:
   - `bootstrap` (default) for filesystem scaffolding helpers.
-  - `schema` when exporting JSON Schema definitions of the config surface.
+  - `schema` when exporting JSON Schema definitions of the config surface. Use the `vtcode_config::schema` helpers to access the raw `RootSchema`, a `serde_json::Value`, or a pretty-printed JSON string for documentation tooling.
   - `vtcode-commons` to reuse the shared `WorkspacePaths` adapters for defaults resolution.
 - Consumers that only need parsing/validation can disable default features and opt out of the `bootstrap` helpers to avoid pulling in filesystem scaffolding code.
 

--- a/docs/vtcode_config_migration.md
+++ b/docs/vtcode_config_migration.md
@@ -73,3 +73,4 @@ This guide walks through updating existing VTCode integrations to rely on the st
 - [Extraction strategy](./vtcode_config_extraction.md) for architectural context and crate layout proposals.
 - `vtcode-core/src/config/defaults/provider.rs` for the live provider trait and reference adapter implementations.
 - `vtcode-core/tests/config_loader_test.rs` showcasing provider-driven bootstrap tests.
+- `cargo run --example minimal -p vtcode-config` for a runnable walkthrough that injects a custom defaults provider before loading configuration.

--- a/vtcode-config/Cargo.toml
+++ b/vtcode-config/Cargo.toml
@@ -34,6 +34,7 @@ schema = ["schemars"]
 
 [dev-dependencies]
 tempfile = "3.0"
+serial_test = "3.1"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/vtcode-config/Cargo.toml
+++ b/vtcode-config/Cargo.toml
@@ -25,10 +25,12 @@ toml_edit = "0.22"
 tracing = "0.1"
 vtcode-commons = { path = "../vtcode-commons" }
 dotenvy = "0.15"
+schemars = { version = "0.8", optional = true, features = ["indexmap"] }
 
 [features]
 default = ["bootstrap"]
 bootstrap = []
+schema = ["schemars"]
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/vtcode-config/examples/minimal.rs
+++ b/vtcode-config/examples/minimal.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tempfile::tempdir;
+use vtcode_commons::reference::StaticWorkspacePaths;
+use vtcode_config::ConfigManager;
+use vtcode_config::defaults::{
+    ConfigDefaultsProvider, WorkspacePathsDefaults, install_config_defaults_provider,
+};
+
+fn main() -> anyhow::Result<()> {
+    // Create a disposable workspace that mimics a downstream project layout.
+    let workspace = tempdir()?;
+    let workspace_root = workspace.path().to_path_buf();
+    let config_dir = workspace_root.join("config");
+
+    std::fs::create_dir_all(&config_dir)?;
+    std::fs::write(
+        config_dir.join("settings.toml"),
+        r#"
+            [agent]
+            provider = "openai"
+            default_model = "gpt-4.1-mini"
+        "#
+        .trim(),
+    )?;
+
+    // Wrap the custom workspace paths with a defaults provider so the loader
+    // searches the new directories and uses the desired syntax defaults.
+    let static_paths = StaticWorkspacePaths::new(&workspace_root, &config_dir)
+        .with_cache_dir(config_dir.join("cache"))
+        .with_telemetry_dir(config_dir.join("telemetry"));
+
+    let defaults = WorkspacePathsDefaults::new(Arc::new(static_paths))
+        .with_config_file_name("settings.toml")
+        .with_home_paths(Vec::<PathBuf>::new())
+        .with_syntax_theme("tokyonight_night")
+        .with_syntax_languages(vec![
+            "rust".to_string(),
+            "python".to_string(),
+            "typescript".to_string(),
+        ]);
+    let defaults: Arc<dyn ConfigDefaultsProvider> = Arc::new(defaults);
+
+    // Swap the provider during the configuration load so downstream adopters
+    // can bootstrap without touching global `.vtcode` directories.
+    let previous = install_config_defaults_provider(Arc::clone(&defaults));
+    let manager = ConfigManager::load_from_workspace(&workspace_root)?;
+
+    println!(
+        "Agent provider: {}\nSyntax theme: {}\nLanguages: {}",
+        manager.config().agent.provider,
+        defaults.syntax_theme(),
+        defaults.syntax_languages().join(", "),
+    );
+
+    // Restore the original provider before exiting.
+    install_config_defaults_provider(previous);
+    Ok(())
+}

--- a/vtcode-config/src/acp.rs
+++ b/vtcode-config/src/acp.rs
@@ -53,6 +53,7 @@ fn default_transport() -> AgentClientProtocolTransport {
 }
 
 /// Agent Client Protocol configuration root
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentClientProtocolConfig {
     /// Globally enable the ACP bridge
@@ -74,6 +75,7 @@ impl Default for AgentClientProtocolConfig {
 }
 
 /// Transport options supported by the ACP bridge
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentClientProtocolTransport {
@@ -88,6 +90,7 @@ impl Default for AgentClientProtocolTransport {
 }
 
 /// Zed-specific configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentClientProtocolZedConfig {
     /// Enable Zed integration
@@ -119,6 +122,7 @@ impl Default for AgentClientProtocolZedConfig {
 }
 
 /// Zed bridge tool configuration flags
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentClientProtocolZedToolsConfig {
     /// Toggle the read_file function bridge
@@ -140,6 +144,7 @@ impl Default for AgentClientProtocolZedToolsConfig {
 }
 
 /// Workspace trust configuration for the Zed ACP bridge
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentClientProtocolZedWorkspaceTrustMode {
@@ -169,6 +174,7 @@ impl AgentClientProtocolZedWorkspaceTrustMode {
 }
 
 /// Workspace trust levels exposed through the Agent Client Protocol configuration.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkspaceTrustLevel {

--- a/vtcode-config/src/context.rs
+++ b/vtcode-config/src/context.rs
@@ -2,6 +2,7 @@ use crate::constants::context as context_defaults;
 use anyhow::{Context, Result, ensure};
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LedgerConfig {
     #[serde(default = "default_enabled")]
@@ -50,6 +51,7 @@ fn default_preserve_in_compression() -> bool {
     true
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TokenBudgetConfig {
     /// Enable token budget tracking
@@ -133,6 +135,7 @@ fn default_detailed_tracking() -> bool {
     false
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContextCurationConfig {
     /// Enable dynamic context curation
@@ -231,6 +234,7 @@ fn default_max_recent_errors() -> usize {
     3
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContextFeaturesConfig {
     #[serde(default)]

--- a/vtcode-config/src/core/agent.rs
+++ b/vtcode-config/src/core/agent.rs
@@ -8,6 +8,7 @@ const DEFAULT_MAX_SNAPSHOTS: usize = 50;
 const DEFAULT_MAX_AGE_DAYS: u64 = 30;
 
 /// Agent-wide configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentConfig {
     /// AI provider for single agent mode (gemini, openai, anthropic, openrouter, xai, zai)
@@ -170,6 +171,7 @@ fn default_instruction_max_bytes() -> usize {
     instructions::DEFAULT_MAX_BYTES
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentCustomPromptsConfig {
     /// Master switch for custom prompt support
@@ -212,6 +214,7 @@ fn default_custom_prompts_max_file_size_kb() -> usize {
     prompts::DEFAULT_CUSTOM_PROMPT_MAX_FILE_SIZE_KB
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentCheckpointingConfig {
     /// Enable automatic checkpoints after each successful turn
@@ -254,6 +257,7 @@ fn default_checkpointing_max_age_days() -> Option<u64> {
     Some(DEFAULT_MAX_AGE_DAYS)
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentOnboardingConfig {
     /// Toggle onboarding message rendering

--- a/vtcode-config/src/core/automation.rs
+++ b/vtcode-config/src/core/automation.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Automation-specific configuration toggles.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct AutomationConfig {
     /// Full-auto execution safeguards.
@@ -11,6 +12,7 @@ pub struct AutomationConfig {
 }
 
 /// Controls for running the agent without interactive approvals.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FullAutoConfig {
     /// Enable the runtime flag once the workspace is configured for autonomous runs.

--- a/vtcode-config/src/core/commands.rs
+++ b/vtcode-config/src/core/commands.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Command execution configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CommandsConfig {
     /// Commands that can be executed without prompting

--- a/vtcode-config/src/core/prompt_cache.rs
+++ b/vtcode-config/src/core/prompt_cache.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 /// Global prompt caching configuration loaded from vtcode.toml
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PromptCachingConfig {
     /// Enable prompt caching features globally
@@ -60,6 +61,7 @@ impl PromptCachingConfig {
 }
 
 /// Per-provider configuration overrides
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ProviderPromptCachingConfig {
     #[serde(default = "OpenAIPromptCacheSettings::default")]
@@ -88,6 +90,7 @@ pub struct ProviderPromptCachingConfig {
 }
 
 /// OpenAI prompt caching controls (automatic with metrics)
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OpenAIPromptCacheSettings {
     #[serde(default = "default_true")]
@@ -115,6 +118,7 @@ impl Default for OpenAIPromptCacheSettings {
 }
 
 /// Anthropic Claude cache control settings
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AnthropicPromptCacheSettings {
     #[serde(default = "default_true")]
@@ -153,6 +157,7 @@ impl Default for AnthropicPromptCacheSettings {
 }
 
 /// Gemini API caching preferences
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GeminiPromptCacheSettings {
     #[serde(default = "default_true")]
@@ -181,6 +186,7 @@ impl Default for GeminiPromptCacheSettings {
 }
 
 /// Gemini prompt caching mode selection
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
@@ -192,6 +198,7 @@ pub enum GeminiPromptCacheMode {
 }
 
 /// OpenRouter passthrough caching controls
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OpenRouterPromptCacheSettings {
     #[serde(default = "default_true")]
@@ -217,6 +224,7 @@ impl Default for OpenRouterPromptCacheSettings {
 }
 
 /// Moonshot prompt caching configuration (leverages server-side reuse)
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MoonshotPromptCacheSettings {
     #[serde(default = "default_moonshot_enabled")]
@@ -232,6 +240,7 @@ impl Default for MoonshotPromptCacheSettings {
 }
 
 /// xAI prompt caching configuration (automatic platform-level cache)
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct XAIPromptCacheSettings {
     #[serde(default = "default_true")]
@@ -247,6 +256,7 @@ impl Default for XAIPromptCacheSettings {
 }
 
 /// DeepSeek prompt caching configuration (automatic KV cache reuse)
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DeepSeekPromptCacheSettings {
     #[serde(default = "default_true")]
@@ -267,6 +277,7 @@ impl Default for DeepSeekPromptCacheSettings {
 }
 
 /// Z.AI prompt caching configuration (disabled until platform exposes metrics)
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ZaiPromptCacheSettings {
     #[serde(default = "default_zai_enabled")]

--- a/vtcode-config/src/core/security.rs
+++ b/vtcode-config/src/core/security.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Security configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SecurityConfig {
     /// Require human confirmation for critical actions

--- a/vtcode-config/src/core/tools.rs
+++ b/vtcode-config/src/core/tools.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::constants::{defaults, tools};
 
 /// Tools configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ToolsConfig {
     /// Default policy for tools not explicitly listed
@@ -12,6 +13,10 @@ pub struct ToolsConfig {
 
     /// Specific tool policies
     #[serde(default)]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(with = "std::collections::BTreeMap<String, ToolPolicy>")
+    )]
     pub policies: IndexMap<String, ToolPolicy>,
 
     /// Maximum inner tool-call loops per user turn
@@ -63,6 +68,7 @@ impl Default for ToolsConfig {
 }
 
 /// Tool execution policy
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ToolPolicy {

--- a/vtcode-config/src/lib.rs
+++ b/vtcode-config/src/lib.rs
@@ -1,3 +1,26 @@
+//! Shared configuration loader utilities for VTCode and downstream integrations.
+//!
+//! This crate exposes [`VTCodeConfig`] and [`ConfigManager`] for reading and
+//! validating `vtcode.toml` files while allowing applications to customize the
+//! filesystem layout via [`ConfigDefaultsProvider`]. Consumers can opt into the
+//! [`bootstrap`](index.html#features) feature (enabled by default) to scaffold
+//! configuration directories with project-specific defaults.
+//!
+//! # Examples
+//! ```no_run
+//! use vtcode_config::ConfigManager;
+//!
+//! # fn main() -> anyhow::Result<()> {
+//! let manager = ConfigManager::load_from_workspace(".")?;
+//! println!("Active provider: {}", manager.config().agent.provider);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Install a custom [`ConfigDefaultsProvider`] with
+//! [`install_config_defaults_provider`] when you need to override search paths
+//! or syntax highlighting defaults exposed by the loader.
+
 pub mod acp;
 pub mod api_keys;
 pub mod constants;

--- a/vtcode-config/src/lib.rs
+++ b/vtcode-config/src/lib.rs
@@ -5,6 +5,8 @@
 //! filesystem layout via [`ConfigDefaultsProvider`]. Consumers can opt into the
 //! [`bootstrap`](index.html#features) feature (enabled by default) to scaffold
 //! configuration directories with project-specific defaults.
+//! Disable default features when you only need parsing/validation to omit the
+//! filesystem bootstrap helpers and reduce dependencies.
 //!
 //! # Examples
 //! ```no_run

--- a/vtcode-config/src/lib.rs
+++ b/vtcode-config/src/lib.rs
@@ -34,6 +34,8 @@ pub mod mcp;
 pub mod models;
 pub mod root;
 pub mod router;
+#[cfg(feature = "schema")]
+pub mod schema;
 pub mod telemetry;
 pub mod types;
 
@@ -62,5 +64,7 @@ pub use mcp::{
 pub use models::{ModelId, OpenRouterMetadata};
 pub use root::{PtyConfig, StatusLineConfig, StatusLineMode, ToolOutputMode, UiConfig};
 pub use router::{ComplexityModelMap, HeuristicSettings, ResourceBudget, RouterConfig};
+#[cfg(feature = "schema")]
+pub use schema::{vtcode_config_schema, vtcode_config_schema_json, vtcode_config_schema_pretty};
 pub use telemetry::TelemetryConfig;
 pub use types::{ReasoningEffortLevel, UiSurfacePreference};

--- a/vtcode-config/src/loader/mod.rs
+++ b/vtcode-config/src/loader/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "bootstrap")]
 pub mod bootstrap;
 
 use crate::acp::AgentClientProtocolConfig;
@@ -167,11 +168,13 @@ impl VTCodeConfig {
         Ok(())
     }
 
+    #[cfg(feature = "bootstrap")]
     /// Bootstrap project with config + gitignore
     pub fn bootstrap_project<P: AsRef<Path>>(workspace: P, force: bool) -> Result<Vec<String>> {
         Self::bootstrap_project_with_options(workspace, force, false)
     }
 
+    #[cfg(feature = "bootstrap")]
     /// Bootstrap project with config + gitignore, with option to create in home directory
     pub fn bootstrap_project_with_options<P: AsRef<Path>>(
         workspace: P,
@@ -184,6 +187,7 @@ impl VTCodeConfig {
         })
     }
 
+    #[cfg(feature = "bootstrap")]
     /// Bootstrap project files using the supplied [`ConfigDefaultsProvider`].
     pub fn bootstrap_project_with_provider<P: AsRef<Path>>(
         workspace: P,
@@ -234,7 +238,8 @@ impl VTCodeConfig {
         Ok(created_files)
     }
 
-    /// Generate default .vtcodegitignore content
+    #[cfg(feature = "bootstrap")]
+    /// Generate the default `vtcode.toml` template used by bootstrap helpers.
     fn default_vtcode_toml_template() -> String {
         r#"# VTCode Configuration File (Example)
 # Getting-started reference; see docs/config/CONFIGURATION_PRECEDENCE.md for override order.
@@ -808,6 +813,7 @@ read_file = true
 list_files = true"#.to_string()
     }
 
+    #[cfg(feature = "bootstrap")]
     fn default_vtcode_gitignore() -> String {
         r#"# Security-focused exclusions
 .env, .env.local, secrets/, .aws/, .ssh/
@@ -827,6 +833,7 @@ target/, build/, dist/, node_modules/, vendor/
         .to_string()
     }
 
+    #[cfg(feature = "bootstrap")]
     /// Create sample configuration file
     pub fn create_sample_config<P: AsRef<Path>>(output: P) -> Result<()> {
         let output = output.as_ref();

--- a/vtcode-config/src/loader/mod.rs
+++ b/vtcode-config/src/loader/mod.rs
@@ -17,6 +17,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Syntax highlighting configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SyntaxHighlightingConfig {
     /// Enable syntax highlighting for tool output
@@ -92,6 +93,7 @@ impl SyntaxHighlightingConfig {
 }
 
 /// Main configuration structure for VTCode
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VTCodeConfig {
     /// Agent-wide settings

--- a/vtcode-config/src/mcp.rs
+++ b/vtcode-config/src/mcp.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
 /// Top-level MCP configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpClientConfig {
     /// Enable MCP functionality
@@ -69,6 +70,7 @@ impl Default for McpClientConfig {
 }
 
 /// UI configuration for MCP display
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpUiConfig {
     /// UI mode for MCP events: "compact" or "full"
@@ -125,6 +127,7 @@ impl McpUiConfig {
 }
 
 /// UI mode for MCP event display
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
@@ -146,6 +149,7 @@ impl std::fmt::Display for McpUiMode {
 }
 
 /// Named renderer profiles for MCP tool output formatting
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum McpRendererProfile {
@@ -156,6 +160,7 @@ pub enum McpRendererProfile {
 }
 
 /// Configuration for a single MCP provider
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpProviderConfig {
     /// Provider name (used for identification)
@@ -191,6 +196,7 @@ impl Default for McpProviderConfig {
 }
 
 /// Allow list configuration for MCP providers
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpAllowListConfig {
     /// Whether to enforce allow list checks
@@ -365,6 +371,7 @@ fn wildcard_match(pattern: &str, candidate: &str) -> bool {
 }
 
 /// Allow list rules for a provider or default configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct McpAllowListRules {
     /// Tool name patterns permitted for the provider
@@ -389,6 +396,7 @@ pub struct McpAllowListRules {
 }
 
 /// Configuration for the MCP server (vtcode acting as an MCP server)
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpServerConfig {
     /// Enable vtcode's MCP server capability
@@ -435,6 +443,7 @@ impl Default for McpServerConfig {
 }
 
 /// MCP server transport types
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
@@ -447,6 +456,7 @@ pub enum McpServerTransport {
 }
 
 /// Transport configuration for MCP providers
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum McpTransportConfig {
@@ -457,6 +467,7 @@ pub enum McpTransportConfig {
 }
 
 /// Configuration for stdio-based MCP servers
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct McpStdioServerConfig {
     /// Command to execute
@@ -475,6 +486,7 @@ pub struct McpStdioServerConfig {
 /// Note: HTTP transport is partially implemented. Basic connectivity testing is supported,
 /// but full streamable HTTP MCP server support requires additional implementation
 /// using Server-Sent Events (SSE) or WebSocket connections.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpHttpServerConfig {
     /// Server endpoint URL

--- a/vtcode-config/src/models.rs
+++ b/vtcode-config/src/models.rs
@@ -22,6 +22,7 @@ pub struct OpenRouterMetadata {
 }
 
 /// Supported AI model providers
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum Provider {
     /// Google Gemini models
@@ -150,6 +151,7 @@ impl FromStr for Provider {
 }
 
 /// Centralized enum for all supported model identifiers
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModelId {
     // Gemini models

--- a/vtcode-config/src/root.rs
+++ b/vtcode-config/src/root.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolOutputMode {
@@ -13,6 +14,7 @@ impl Default for ToolOutputMode {
     }
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
@@ -23,6 +25,7 @@ pub enum StatusLineMode {
     Hidden,
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StatusLineConfig {
     #[serde(default = "default_status_line_mode")]
@@ -46,6 +49,7 @@ impl Default for StatusLineConfig {
     }
 }
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct UiConfig {
     #[serde(default = "default_tool_output_mode")]
@@ -70,6 +74,7 @@ impl Default for UiConfig {
 }
 
 /// PTY configuration
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PtyConfig {
     /// Enable PTY functionality

--- a/vtcode-config/src/router.rs
+++ b/vtcode-config/src/router.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, ensure};
 use serde::{Deserialize, Serialize};
 
 /// Budget awareness for routing decisions
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourceBudget {
     /// Max tokens per request (soft cap)
@@ -16,6 +17,7 @@ pub struct ResourceBudget {
 }
 
 /// Map from a complexity label to a model identifier
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ComplexityModelMap {
     /// Simple, quick tasks
@@ -36,6 +38,7 @@ pub struct ComplexityModelMap {
 }
 
 /// Tunable thresholds for heuristic task classification
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HeuristicSettings {
     /// Maximum characters treated as a "simple" request
@@ -98,6 +101,7 @@ impl HeuristicSettings {
 }
 
 /// Router configuration for dynamic model/engine selection
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RouterConfig {
     /// Enable router decisions for chat/ask commands

--- a/vtcode-config/src/schema.rs
+++ b/vtcode-config/src/schema.rs
@@ -1,0 +1,24 @@
+#![cfg(feature = "schema")]
+
+use anyhow::{Context, Result};
+use schemars::{schema::RootSchema, schema_for};
+
+use crate::loader::VTCodeConfig;
+
+/// Generate the JSON Schema describing the `vtcode.toml` configuration surface.
+pub fn vtcode_config_schema() -> RootSchema {
+    schema_for!(VTCodeConfig)
+}
+
+/// Render the configuration schema as a `serde_json::Value` for downstream tooling.
+pub fn vtcode_config_schema_json() -> Result<serde_json::Value> {
+    let schema = vtcode_config_schema();
+    serde_json::to_value(schema).context("failed to serialize vtcode-config schema to JSON value")
+}
+
+/// Render the configuration schema as a pretty-printed JSON string.
+pub fn vtcode_config_schema_pretty() -> Result<String> {
+    let value = vtcode_config_schema_json()?;
+    serde_json::to_string_pretty(&value)
+        .context("failed to serialize vtcode-config schema to pretty JSON string")
+}

--- a/vtcode-config/src/telemetry.rs
+++ b/vtcode-config/src/telemetry.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TelemetryConfig {
     #[serde(default = "default_true")]

--- a/vtcode-config/src/types/mod.rs
+++ b/vtcode-config/src/types/mod.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 /// Supported reasoning effort levels configured via vtcode.toml
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffortLevel {
@@ -79,6 +80,7 @@ impl<'de> Deserialize<'de> for ReasoningEffortLevel {
 }
 
 /// Preferred rendering surface for the interactive chat UI
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum UiSurfacePreference {

--- a/vtcode-config/tests/loader.rs
+++ b/vtcode-config/tests/loader.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
+use serial_test::serial;
 use tempfile::TempDir;
 use vtcode_commons::paths::WorkspacePaths;
 use vtcode_config::ConfigManager;
@@ -61,6 +62,7 @@ fn write_config(path: &Path, provider: &str) -> Result<()> {
 }
 
 #[test]
+#[serial]
 fn loads_config_from_workspace_root_before_config_dir() -> Result<()> {
     let workspace = TempDir::new()?;
     let workspace_root = workspace.path();
@@ -89,6 +91,7 @@ fn loads_config_from_workspace_root_before_config_dir() -> Result<()> {
 }
 
 #[test]
+#[serial]
 fn loads_config_from_config_dir_when_root_missing() -> Result<()> {
     let workspace = TempDir::new()?;
     let workspace_root = workspace.path();
@@ -115,6 +118,7 @@ fn loads_config_from_config_dir_when_root_missing() -> Result<()> {
 }
 
 #[test]
+#[serial]
 fn loads_config_from_home_directory_when_workspace_missing() -> Result<()> {
     let workspace = TempDir::new()?;
     let workspace_root = workspace.path();
@@ -138,6 +142,7 @@ fn loads_config_from_home_directory_when_workspace_missing() -> Result<()> {
 }
 
 #[test]
+#[serial]
 fn falls_back_to_default_config_when_no_files_found() -> Result<()> {
     let workspace = TempDir::new()?;
     let workspace_root = workspace.path();

--- a/vtcode-config/tests/loader.rs
+++ b/vtcode-config/tests/loader.rs
@@ -1,0 +1,155 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use tempfile::TempDir;
+use vtcode_commons::paths::WorkspacePaths;
+use vtcode_config::ConfigManager;
+use vtcode_config::constants::defaults;
+use vtcode_config::defaults::provider::with_config_defaults_provider_for_test;
+use vtcode_config::defaults::{ConfigDefaultsProvider, WorkspacePathsDefaults};
+
+#[derive(Clone)]
+struct TestPaths {
+    root: PathBuf,
+    config_dir: PathBuf,
+}
+
+impl TestPaths {
+    fn new(root: PathBuf, config_dir: PathBuf) -> Self {
+        Self { root, config_dir }
+    }
+}
+
+impl WorkspacePaths for TestPaths {
+    fn workspace_root(&self) -> &Path {
+        &self.root
+    }
+
+    fn config_dir(&self) -> PathBuf {
+        self.config_dir.clone()
+    }
+}
+
+fn with_test_defaults<T>(
+    workspace_root: &Path,
+    config_dir: PathBuf,
+    home_paths: Vec<PathBuf>,
+    action: impl FnOnce() -> T,
+) -> T {
+    let workspace_paths = TestPaths::new(workspace_root.to_path_buf(), config_dir);
+    let provider = WorkspacePathsDefaults::new(Arc::new(workspace_paths))
+        .with_home_paths(home_paths)
+        .build();
+    let provider: Arc<dyn ConfigDefaultsProvider> = provider.into();
+
+    with_config_defaults_provider_for_test(provider, action)
+}
+
+fn write_config(path: &Path, provider: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let contents = format!(
+        "[agent]\nprovider = \"{}\"\nmax_conversation_turns = 5\n",
+        provider
+    );
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+#[test]
+fn loads_config_from_workspace_root_before_config_dir() -> Result<()> {
+    let workspace = TempDir::new()?;
+    let workspace_root = workspace.path();
+    let config_dir = workspace_root.join(".vtcode");
+    fs::create_dir_all(&config_dir)?;
+
+    let root_config = workspace_root.join("vtcode.toml");
+    let config_dir_config = config_dir.join("vtcode.toml");
+    let home_config = workspace_root.join("home").join("vtcode.toml");
+
+    write_config(&root_config, "workspace-root")?;
+    write_config(&config_dir_config, "config-dir")?;
+    write_config(&home_config, "home")?;
+
+    let manager = with_test_defaults(
+        workspace_root,
+        config_dir,
+        vec![home_config.clone()],
+        || ConfigManager::load_from_workspace(workspace_root),
+    )?;
+
+    assert_eq!(manager.config().agent.provider, "workspace-root");
+    assert_eq!(manager.config_path(), Some(root_config.as_path()));
+
+    Ok(())
+}
+
+#[test]
+fn loads_config_from_config_dir_when_root_missing() -> Result<()> {
+    let workspace = TempDir::new()?;
+    let workspace_root = workspace.path();
+    let config_dir = workspace_root.join(".vtcode");
+    fs::create_dir_all(&config_dir)?;
+
+    let config_dir_config = config_dir.join("vtcode.toml");
+    let home_config = workspace_root.join("home").join("vtcode.toml");
+
+    write_config(&config_dir_config, "config-dir")?;
+    write_config(&home_config, "home")?;
+
+    let manager = with_test_defaults(
+        workspace_root,
+        config_dir,
+        vec![home_config.clone()],
+        || ConfigManager::load_from_workspace(workspace_root),
+    )?;
+
+    assert_eq!(manager.config().agent.provider, "config-dir");
+    assert_eq!(manager.config_path(), Some(config_dir_config.as_path()));
+
+    Ok(())
+}
+
+#[test]
+fn loads_config_from_home_directory_when_workspace_missing() -> Result<()> {
+    let workspace = TempDir::new()?;
+    let workspace_root = workspace.path();
+    let config_dir = workspace_root.join(".vtcode");
+    fs::create_dir_all(&config_dir)?;
+
+    let home_config = workspace_root.join("home").join("vtcode.toml");
+    write_config(&home_config, "home")?;
+
+    let manager = with_test_defaults(
+        workspace_root,
+        config_dir,
+        vec![home_config.clone()],
+        || ConfigManager::load_from_workspace(workspace_root),
+    )?;
+
+    assert_eq!(manager.config().agent.provider, "home");
+    assert_eq!(manager.config_path(), Some(home_config.as_path()));
+
+    Ok(())
+}
+
+#[test]
+fn falls_back_to_default_config_when_no_files_found() -> Result<()> {
+    let workspace = TempDir::new()?;
+    let workspace_root = workspace.path();
+    let config_dir = workspace_root.join(".vtcode");
+    fs::create_dir_all(&config_dir)?;
+
+    let manager = with_test_defaults(workspace_root, config_dir, Vec::new(), || {
+        ConfigManager::load_from_workspace(workspace_root)
+    })?;
+
+    assert!(manager.config_path().is_none());
+    assert_eq!(manager.config().agent.provider, defaults::DEFAULT_PROVIDER);
+
+    Ok(())
+}

--- a/vtcode-config/tests/schema.rs
+++ b/vtcode-config/tests/schema.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "schema")]
+
+use vtcode_config::{vtcode_config_schema, vtcode_config_schema_json, vtcode_config_schema_pretty};
+
+#[test]
+fn schema_helpers_produce_consistent_output() {
+    let root = vtcode_config_schema();
+    let as_json = vtcode_config_schema_json().expect("schema to serialize to JSON value");
+    assert!(
+        as_json.is_object(),
+        "expected JSON schema representation to be an object"
+    );
+
+    let as_string = vtcode_config_schema_pretty().expect("schema to serialize to JSON string");
+    assert!(
+        as_string.contains("vtcode_config::loader::VTCodeConfig"),
+        "pretty schema output should mention the root configuration type"
+    );
+
+    // Ensure both helper paths describe the same schema title.
+    let title_from_value = as_json
+        .get("title")
+        .and_then(|value| value.as_str())
+        .expect("schema JSON should include a title");
+    let title_from_root = root
+        .schema
+        .metadata
+        .as_ref()
+        .and_then(|meta| meta.title.as_deref())
+        .unwrap_or("");
+    assert_eq!(title_from_value, title_from_root);
+}


### PR DESCRIPTION
## Summary
- document the vtcode-config crate with a top-level usage overview and example
- add integration-style tests covering ConfigManager search order with custom defaults providers
- mark the component extraction TODO item for vtcode-config testing/documentation as complete

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68f74fac654c8323bf30912bb35b6a2d