### PR TITLE
fix: allow indexing nested allowed directories

### DIFF
--- a/vtcode-indexer/src/lib.rs
+++ b/vtcode-indexer/src/lib.rs
@@ -385,7 +385,7 @@ impl SimpleIndexer {
         self.config
             .allowed_dirs
             .iter()
-            .any(|allowed| allowed == path)
+            .any(|allowed| path.starts_with(allowed))
     }
 
     fn walk_allowed_descendants<F>(&mut self, dir_path: &Path, callback: &mut F) -> Result<()>
@@ -406,7 +406,7 @@ impl SimpleIndexer {
             .config
             .allowed_dirs
             .iter()
-            .any(|allowed| allowed == path)
+            .any(|allowed| path.starts_with(allowed))
         {
             return false;
         }


### PR DESCRIPTION
## Summary
- extract the SimpleIndexer implementation into a new vtcode-indexer crate with configurable paths, allowlists, and tests
- wire vtcode-core to depend on the crate, re-export its SimpleIndexer, and update workspace membership
- record the vtcode-indexer milestone in the extraction plan and todo list while queuing follow-up tasks for pluggable storage and filters
- fix allowed directory traversal so nested descendants remain indexable

## Testing
- cargo fmt -p vtcode-indexer
- cargo clippy -p vtcode-indexer -- -D warnings
- cargo test -p vtcode-indexer


------
https://chatgpt.com/codex/tasks/task_e_68f7ba59464883238c719a6d09798e9c