### PR TITLE
Add Accept-Language header for Z.AI requests

### DIFF
--- a/vtcode-config/src/constants.rs
+++ b/vtcode-config/src/constants.rs
@@ -476,6 +476,12 @@ pub mod urls {
     pub const OLLAMA_API_BASE: &str = "http://localhost:11434";
 }
 
+/// HTTP header constants for provider integrations
+pub mod headers {
+    pub const ACCEPT_LANGUAGE: &str = "Accept-Language";
+    pub const ACCEPT_LANGUAGE_DEFAULT: &str = "en-US,en";
+}
+
 /// Tool name constants to avoid hardcoding strings throughout the codebase
 pub mod tools {
     pub const GREP_FILE: &str = "grep_file";

--- a/vtcode-core/src/llm/providers/zai.rs
+++ b/vtcode-core/src/llm/providers/zai.rs
@@ -1,4 +1,4 @@
-use crate::config::constants::{models, urls};
+use crate::config::constants::{headers, models, urls};
 use crate::config::core::PromptCachingConfig;
 use crate::llm::client::LLMClient;
 use crate::llm::error_display;
@@ -488,6 +488,7 @@ impl LLMProvider for ZAIProvider {
             .http_client
             .post(&url)
             .bearer_auth(&self.api_key)
+            .header(headers::ACCEPT_LANGUAGE, headers::ACCEPT_LANGUAGE_DEFAULT)
             .json(&payload)
             .send()
             .await


### PR DESCRIPTION
## Summary
- add shared constants for Z.AI Accept-Language headers
- include the Accept-Language header on direct Z.AI chat completions requests to align with current API docs

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f99b4614bc8323a28920d70503bec8