### PR TITLE
Support interactive MCP elicitation handling

### DIFF
--- a/src/agent/runloop/mcp_elicitation.rs
+++ b/src/agent/runloop/mcp_elicitation.rs
@@ -1,0 +1,86 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use vtcode_core::mcp_client::{
+    ElicitationAction, McpElicitationHandler, McpElicitationRequest, McpElicitationResponse,
+};
+
+/// Interactive handler that prompts the user on the terminal when an MCP provider
+/// requests additional input via the elicitation flow.
+pub struct InteractiveMcpElicitationHandler {
+    prompt_lock: Mutex<()>,
+}
+
+impl InteractiveMcpElicitationHandler {
+    pub fn new() -> Self {
+        Self {
+            prompt_lock: Mutex::new(()),
+        }
+    }
+}
+
+#[async_trait]
+impl McpElicitationHandler for InteractiveMcpElicitationHandler {
+    async fn handle_elicitation(
+        &self,
+        provider: &str,
+        request: McpElicitationRequest,
+    ) -> Result<McpElicitationResponse> {
+        use std::io::{self, Write};
+
+        let _guard = self.prompt_lock.lock().await;
+
+        println!();
+        println!("=== MCP elicitation request from '{}' ===", provider);
+        println!("{}", request.message);
+
+        if !request.requested_schema.is_null() {
+            let schema_display = serde_json::to_string_pretty(&request.requested_schema)
+                .context("Failed to format MCP elicitation schema")?;
+            println!("Expected response schema:\n{}", schema_display);
+        }
+
+        println!(
+            "Enter JSON to accept, press Enter to decline, or type 'cancel' to cancel the operation."
+        );
+        print!("Response> ");
+        io::stdout().flush().ok();
+
+        let input = tokio::task::spawn_blocking(|| {
+            let mut buffer = String::new();
+            io::stdin().read_line(&mut buffer).map(|_| buffer)
+        })
+        .await
+        .context("Failed to read elicitation response")??;
+
+        let trimmed = input.trim();
+
+        if trimmed.eq_ignore_ascii_case("cancel") {
+            println!("Cancelling elicitation request from '{}'.", provider);
+            return Ok(McpElicitationResponse {
+                action: ElicitationAction::Cancel,
+                content: None,
+            });
+        }
+
+        if trimmed.is_empty() {
+            println!("Declining elicitation request from '{}'.", provider);
+            return Ok(McpElicitationResponse {
+                action: ElicitationAction::Decline,
+                content: None,
+            });
+        }
+
+        let content: Value =
+            serde_json::from_str(trimmed).context("Elicitation response must be valid JSON")?;
+
+        println!("Submitting elicitation response to '{}'.", provider);
+
+        Ok(McpElicitationResponse {
+            action: ElicitationAction::Accept,
+            content: Some(content),
+        })
+    }
+}

--- a/src/agent/runloop/mod.rs
+++ b/src/agent/runloop/mod.rs
@@ -8,6 +8,7 @@ use vtcode_core::utils::session_archive::SessionSnapshot;
 
 mod context;
 mod git;
+mod mcp_elicitation;
 mod mcp_events;
 mod model_picker;
 mod prompt;

--- a/src/agent/runloop/unified/session_setup.rs
+++ b/src/agent/runloop/unified/session_setup.rs
@@ -21,6 +21,7 @@ use super::prompts::read_system_prompt;
 use crate::agent::runloop::ResumeSession;
 use crate::agent::runloop::context::ContextTrimConfig;
 use crate::agent::runloop::context::load_context_trim_config;
+use crate::agent::runloop::mcp_elicitation::InteractiveMcpElicitationHandler;
 use crate::agent::runloop::mcp_events;
 use crate::agent::runloop::sandbox::SandboxCoordinator;
 use crate::agent::runloop::telemetry::build_trajectory_logger;
@@ -67,6 +68,7 @@ pub(crate) async fn initialize_session(
                 cfg.mcp.providers.len()
             );
             let mut client = McpClient::new(cfg.mcp.clone());
+            client.set_elicitation_handler(Arc::new(InteractiveMcpElicitationHandler::new()));
             match tokio::time::timeout(tokio::time::Duration::from_secs(30), client.initialize())
                 .await
             {


### PR DESCRIPTION
## Summary
- add an optional elicitation handler interface to the MCP client and pass it through provider and transport setup so providers can request end-user input instead of being auto-declined
- wire the CLI session setup to install a terminal-backed elicitation handler that prompts the user and returns their response when an MCP provider issues an elicitation request
- re-export MCP elicitation action types for downstream callers and log handler outcomes for better observability

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f91ff2288083239bacee3035061444