### PR TITLE
Enhance Ollama tool support

### DIFF
--- a/docs/PROVIDER_GUIDES.md
+++ b/docs/PROVIDER_GUIDES.md
@@ -26,12 +26,14 @@ This index collects provider-specific guides for configuring VT Code with differ
   - [Model catalog](https://openrouter.ai/docs/llms)
 - Default models: `x-ai/grok-code-fast-1`, `qwen/qwen3-coder` (override via `vtcode.toml` or CLI `--model`).
 
-## Ollama Local Models
+## Ollama Local & Cloud Models
 
 - **Setup:** Install and run Ollama locally ([official install](https://ollama.com/download))
-- **Configuration:** No API key required since Ollama runs locally
+- **Configuration:** Local usage needs no key; set `OLLAMA_API_KEY` to access Ollama Cloud
 - **Default model:** Any locally available model (e.g., `llama3:8b`, `mistral:7b`, `qwen3:1.7b`)
-- **Custom Models:** Use the `custom-ollama` option in the model picker to enter any locally available model ID
-- **Base URL:** Configurable via `OLLAMA_BASE_URL` environment variable (defaults to `http://localhost:11434/v1`)
+- **Cloud models:** Use IDs like `gpt-oss:120b-cloud` with `OLLAMA_BASE_URL=https://ollama.com`
+- **Custom Models:** Use the `custom-ollama` option in the model picker to enter any locally or cloud-available model ID
+- **Base URL:** Configurable via `OLLAMA_BASE_URL` environment variable (defaults to `http://localhost:11434`)
+- **Features:** Streaming, structured tool calling (including Ollama's web search tools), and thinking traces when `reasoning_effort` is enabled
 
 > ℹ️ Additional provider-specific guides will be added as new integrations land in VT Code.

--- a/docs/models.json
+++ b/docs/models.json
@@ -1945,16 +1945,108 @@
   },
   "ollama": {
     "id": "ollama",
-    "env": [],
-    "api": "http://localhost:11434/v1",
-    "name": "Ollama Local",
+    "env": [
+      "OLLAMA_API_KEY (optional)"
+    ],
+    "api": "http://localhost:11434",
+    "name": "Ollama",
     "doc": "https://github.com/ollama/ollama/blob/main/docs/api.md",
     "models": {
       "gpt-oss:20b": {
         "id": "gpt-oss:20b",
-        "name": "GPT-OSS 20B",
+        "name": "GPT-OSS 20B (local)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "gpt-oss:120b-cloud": {
+        "id": "gpt-oss:120b-cloud",
+        "name": "GPT-OSS 120B (cloud)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "qwen3:1.7b": {
+        "id": "qwen3:1.7b",
+        "name": "Qwen3 1.7B (local)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 32768
+      },
+      "deepseek-v3.1:671b-cloud": {
+        "id": "deepseek-v3.1:671b-cloud",
+        "name": "DeepSeek V3.1 671B (cloud)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "kimi-k2:1t-cloud": {
+        "id": "kimi-k2:1t-cloud",
+        "name": "Kimi K2 1T (cloud)",
         "reasoning": false,
-        "tool_call": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "qwen3-coder:480b-cloud": {
+        "id": "qwen3-coder:480b-cloud",
+        "name": "Qwen3 Coder 480B (cloud)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "glm-4.6:cloud": {
+        "id": "glm-4.6:cloud",
+        "name": "GLM 4.6 (cloud)",
+        "reasoning": true,
+        "tool_call": true,
         "modalities": {
           "input": [
             "text"

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1,11 +1,12 @@
 # Ollama Provider Guide
 
-Ollama is a local AI model runner that allows you to run LLMs directly on your machine without requiring internet access or API keys. VT Code integrates with Ollama to provide local AI capabilities for coding tasks.
+Ollama can serve models locally on your machine or proxy larger releases through the Ollama Cloud service. VT Code integrates with both deployment modes so you can keep lightweight workflows offline while bursting to the cloud for heavier jobs.
 
 ## Prerequisites
 
 - Ollama installed and running locally ([download](https://ollama.com/download))
-- At least one model pulled locally (e.g., `ollama pull llama3:8b`)
+- Optional: Ollama Cloud account with an [API key](https://ollama.com/settings/keys) for remote models
+- At least one model pulled locally or in your cloud workspace (e.g., `ollama pull llama3:8b` or `ollama pull gpt-oss:120b-cloud`)
 
 ## Installation and Setup
 
@@ -29,7 +30,8 @@ Ollama is a local AI model runner that allows you to run LLMs directly on your m
 
 ### Environment Variables
 
-- `OLLAMA_BASE_URL` (optional): Custom Ollama endpoint (default: `http://localhost:11434/v1`)
+- `OLLAMA_BASE_URL` (optional): Custom Ollama endpoint (defaults to `http://localhost:11434`). Set to `https://ollama.com` to send requests directly to Ollama Cloud.
+- `OLLAMA_API_KEY` (optional): Required when connecting to Ollama Cloud. Not needed for purely local workloads.
 
 ### VT Code Configuration
 
@@ -39,7 +41,7 @@ Set up `vtcode.toml` in your project root:
 [agent]
 provider = "ollama"                    # Ollama provider
 default_model = "llama3:8b"           # Any locally available model
-# Note: No API key required for local Ollama
+# Note: API key only required when targeting Ollama Cloud
 
 [tools]
 default_policy = "prompt"             # Safety: "allow", "prompt", or "deny"
@@ -62,32 +64,78 @@ vtcode
 vtcode --provider ollama --model mistral:7b ask "Review this code"
 vtcode --provider ollama --model codellama:7b ask "Explain this function"
 vtcode --provider ollama --model gpt-oss-20b ask "Help with this implementation"
+vtcode --provider ollama --model gpt-oss:120b-cloud ask "Plan this large migration"
 ```
+
+The `/model` picker now lists the core Ollama catalog so you can choose them without typing IDs:
+
+- `gpt-oss:20b` (local)
+- `gpt-oss:120b-cloud`
+- `deepseek-v3.1:671b-cloud`
+- `kimi-k2:1t-cloud`
+- `qwen3:1.7b`
+- `qwen3-coder:480b-cloud`
+- `glm-4.6:cloud`
+
+These entries appear beneath the Ollama provider section alongside the "Custom Ollama model" option.
 
 ## OpenAI OSS Models Support
 
-VT Code includes support for OpenAI's open-source models that can be run via Ollama:
+VT Code includes support for OpenAI's open-source models that can be run via Ollama locally or through the cloud preview:
 
-- `gpt-oss-20b`: Open-source 20B parameter model from OpenAI
+- `gpt-oss-20b`: Open-source 20B parameter model from OpenAI (local)
+- `gpt-oss:120b-cloud`: Cloud-hosted 120B parameter model managed by Ollama
 
 To use these models:
 
 ```bash
-# Pull the model first
+# Pull the model first (local or cloud)
 ollama pull gpt-oss-20b
+ollama pull gpt-oss:120b-cloud
 
 # Use in VT Code
 vtcode --provider ollama --model gpt-oss-20b ask "Code review this function"
+vtcode --provider ollama --model gpt-oss:120b-cloud ask "Assist with this architecture review"
 ```
+
+## Tool calling and web search integration
+
+Ollama's API exposes OpenAI-compatible [tool calling](https://docs.ollama.com/capabilities/tool-calling) as well as the [web search](https://docs.ollama.com/capabilities/web-search) helpers. VT Code now forwards tool definitions to Ollama and surfaces any `tool_calls` responses from the model. A typical workflow looks like this:
+
+1. Define tools in `vtcode.toml` (or via slash commands) with JSON schemas that match your functions. For example, expose `web_search` and `web_fetch` so the agent can call Ollama's hosted knowledge tools.
+2. The agent will stream back `tool_calls` with structured arguments. VT Code automatically routes each call to the configured tool runner and includes the results as `tool` messages in the follow-up request.
+3. Ollama's responses can include multiple tools per turn. VT Code enforces `tool_call_id` requirements for reliability while still letting the model decide when to call a tool.
+
+Because the provider now understands these payloads you can mix Ollama's native utilities with your existing MCP toolchain.
+
+## Thinking traces and streaming
+
+Thinking-capable models such as `gpt-oss` and `qwen3` emit a dedicated `thinking` channel ([docs](https://docs.ollama.com/capabilities/thinking)). Set the reasoning effort to `medium` or `high` (e.g., `vtcode --reasoning high`) or configure `reasoning_effort = "high"` in `vtcode.toml` and VT Code forwards the appropriate `think` parameter (`low`/`medium`/`high` for GPT-OSS, boolean for Qwen). During streaming runs you will now see separate "Reasoning" lines followed by the final answer tokens so you can inspect or hide the trace as needed.
+
+Ollama continues to support incremental streaming ([docs](https://docs.ollama.com/capabilities/streaming)), and VT Code uses it by default. Combine reasoning with streaming to watch the model deliberate before it produces the final response.
+
+## Using Ollama Cloud directly
+
+When you have an Ollama API key you can target the managed endpoint without running a local server:
+
+```bash
+export OLLAMA_API_KEY="sk-..."
+export OLLAMA_BASE_URL="https://ollama.com"
+
+vtcode --provider ollama --model gpt-oss:120b-cloud ask "Summarize this spec"
+```
+
+VT Code automatically attaches the bearer token to requests when the API key is present.
 
 ## Troubleshooting
 
 ### Common Issues
 
-1. **"Connection refused" errors**: Ensure Ollama server is running (`ollama serve`)
+1. **"Connection refused" errors**: Ensure Ollama server is running (`ollama serve`) or that `OLLAMA_BASE_URL` points to a reachable endpoint
 2. **Model not found**: Ensure the requested model has been pulled (`ollama pull MODEL_NAME`)
-3. **Performance issues**: Consider model size - larger models require more RAM
-4. **Memory errors**: For large models like gpt-oss-120b, ensure sufficient RAM (64GB+ recommended)
+3. **Unauthorized (401) errors**: Set `OLLAMA_API_KEY` when targeting Ollama Cloud
+4. **Performance issues**: Consider model size - larger models require more RAM
+5. **Memory errors**: For large local models like gpt-oss-120b, ensure sufficient RAM (64GB+ recommended)
 
 ### Testing Ollama Connection
 

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -227,11 +227,12 @@ impl ModelPickerState {
         })?;
         let mut config = manager.config().clone();
         config.agent.provider = selection.provider.clone();
-        
+
         // For local Ollama models, do not store API key environment variable since they don't require them
         // For cloud Ollama models, store the environment variable reference
         if selection.provider_enum == Some(Provider::Ollama) {
-            let is_cloud_model = selection.model.contains(":cloud") || selection.model.contains("-cloud");
+            let is_cloud_model =
+                selection.model.contains(":cloud") || selection.model.contains("-cloud");
             if is_cloud_model {
                 // Cloud Ollama models should keep the API key environment variable
                 config.agent.api_key_env = selection.env_key.clone();
@@ -259,10 +260,10 @@ impl ModelPickerState {
                 config.agent.custom_api_keys.remove(&selection.provider);
             }
         }
-        
+
         config.agent.default_model = selection.model.clone();
         config.agent.reasoning_effort = selection.reasoning;
-        
+
         config.router.models.simple = selection.model.clone();
         config.router.models.standard = selection.model.clone();
         config.router.models.complex = selection.model.clone();
@@ -307,19 +308,17 @@ impl ModelPickerState {
                     renderer.line(MessageStyle::Error, CLOSE_THEME_MESSAGE)?;
                     Ok(ModelPickerProgress::InProgress)
                 }
-                InlineListSelection::Session(_) 
-                | InlineListSelection::SlashCommand(_) 
-                | InlineListSelection::ToolApproval(_) => {
-                    Ok(ModelPickerProgress::InProgress)
-                }
+                InlineListSelection::Session(_)
+                | InlineListSelection::SlashCommand(_)
+                | InlineListSelection::ToolApproval(_) => Ok(ModelPickerProgress::InProgress),
             },
             PickerStep::AwaitReasoning => match choice {
                 InlineListSelection::Reasoning(level) => {
                     renderer.close_modal();
                     self.apply_reasoning_choice(renderer, level)
                 }
-                InlineListSelection::CustomModel 
-                | InlineListSelection::Model(_) 
+                InlineListSelection::CustomModel
+                | InlineListSelection::Model(_)
                 | InlineListSelection::ToolApproval(_) => {
                     renderer.line(
                         MessageStyle::Error,
@@ -331,8 +330,7 @@ impl ModelPickerState {
                     renderer.line(MessageStyle::Error, CLOSE_THEME_MESSAGE)?;
                     Ok(ModelPickerProgress::InProgress)
                 }
-                InlineListSelection::Session(_) 
-                | InlineListSelection::SlashCommand(_) => {
+                InlineListSelection::Session(_) | InlineListSelection::SlashCommand(_) => {
                     Ok(ModelPickerProgress::InProgress)
                 }
             },
@@ -1187,14 +1185,15 @@ fn parse_model_selection(options: &[ModelOption], input: &str) -> Result<Selecti
         .unwrap_or(false);
     let requires_api_key = if provider_enum == Some(Provider::Ollama) {
         // For Ollama, only cloud models (containing ":cloud" or "-cloud") require API keys
-        let is_cloud_model = model_token.trim().contains(":cloud") || model_token.trim().contains("-cloud");
+        let is_cloud_model =
+            model_token.trim().contains(":cloud") || model_token.trim().contains("-cloud");
         if is_cloud_model {
             match std::env::var(&env_key) {
                 Ok(value) => value.trim().is_empty(),
                 Err(_) => true,
             }
         } else {
-            false  // Local Ollama models don't require an API key
+            false // Local Ollama models don't require an API key
         }
     } else {
         match std::env::var(&env_key) {
@@ -1228,7 +1227,7 @@ fn selection_from_option(option: &ModelOption) -> SelectionDetail {
                 Err(_) => true,
             }
         } else {
-            false  // Local Ollama models don't require an API key
+            false // Local Ollama models don't require an API key
         }
     } else {
         match std::env::var(&env_key) {

--- a/src/agent/runloop/text_tools.rs
+++ b/src/agent/runloop/text_tools.rs
@@ -383,12 +383,13 @@ fn parse_channel_tool_call(text: &str) -> Option<(String, Value)> {
 
     // Extract the channel commentary to find tool name
     // Handle both formats: with and without <|constrain|> tag
-    let channel_end = if let Some(constrain_pos) = text[channel_start..message_start].find("<|constrain|>") {
-        channel_start + "<|channel|>".len() + constrain_pos
-    } else {
-        message_start
-    };
-    
+    let channel_end =
+        if let Some(constrain_pos) = text[channel_start..message_start].find("<|constrain|>") {
+            channel_start + "<|channel|>".len() + constrain_pos
+        } else {
+            message_start
+        };
+
     let channel_text = &text[channel_start + "<|channel|>".len()..channel_end];
 
     // Parse tool name from channel commentary
@@ -424,7 +425,7 @@ fn parse_channel_tool_call(text: &str) -> Option<(String, Value)> {
 fn parse_tool_name_from_reference(tool_ref: &str) -> &str {
     match tool_ref {
         "repo_browser.list_files" | "list_files" => "list_files",
-        "repo_browser.read_file" | "read_file" => "read_file", 
+        "repo_browser.read_file" | "read_file" => "read_file",
         "repo_browser.write_file" | "write_file" => "write_file",
         "container.exec" | "exec" => "run_terminal_cmd",
         "bash" => "bash",
@@ -464,18 +465,18 @@ fn convert_harmony_args_to_tool_format(tool_name: &str, parsed: Value) -> Value 
         "list_files" => {
             // Convert harmony list_files format to vtcode format
             let mut args = serde_json::Map::new();
-            
+
             if let Some(path) = parsed.get("path") {
                 args.insert("path".to_string(), path.clone());
             }
-            
+
             if let Some(recursive) = parsed.get("recursive") {
                 args.insert("recursive".to_string(), recursive.clone());
             }
-            
+
             Value::Object(args)
         }
-        _ => parsed
+        _ => parsed,
     }
 }
 
@@ -1340,7 +1341,8 @@ mode: overwrite
 
     #[test]
     fn test_parse_harmony_channel_tool_call_with_string_cmd() {
-        let message = "<|start|>assistant<|channel|>commentary to=bash<|message|>{\"cmd\":\"pwd\"}<|call|>";
+        let message =
+            "<|start|>assistant<|channel|>commentary to=bash<|message|>{\"cmd\":\"pwd\"}<|call|>";
         let (name, args) = detect_textual_tool_call(message).expect("should parse harmony format");
         assert_eq!(name, "bash");
         assert_eq!(args["command"], serde_json::json!(["pwd"]));

--- a/src/agent/runloop/unified/tool_routing.rs
+++ b/src/agent/runloop/unified/tool_routing.rs
@@ -104,7 +104,7 @@ pub(crate) async fn prompt_tool_permission<S: UiSession + ?Sized>(
             InlineEvent::ListModalSubmit(selection) => {
                 handle.close_modal();
                 handle.clear_input();
-                
+
                 match selection {
                     InlineListSelection::ToolApproval(true) => {
                         return Ok(HitlDecision::Approved);

--- a/src/agent/runloop/unified/tool_summary.rs
+++ b/src/agent/runloop/unified/tool_summary.rs
@@ -374,10 +374,10 @@ mod tests {
         let args = json!({
             "command": ["bash", "-lc", "ls -R"]
         });
-        
+
         let result = describe_shell_command(&args);
         assert!(result.is_some());
-        
+
         let (description, _used) = result.unwrap();
         assert_eq!(description, "[Command] `bash -lc ls -R`");
     }
@@ -387,10 +387,10 @@ mod tests {
         let args = json!({
             "bash_command": "pwd"
         });
-        
+
         let result = describe_shell_command(&args);
         assert!(result.is_some());
-        
+
         let (description, _used) = result.unwrap();
         assert_eq!(description, "[Command] `pwd`");
     }
@@ -401,10 +401,10 @@ mod tests {
         let args = json!({
             "command": [long_command]
         });
-        
+
         let result = describe_shell_command(&args);
         assert!(result.is_some());
-        
+
         let (description, _used) = result.unwrap();
         assert!(description.starts_with("[Command] `"));
         assert!(description.ends_with("`"));

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -193,7 +193,7 @@ fn is_sensitive_key(key: &str) -> bool {
 fn strip_harmony_syntax(text: &str) -> String {
     // Remove harmony tool call patterns
     let mut result = text.to_string();
-    
+
     // Pattern: <|start|>assistant<|channel|>commentary to=... <|constrain|>...<|message|>...<|call|>
     // We want to remove everything from <|start|> to <|call|> inclusive
     while let Some(start_pos) = result.find("<|start|>") {
@@ -205,13 +205,13 @@ fn strip_harmony_syntax(text: &str) -> String {
             result.replace_range(start_pos..start_pos + "<|start|>".len(), "");
         }
     }
-    
+
     // Clean up any remaining harmony tags
     result = result.replace("<|channel|>", "");
     result = result.replace("<|constrain|>", "");
     result = result.replace("<|message|>", "");
     result = result.replace("<|call|>", "");
-    
+
     // Clean up extra whitespace
     result.trim().to_string()
 }
@@ -1435,7 +1435,10 @@ pub(crate) async fn run_single_agent_loop_unified(
 
             // Strip harmony syntax from displayed content if present
             if let Some(ref text) = final_text {
-                if text.contains("<|start|>") || text.contains("<|channel|>") || text.contains("<|call|>") {
+                if text.contains("<|start|>")
+                    || text.contains("<|channel|>")
+                    || text.contains("<|call|>")
+                {
                     // Remove harmony tool call syntax from the displayed text
                     let cleaned = strip_harmony_syntax(text);
                     if !cleaned.trim().is_empty() {
@@ -1734,7 +1737,10 @@ pub(crate) async fn run_single_agent_loop_unified(
 
                                     // Don't short-circuit - let the agent reason about tool output
                                     // The agent should always have a chance to process and explain results
-                                    let _ = (command_success, should_short_circuit_shell(input, name, &args_val));
+                                    let _ = (
+                                        command_success,
+                                        should_short_circuit_shell(input, name, &args_val),
+                                    );
                                 }
                                 ToolExecutionStatus::Failure { error } => {
                                     tool_spinner.finish();
@@ -1743,13 +1749,13 @@ pub(crate) async fn run_single_agent_loop_unified(
                                     tokio::time::sleep(Duration::from_millis(50)).await;
 
                                     session_stats.record_tool(name);
-                                    
+
                                     // Display failure indicator with clear messaging
                                     renderer.line(
                                         MessageStyle::Error,
                                         &format!("\x1b[31m✗\x1b[0m Tool '{}' failed", name),
                                     )?;
-                                    
+
                                     traj.log_tool_call(
                                         working_history.len(),
                                         name,
@@ -1807,10 +1813,12 @@ pub(crate) async fn run_single_agent_loop_unified(
                                         MessageStyle::Error,
                                         &format!("Error: {}", error_message),
                                     )?;
-                                    
+
                                     // Display error type for better understanding
                                     let error_type_msg = match classified_clone {
-                                        ToolErrorType::InvalidParameters => "Invalid parameters provided",
+                                        ToolErrorType::InvalidParameters => {
+                                            "Invalid parameters provided"
+                                        }
                                         ToolErrorType::ToolNotFound => "Tool not found",
                                         ToolErrorType::ResourceNotFound => "Resource not found",
                                         ToolErrorType::PermissionDenied => "Permission denied",
@@ -1823,7 +1831,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                                         MessageStyle::Info,
                                         &format!("Type: {}", error_type_msg),
                                     )?;
-                                    
+
                                     // Encourage retry with helpful message
                                     renderer.line(
                                         MessageStyle::Info,
@@ -2092,7 +2100,10 @@ pub(crate) async fn run_single_agent_loop_unified(
             // to let the agent see tool results and decide next steps
             #[cfg(debug_assertions)]
             {
-                renderer.line(MessageStyle::Info, "Tools executed, continuing to get model response...")?;
+                renderer.line(
+                    MessageStyle::Info,
+                    "Tools executed, continuing to get model response...",
+                )?;
             }
             continue;
         };

--- a/tests/tool_call_verification.rs
+++ b/tests/tool_call_verification.rs
@@ -283,7 +283,10 @@ fn test_all_providers_tool_validation() {
         reasoning_effort: None,
     };
 
-    assert!(ollama.validate_request(&ollama_request).is_err());
+    assert!(
+        ollama.validate_request(&ollama_request).is_ok(),
+        "Ollama should accept tool-bearing requests"
+    );
 }
 
 #[test]
@@ -401,11 +404,13 @@ fn test_provider_tool_support_matrix() {
         }
     }
 
-    assert!(
-        !ollama.supports_tools(models::ollama::DEFAULT_MODEL),
-        "Ollama should disable tool calling for {}",
-        models::ollama::DEFAULT_MODEL
-    );
+    for &model in models::ollama::SUPPORTED_MODELS {
+        assert!(
+            ollama.supports_tools(model),
+            "Ollama should advertise tool calling for {}",
+            model
+        );
+    }
 
     for &model in models::openai::TOOL_UNAVAILABLE_MODELS {
         assert!(

--- a/vtcode-config/src/api_keys.rs
+++ b/vtcode-config/src/api_keys.rs
@@ -25,6 +25,8 @@ pub struct ApiKeySources {
     pub deepseek_env: String,
     /// Z.AI API key environment variable name
     pub zai_env: String,
+    /// Ollama API key environment variable name
+    pub ollama_env: String,
     /// Gemini API key from configuration file
     pub gemini_config: Option<String>,
     /// Anthropic API key from configuration file
@@ -39,6 +41,8 @@ pub struct ApiKeySources {
     pub deepseek_config: Option<String>,
     /// Z.AI API key from configuration file
     pub zai_config: Option<String>,
+    /// Ollama API key from configuration file
+    pub ollama_config: Option<String>,
 }
 
 impl Default for ApiKeySources {
@@ -51,6 +55,7 @@ impl Default for ApiKeySources {
             xai_env: "XAI_API_KEY".to_string(),
             deepseek_env: "DEEPSEEK_API_KEY".to_string(),
             zai_env: "ZAI_API_KEY".to_string(),
+            ollama_env: "OLLAMA_API_KEY".to_string(),
             gemini_config: None,
             anthropic_config: None,
             openai_config: None,
@@ -58,6 +63,7 @@ impl Default for ApiKeySources {
             xai_config: None,
             deepseek_config: None,
             zai_config: None,
+            ollama_config: None,
         }
     }
 }
@@ -73,6 +79,7 @@ impl ApiKeySources {
             "openrouter" => ("OPENROUTER_API_KEY", vec![]),
             "xai" => ("XAI_API_KEY", vec![]),
             "zai" => ("ZAI_API_KEY", vec![]),
+            "ollama" => ("OLLAMA_API_KEY", vec![]),
             _ => ("GEMINI_API_KEY", vec!["GOOGLE_API_KEY"]),
         };
 
@@ -113,6 +120,11 @@ impl ApiKeySources {
             } else {
                 "ZAI_API_KEY".to_string()
             },
+            ollama_env: if provider == "ollama" {
+                primary_env.to_string()
+            } else {
+                "OLLAMA_API_KEY".to_string()
+            },
             gemini_config: None,
             anthropic_config: None,
             openai_config: None,
@@ -120,6 +132,7 @@ impl ApiKeySources {
             xai_config: None,
             deepseek_config: None,
             zai_config: None,
+            ollama_config: None,
         }
     }
 }
@@ -177,6 +190,7 @@ pub fn get_api_key(provider: &str, sources: &ApiKeySources) -> Result<String> {
         "openrouter" => "OPENROUTER_API_KEY",
         "xai" => "XAI_API_KEY",
         "zai" => "ZAI_API_KEY",
+        "ollama" => "OLLAMA_API_KEY",
         _ => "GEMINI_API_KEY",
     };
 
@@ -196,6 +210,7 @@ pub fn get_api_key(provider: &str, sources: &ApiKeySources) -> Result<String> {
         "openrouter" => get_openrouter_api_key(sources),
         "xai" => get_xai_api_key(sources),
         "zai" => get_zai_api_key(sources),
+        "ollama" => get_ollama_api_key(sources),
         _ => Err(anyhow::anyhow!("Unsupported provider: {}", provider)),
     }
 }
@@ -302,6 +317,11 @@ fn get_deepseek_api_key(sources: &ApiKeySources) -> Result<String> {
 /// Get Z.AI API key with secure fallback
 fn get_zai_api_key(sources: &ApiKeySources) -> Result<String> {
     get_api_key_with_fallback(&sources.zai_env, sources.zai_config.as_ref(), "Z.AI")
+}
+
+/// Get Ollama API key with secure fallback
+fn get_ollama_api_key(sources: &ApiKeySources) -> Result<String> {
+    get_api_key_with_fallback(&sources.ollama_env, sources.ollama_config.as_ref(), "Ollama")
 }
 
 #[cfg(test)]
@@ -472,5 +492,45 @@ mod tests {
 
         let result = get_openai_api_key(&sources);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_ollama_api_key_from_env() {
+        // Set environment variable
+        unsafe {
+            env::set_var("TEST_OLLAMA_KEY", "test-ollama-key");
+        }
+
+        let sources = ApiKeySources {
+            ollama_env: "TEST_OLLAMA_KEY".to_string(),
+            ..Default::default()
+        };
+
+        let result = get_ollama_api_key(&sources);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "test-ollama-key");
+
+        // Clean up
+        unsafe {
+            env::remove_var("TEST_OLLAMA_KEY");
+        }
+    }
+
+    #[test]
+    fn test_get_api_key_ollama_provider() {
+        // Set environment variable
+        unsafe {
+            env::set_var("OLLAMA_API_KEY", "test-ollama-env-key");
+        }
+
+        let sources = ApiKeySources::default();
+        let result = get_api_key("ollama", &sources);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "test-ollama-env-key");
+
+        // Clean up
+        unsafe {
+            env::remove_var("OLLAMA_API_KEY");
+        }
     }
 }

--- a/vtcode-config/src/constants.rs
+++ b/vtcode-config/src/constants.rs
@@ -111,11 +111,37 @@ pub mod models {
     }
 
     pub mod ollama {
-        pub const DEFAULT_MODEL: &str = "gpt-oss:20b";
-        pub const SUPPORTED_MODELS: &[&str] = &[DEFAULT_MODEL, QWEN3_1_7B];
+        pub const DEFAULT_LOCAL_MODEL: &str = "gpt-oss:20b";
+        pub const DEFAULT_CLOUD_MODEL: &str = "gpt-oss:120b-cloud";
+        pub const DEFAULT_MODEL: &str = DEFAULT_LOCAL_MODEL;
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            DEFAULT_LOCAL_MODEL,
+            QWEN3_1_7B,
+            DEFAULT_CLOUD_MODEL,
+            DEEPSEEK_V31_671B_CLOUD,
+            KIMI_K2_1T_CLOUD,
+            QWEN3_CODER_480B_CLOUD,
+            GLM_46_CLOUD,
+        ];
 
-        pub const GPT_OSS_20B: &str = DEFAULT_MODEL;
+        /// Models that emit structured reasoning traces when `think` is enabled
+        pub const REASONING_MODELS: &[&str] = &[
+            GPT_OSS_20B,
+            GPT_OSS_120B_CLOUD,
+            QWEN3_1_7B,
+            QWEN3_CODER_480B_CLOUD,
+        ];
+
+        /// Models that require an explicit reasoning effort level instead of boolean toggle
+        pub const REASONING_LEVEL_MODELS: &[&str] = &[GPT_OSS_20B, GPT_OSS_120B_CLOUD];
+
+        pub const GPT_OSS_20B: &str = DEFAULT_LOCAL_MODEL;
+        pub const GPT_OSS_120B_CLOUD: &str = DEFAULT_CLOUD_MODEL;
         pub const QWEN3_1_7B: &str = "qwen3:1.7b";
+        pub const DEEPSEEK_V31_671B_CLOUD: &str = "deepseek-v3.1:671b-cloud";
+        pub const KIMI_K2_1T_CLOUD: &str = "kimi-k2:1t-cloud";
+        pub const QWEN3_CODER_480B_CLOUD: &str = "qwen3-coder:480b-cloud";
+        pub const GLM_46_CLOUD: &str = "glm-4.6:cloud";
     }
 
     // DeepSeek models (native API)
@@ -474,6 +500,7 @@ pub mod urls {
     pub const Z_AI_API_BASE: &str = "https://api.z.ai/api";
     pub const MOONSHOT_API_BASE: &str = "https://api.moonshot.cn/v1";
     pub const OLLAMA_API_BASE: &str = "http://localhost:11434";
+    pub const OLLAMA_CLOUD_API_BASE: &str = "https://ollama.com";
 }
 
 /// Tool name constants to avoid hardcoding strings throughout the codebase

--- a/vtcode-config/src/models.rs
+++ b/vtcode-config/src/models.rs
@@ -242,6 +242,10 @@ pub enum ModelId {
     MoonshotKimiLatest128k,
 
     // Ollama models
+    /// GPT-OSS 20B - Open-weight GPT-OSS 20B model served via Ollama locally
+    OllamaGptOss20b,
+    /// GPT-OSS 120B Cloud - Cloud-hosted GPT-OSS 120B served via Ollama Cloud
+    OllamaGptOss120bCloud,
     /// Qwen3 1.7B - Qwen3 1.7B model served via Ollama
     OllamaQwen317b,
 
@@ -415,6 +419,8 @@ impl ModelId {
             ModelId::MoonshotKimiLatest32k => models::MOONSHOT_KIMI_LATEST_32K,
             ModelId::MoonshotKimiLatest128k => models::MOONSHOT_KIMI_LATEST_128K,
             // Ollama models
+            ModelId::OllamaGptOss20b => models::ollama::GPT_OSS_20B,
+            ModelId::OllamaGptOss120bCloud => models::ollama::GPT_OSS_120B_CLOUD,
             ModelId::OllamaQwen317b => models::ollama::QWEN3_1_7B,
             // OpenRouter models
             _ => unreachable!(),
@@ -462,7 +468,9 @@ impl ModelId {
             | ModelId::MoonshotKimiLatest8k
             | ModelId::MoonshotKimiLatest32k
             | ModelId::MoonshotKimiLatest128k => Provider::Moonshot,
-            ModelId::OllamaQwen317b => Provider::Ollama,
+            ModelId::OllamaGptOss20b | ModelId::OllamaGptOss120bCloud | ModelId::OllamaQwen317b => {
+                Provider::Ollama
+            }
             _ => unreachable!(),
         }
     }
@@ -520,6 +528,8 @@ impl ModelId {
             ModelId::MoonshotKimiLatest32k => "Kimi Latest 32K",
             ModelId::MoonshotKimiLatest128k => "Kimi Latest 128K",
             // Ollama models
+            ModelId::OllamaGptOss20b => "GPT-OSS 20B (local)",
+            ModelId::OllamaGptOss120bCloud => "GPT-OSS 120B (cloud)",
             ModelId::OllamaQwen317b => "Qwen3 1.7B (local)",
             // OpenRouter models
             _ => unreachable!(),
@@ -615,6 +625,12 @@ impl ModelId {
             ModelId::MoonshotKimiLatest128k => {
                 "Kimi Latest 128K flagship vision tier delivering maximum context and newest capabilities"
             }
+            ModelId::OllamaGptOss20b => {
+                "Local GPT-OSS 20B deployment served via Ollama with no external API dependency"
+            }
+            ModelId::OllamaGptOss120bCloud => {
+                "Cloud-hosted GPT-OSS 120B accessed through Ollama Cloud for larger reasoning tasks"
+            }
             ModelId::OllamaQwen317b => {
                 "Qwen3 1.7B served locally through Ollama without external API requirements"
             }
@@ -672,6 +688,8 @@ impl ModelId {
             ModelId::MoonshotKimiLatest32k,
             ModelId::MoonshotKimiLatest128k,
             // Ollama models
+            ModelId::OllamaGptOss20b,
+            ModelId::OllamaGptOss120bCloud,
             ModelId::OllamaQwen317b,
         ];
         models.extend(Self::openrouter_models());
@@ -723,7 +741,7 @@ impl ModelId {
             Provider::Moonshot => ModelId::MoonshotKimiK20905Preview,
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
-            Provider::Ollama => ModelId::OllamaQwen317b,
+            Provider::Ollama => ModelId::OllamaGptOss20b,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -753,7 +771,7 @@ impl ModelId {
             Provider::Moonshot => ModelId::MoonshotKimiK2TurboPreview,
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
-            Provider::Ollama => ModelId::OllamaQwen317b,
+            Provider::Ollama => ModelId::OllamaGptOss20b,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -893,6 +911,8 @@ impl ModelId {
             | ModelId::MoonshotKimiLatest8k
             | ModelId::MoonshotKimiLatest32k
             | ModelId::MoonshotKimiLatest128k => "latest",
+            ModelId::OllamaGptOss20b => "oss",
+            ModelId::OllamaGptOss120bCloud => "oss-cloud",
             ModelId::OllamaQwen317b => "oss",
             _ => unreachable!(),
         }
@@ -960,6 +980,8 @@ impl FromStr for ModelId {
             s if s == models::MOONSHOT_KIMI_LATEST_8K => Ok(ModelId::MoonshotKimiLatest8k),
             s if s == models::MOONSHOT_KIMI_LATEST_32K => Ok(ModelId::MoonshotKimiLatest32k),
             s if s == models::MOONSHOT_KIMI_LATEST_128K => Ok(ModelId::MoonshotKimiLatest128k),
+            s if s == models::ollama::GPT_OSS_20B => Ok(ModelId::OllamaGptOss20b),
+            s if s == models::ollama::GPT_OSS_120B_CLOUD => Ok(ModelId::OllamaGptOss120bCloud),
             s if s == models::ollama::QWEN3_1_7B => Ok(ModelId::OllamaQwen317b),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
@@ -1276,6 +1298,8 @@ mod tests {
             ModelId::MoonshotKimiK20905Preview.provider(),
             Provider::Moonshot
         );
+        assert_eq!(ModelId::OllamaGptOss20b.provider(), Provider::Ollama);
+        assert_eq!(ModelId::OllamaGptOss120bCloud.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaQwen317b.provider(), Provider::Ollama);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
@@ -1319,7 +1343,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_orchestrator_for_provider(Provider::Ollama),
-            ModelId::OllamaQwen317b
+            ModelId::OllamaGptOss20b
         );
         assert_eq!(
             ModelId::default_orchestrator_for_provider(Provider::ZAI),
@@ -1377,7 +1401,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_single_for_provider(Provider::Ollama),
-            ModelId::OllamaQwen317b
+            ModelId::OllamaGptOss20b
         );
     }
 
@@ -1553,8 +1577,10 @@ mod tests {
         assert_eq!(moonshot_models.len(), 7);
 
         let ollama_models = ModelId::models_for_provider(Provider::Ollama);
+        assert!(ollama_models.contains(&ModelId::OllamaGptOss20b));
+        assert!(ollama_models.contains(&ModelId::OllamaGptOss120bCloud));
         assert!(ollama_models.contains(&ModelId::OllamaQwen317b));
-        assert_eq!(ollama_models.len(), 1);
+        assert_eq!(ollama_models.len(), 3);
     }
 
     #[test]

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -106,7 +106,7 @@ impl Provider {
                 }
                 models::openrouter::REASONING_MODELS.contains(&model)
             }
-            Provider::Ollama => false,
+            Provider::Ollama => models::ollama::REASONING_LEVEL_MODELS.contains(&model),
             Provider::Moonshot => false,
             Provider::XAI => model == models::xai::GROK_4 || model == models::xai::GROK_4_CODE,
             Provider::ZAI => model == models::zai::GLM_4_6,
@@ -239,8 +239,20 @@ pub enum ModelId {
     MoonshotKimiLatest128k,
 
     // Ollama models
+    /// GPT-OSS 20B - Open-weight GPT-OSS 20B model served via Ollama locally
+    OllamaGptOss20b,
+    /// GPT-OSS 120B Cloud - Cloud-hosted GPT-OSS 120B served via Ollama Cloud
+    OllamaGptOss120bCloud,
     /// Qwen3 1.7B - Qwen3 1.7B model served via Ollama
     OllamaQwen317b,
+    /// DeepSeek V3.1 671B Cloud - DeepSeek reasoning deployment via Ollama Cloud
+    OllamaDeepseekV31_671bCloud,
+    /// Kimi K2 1T Cloud - Kimi flagship model hosted by Ollama Cloud
+    OllamaKimiK21tCloud,
+    /// Qwen3 Coder 480B Cloud - Large Qwen3 coding specialist via Ollama Cloud
+    OllamaQwen3Coder480bCloud,
+    /// GLM 4.6 Cloud - GLM 4.6 reasoning model via Ollama Cloud
+    OllamaGlm46Cloud,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model powered by xAI Grok
@@ -412,7 +424,13 @@ impl ModelId {
             ModelId::MoonshotKimiLatest32k => models::MOONSHOT_KIMI_LATEST_32K,
             ModelId::MoonshotKimiLatest128k => models::MOONSHOT_KIMI_LATEST_128K,
             // Ollama models
+            ModelId::OllamaGptOss20b => models::ollama::GPT_OSS_20B,
+            ModelId::OllamaGptOss120bCloud => models::ollama::GPT_OSS_120B_CLOUD,
             ModelId::OllamaQwen317b => models::ollama::QWEN3_1_7B,
+            ModelId::OllamaDeepseekV31_671bCloud => models::ollama::DEEPSEEK_V31_671B_CLOUD,
+            ModelId::OllamaKimiK21tCloud => models::ollama::KIMI_K2_1T_CLOUD,
+            ModelId::OllamaQwen3Coder480bCloud => models::ollama::QWEN3_CODER_480B_CLOUD,
+            ModelId::OllamaGlm46Cloud => models::ollama::GLM_46_CLOUD,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -459,7 +477,13 @@ impl ModelId {
             | ModelId::MoonshotKimiLatest8k
             | ModelId::MoonshotKimiLatest32k
             | ModelId::MoonshotKimiLatest128k => Provider::Moonshot,
-            ModelId::OllamaQwen317b => Provider::Ollama,
+            ModelId::OllamaGptOss20b
+            | ModelId::OllamaGptOss120bCloud
+            | ModelId::OllamaQwen317b
+            | ModelId::OllamaDeepseekV31_671bCloud
+            | ModelId::OllamaKimiK21tCloud
+            | ModelId::OllamaQwen3Coder480bCloud
+            | ModelId::OllamaGlm46Cloud => Provider::Ollama,
             _ => unreachable!(),
         }
     }
@@ -517,7 +541,13 @@ impl ModelId {
             ModelId::MoonshotKimiLatest32k => "Kimi Latest 32K",
             ModelId::MoonshotKimiLatest128k => "Kimi Latest 128K",
             // Ollama models
+            ModelId::OllamaGptOss20b => "GPT-OSS 20B (local)",
+            ModelId::OllamaGptOss120bCloud => "GPT-OSS 120B (cloud)",
             ModelId::OllamaQwen317b => "Qwen3 1.7B (local)",
+            ModelId::OllamaDeepseekV31_671bCloud => "DeepSeek V3.1 671B (cloud)",
+            ModelId::OllamaKimiK21tCloud => "Kimi K2 1T (cloud)",
+            ModelId::OllamaQwen3Coder480bCloud => "Qwen3 Coder 480B (cloud)",
+            ModelId::OllamaGlm46Cloud => "GLM 4.6 (cloud)",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -612,8 +642,26 @@ impl ModelId {
             ModelId::MoonshotKimiLatest128k => {
                 "Kimi Latest 128K flagship vision tier delivering maximum context and newest capabilities"
             }
+            ModelId::OllamaGptOss20b => {
+                "Local GPT-OSS 20B deployment served via Ollama with no external API dependency"
+            }
+            ModelId::OllamaGptOss120bCloud => {
+                "Cloud-hosted GPT-OSS 120B accessed through Ollama Cloud for larger reasoning tasks"
+            }
             ModelId::OllamaQwen317b => {
                 "Qwen3 1.7B served locally through Ollama without external API requirements"
+            }
+            ModelId::OllamaDeepseekV31_671bCloud => {
+                "DeepSeek V3.1 671B cloud deployment via Ollama with tool use and long-form reasoning"
+            }
+            ModelId::OllamaKimiK21tCloud => {
+                "Kimi K2 1T cloud model streamed through Ollama for multilingual research tasks"
+            }
+            ModelId::OllamaQwen3Coder480bCloud => {
+                "Qwen3 Coder 480B expert model provided by Ollama Cloud for complex code generation"
+            }
+            ModelId::OllamaGlm46Cloud => {
+                "GLM 4.6 reasoning model offered by Ollama Cloud with extended context support"
             }
             _ => unreachable!(),
         }
@@ -669,7 +717,13 @@ impl ModelId {
             ModelId::MoonshotKimiLatest32k,
             ModelId::MoonshotKimiLatest128k,
             // Ollama models
+            ModelId::OllamaGptOss20b,
+            ModelId::OllamaGptOss120bCloud,
             ModelId::OllamaQwen317b,
+            ModelId::OllamaDeepseekV31_671bCloud,
+            ModelId::OllamaKimiK21tCloud,
+            ModelId::OllamaQwen3Coder480bCloud,
+            ModelId::OllamaGlm46Cloud,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -725,7 +779,7 @@ impl ModelId {
             Provider::Moonshot => ModelId::MoonshotKimiK20905Preview,
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
-            Provider::Ollama => ModelId::OllamaQwen317b,
+            Provider::Ollama => ModelId::OllamaGptOss20b,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -755,7 +809,7 @@ impl ModelId {
             Provider::Moonshot => ModelId::MoonshotKimiK2TurboPreview,
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
-            Provider::Ollama => ModelId::OllamaQwen317b,
+            Provider::Ollama => ModelId::OllamaGptOss20b,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -895,7 +949,13 @@ impl ModelId {
             | ModelId::MoonshotKimiLatest8k
             | ModelId::MoonshotKimiLatest32k
             | ModelId::MoonshotKimiLatest128k => "latest",
+            ModelId::OllamaGptOss20b => "oss",
+            ModelId::OllamaGptOss120bCloud => "oss-cloud",
             ModelId::OllamaQwen317b => "oss",
+            ModelId::OllamaDeepseekV31_671bCloud => "deepseek-v3.1",
+            ModelId::OllamaKimiK21tCloud => "kimi-k2",
+            ModelId::OllamaQwen3Coder480bCloud => "qwen3",
+            ModelId::OllamaGlm46Cloud => "glm-4.6",
             _ => unreachable!(),
         }
     }
@@ -962,7 +1022,17 @@ impl FromStr for ModelId {
             s if s == models::MOONSHOT_KIMI_LATEST_8K => Ok(ModelId::MoonshotKimiLatest8k),
             s if s == models::MOONSHOT_KIMI_LATEST_32K => Ok(ModelId::MoonshotKimiLatest32k),
             s if s == models::MOONSHOT_KIMI_LATEST_128K => Ok(ModelId::MoonshotKimiLatest128k),
+            s if s == models::ollama::GPT_OSS_20B => Ok(ModelId::OllamaGptOss20b),
+            s if s == models::ollama::GPT_OSS_120B_CLOUD => Ok(ModelId::OllamaGptOss120bCloud),
             s if s == models::ollama::QWEN3_1_7B => Ok(ModelId::OllamaQwen317b),
+            s if s == models::ollama::DEEPSEEK_V31_671B_CLOUD => {
+                Ok(ModelId::OllamaDeepseekV31_671bCloud)
+            }
+            s if s == models::ollama::KIMI_K2_1T_CLOUD => Ok(ModelId::OllamaKimiK21tCloud),
+            s if s == models::ollama::QWEN3_CODER_480B_CLOUD => {
+                Ok(ModelId::OllamaQwen3Coder480bCloud)
+            }
+            s if s == models::ollama::GLM_46_CLOUD => Ok(ModelId::OllamaGlm46Cloud),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -1278,6 +1348,8 @@ mod tests {
             ModelId::MoonshotKimiK20905Preview.provider(),
             Provider::Moonshot
         );
+        assert_eq!(ModelId::OllamaGptOss20b.provider(), Provider::Ollama);
+        assert_eq!(ModelId::OllamaGptOss120bCloud.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaQwen317b.provider(), Provider::Ollama);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
@@ -1321,7 +1393,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_orchestrator_for_provider(Provider::Ollama),
-            ModelId::OllamaQwen317b
+            ModelId::OllamaGptOss20b
         );
         assert_eq!(
             ModelId::default_orchestrator_for_provider(Provider::ZAI),
@@ -1379,7 +1451,7 @@ mod tests {
         );
         assert_eq!(
             ModelId::default_single_for_provider(Provider::Ollama),
-            ModelId::OllamaQwen317b
+            ModelId::OllamaGptOss20b
         );
     }
 
@@ -1496,6 +1568,16 @@ mod tests {
         assert_eq!(ModelId::MoonshotKimiLatest8k.generation(), "latest");
         assert_eq!(ModelId::MoonshotKimiLatest32k.generation(), "latest");
         assert_eq!(ModelId::MoonshotKimiLatest128k.generation(), "latest");
+        assert_eq!(ModelId::OllamaGptOss20b.generation(), "oss");
+        assert_eq!(ModelId::OllamaGptOss120bCloud.generation(), "oss-cloud");
+        assert_eq!(ModelId::OllamaQwen317b.generation(), "oss");
+        assert_eq!(
+            ModelId::OllamaDeepseekV31_671bCloud.generation(),
+            "deepseek-v3.1"
+        );
+        assert_eq!(ModelId::OllamaKimiK21tCloud.generation(), "kimi-k2");
+        assert_eq!(ModelId::OllamaQwen3Coder480bCloud.generation(), "qwen3");
+        assert_eq!(ModelId::OllamaGlm46Cloud.generation(), "glm-4.6");
 
         for entry in openrouter_generated::ENTRIES {
             assert_eq!(entry.variant.generation(), entry.generation);
@@ -1555,8 +1637,14 @@ mod tests {
         assert_eq!(moonshot_models.len(), 7);
 
         let ollama_models = ModelId::models_for_provider(Provider::Ollama);
+        assert!(ollama_models.contains(&ModelId::OllamaGptOss20b));
+        assert!(ollama_models.contains(&ModelId::OllamaGptOss120bCloud));
         assert!(ollama_models.contains(&ModelId::OllamaQwen317b));
-        assert_eq!(ollama_models.len(), 1);
+        assert!(ollama_models.contains(&ModelId::OllamaDeepseekV31_671bCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaKimiK21tCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder480bCloud));
+        assert!(ollama_models.contains(&ModelId::OllamaGlm46Cloud));
+        assert_eq!(ollama_models.len(), 7);
     }
 
     #[test]

--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -491,6 +491,7 @@ struct OllamaChatResponse {
 #[derive(Debug, Deserialize)]
 struct OllamaResponseMessage {
     #[serde(default)]
+    #[allow(dead_code)]
     role: Option<String>,
     #[serde(default)]
     content: Option<String>,
@@ -504,6 +505,7 @@ struct OllamaResponseMessage {
 struct OllamaResponseToolCall {
     #[serde(default)]
     #[serde(rename = "type")]
+    #[allow(dead_code)]
     call_type: Option<String>,
     #[serde(default)]
     function: Option<OllamaResponseFunctionCall>,

--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -291,12 +291,17 @@ impl OllamaProvider {
             None
         };
 
+        let tools = match request.tool_choice {
+            Some(ToolChoice::None) => None,
+            _ => request.tools.clone(),
+        };
+
         Ok(OllamaChatRequest {
             model: request.model.clone(),
             messages,
             stream,
             options,
-            tools: request.tools.clone(),
+            tools,
             think: Self::think_value(request),
         })
     }

--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -354,7 +354,9 @@ impl OllamaProvider {
                 LLMError::Provider("Ollama response missing tool function name".to_string())
             })?;
 
-            let arguments_value = function.arguments.unwrap_or(Value::Null);
+            let arguments_value = function
+                .arguments
+                .unwrap_or_else(|| Value::Object(Map::new()));
             let arguments = match arguments_value {
                 Value::String(raw) => raw,
                 other => serde_json::to_string(&other).map_err(|err| {

--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -66,7 +66,7 @@ impl OllamaProvider {
         };
         Self {
             http_client: HttpClient::new(),
-            base_url: override_base_url(default_base, base_url),
+            base_url: override_base_url(default_base, base_url, Some(env_vars::OLLAMA_BASE_URL)),
             model,
             api_key,
         }

--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -59,26 +59,26 @@ impl OllamaProvider {
         api_key: Option<String>,
     ) -> Self {
         let api_key = Self::normalize_api_key(api_key);
-        
+
         // Determine if this is a cloud model based on the model name
         // Cloud models are identified by having ":cloud" or "-cloud" in their name
         let is_cloud_model = model.contains(":cloud") || model.contains("-cloud");
-        
+
         // For local Ollama models (not cloud ones), do not use any API key
         // This prevents sending an API key to local Ollama instances
         let effective_api_key = if is_cloud_model {
             api_key
         } else {
-            None  // Always use no API key for local Ollama models
+            None // Always use no API key for local Ollama models
         };
-        
+
         // Use appropriate base URL based on whether it's a cloud model or not
         let default_base = if is_cloud_model {
             urls::OLLAMA_CLOUD_API_BASE
         } else {
             urls::OLLAMA_API_BASE
         };
-        
+
         Self {
             http_client: HttpClient::new(),
             base_url: override_base_url(default_base, base_url, Some(env_vars::OLLAMA_BASE_URL)),
@@ -350,9 +350,12 @@ impl OllamaProvider {
             })?;
 
             let arguments_value = function.arguments.unwrap_or(Value::Null);
-            let arguments = serde_json::to_string(&arguments_value).map_err(|err| {
-                LLMError::Provider(format!("Failed to serialize Ollama tool arguments: {err}"))
-            })?;
+            let arguments = match arguments_value {
+                Value::String(raw) => raw,
+                other => serde_json::to_string(&other).map_err(|err| {
+                    LLMError::Provider(format!("Failed to serialize Ollama tool arguments: {err}"))
+                })?,
+            };
 
             let id = function
                 .index

--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -3,7 +3,7 @@ use crate::config::core::PromptCachingConfig;
 use crate::llm::client::LLMClient;
 use crate::llm::provider::{
     FinishReason, LLMError, LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent,
-    Message, MessageRole, Usage,
+    Message, MessageRole, ToolCall, ToolDefinition, Usage,
 };
 use crate::llm::types as llm_types;
 use async_stream::try_stream;
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
+use std::collections::HashMap;
 
 use super::common::{override_base_url, resolve_model};
 
@@ -19,6 +20,7 @@ pub struct OllamaProvider {
     http_client: HttpClient,
     base_url: String,
     model: String,
+    api_key: Option<String>,
 }
 
 impl OllamaProvider {
@@ -27,30 +29,60 @@ impl OllamaProvider {
     }
 
     pub fn with_model(api_key: String, model: String) -> Self {
-        let _ = api_key;
-        Self::with_model_internal(model, None)
+        Self::with_model_internal(model, None, Some(api_key))
     }
 
     pub fn from_config(
-        _api_key: Option<String>,
+        api_key: Option<String>,
         model: Option<String>,
         base_url: Option<String>,
         _prompt_cache: Option<PromptCachingConfig>,
     ) -> Self {
         let resolved_model = resolve_model(model, models::ollama::DEFAULT_MODEL);
-        Self::with_model_internal(resolved_model, base_url)
+        Self::with_model_internal(resolved_model, base_url, api_key)
     }
 
-    fn with_model_internal(model: String, base_url: Option<String>) -> Self {
+    fn normalize_api_key(api_key: Option<String>) -> Option<String> {
+        api_key.and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+    }
+
+    fn with_model_internal(
+        model: String,
+        base_url: Option<String>,
+        api_key: Option<String>,
+    ) -> Self {
+        let api_key = Self::normalize_api_key(api_key);
+        let default_base = if api_key.is_some() {
+            urls::OLLAMA_CLOUD_API_BASE
+        } else {
+            urls::OLLAMA_API_BASE
+        };
         Self {
             http_client: HttpClient::new(),
-            base_url: override_base_url(urls::OLLAMA_API_BASE, base_url),
+            base_url: override_base_url(default_base, base_url),
             model,
+            api_key,
         }
     }
 
     fn chat_url(&self) -> String {
         format!("{}/api/chat", self.base_url.trim_end_matches('/'))
+    }
+
+    fn authorized_post(&self, url: String) -> reqwest::RequestBuilder {
+        let builder = self.http_client.post(url);
+        if let Some(api_key) = &self.api_key {
+            builder.bearer_auth(api_key)
+        } else {
+            builder
+        }
     }
 
     fn default_request(&self, prompt: &str) -> LLMRequest {
@@ -124,10 +156,14 @@ impl OllamaProvider {
             return None;
         }
 
+        let tools = value
+            .get("tools")
+            .and_then(|entry| serde_json::from_value::<Vec<ToolDefinition>>(entry.clone()).ok());
+
         Some(LLMRequest {
             messages,
             system_prompt,
-            tools: None,
+            tools,
             model: value
                 .get("model")
                 .and_then(|m| m.as_str())
@@ -159,40 +195,74 @@ impl OllamaProvider {
         stream: bool,
     ) -> Result<OllamaChatRequest, LLMError> {
         let mut messages = Vec::new();
+        let mut tool_names: HashMap<String, String> = HashMap::new();
 
         if let Some(system) = &request.system_prompt {
             if !system.trim().is_empty() {
                 messages.push(OllamaChatMessage {
                     role: "system".to_string(),
-                    content: system.clone(),
+                    content: Some(system.clone()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    tool_name: None,
                 });
             }
         }
 
         for message in &request.messages {
-            if message.has_tool_calls() {
-                return Err(LLMError::InvalidRequest(
-                    "Ollama does not support structured tool calling".to_string(),
-                ));
-            }
-
             match message.role {
-                MessageRole::System => messages.push(OllamaChatMessage {
-                    role: "system".to_string(),
-                    content: message.content.clone(),
-                }),
-                MessageRole::User => messages.push(OllamaChatMessage {
-                    role: "user".to_string(),
-                    content: message.content.clone(),
-                }),
-                MessageRole::Assistant => messages.push(OllamaChatMessage {
-                    role: "assistant".to_string(),
-                    content: message.content.clone(),
-                }),
                 MessageRole::Tool => {
-                    return Err(LLMError::InvalidRequest(
-                        "Ollama does not support tool response messages".to_string(),
-                    ));
+                    let tool_name = message
+                        .tool_call_id
+                        .as_ref()
+                        .and_then(|id| tool_names.get(id).cloned());
+                    messages.push(OllamaChatMessage {
+                        role: "tool".to_string(),
+                        content: Some(message.content.clone()),
+                        tool_calls: None,
+                        tool_call_id: message.tool_call_id.clone(),
+                        tool_name,
+                    });
+                }
+                _ => {
+                    let mut payload_message = OllamaChatMessage {
+                        role: message.role.as_generic_str().to_string(),
+                        content: Some(message.content.clone()),
+                        tool_calls: None,
+                        tool_call_id: None,
+                        tool_name: None,
+                    };
+
+                    if let Some(tool_calls) = message.get_tool_calls() {
+                        let mut converted = Vec::new();
+                        for (index, tool_call) in tool_calls.iter().enumerate() {
+                            if !tool_call.id.is_empty() {
+                                tool_names
+                                    .entry(tool_call.id.clone())
+                                    .or_insert_with(|| tool_call.function.name.clone());
+                            }
+
+                            let arguments =
+                                Self::parse_tool_arguments(&tool_call.function.arguments)?;
+                            converted.push(OllamaToolCall {
+                                call_type: tool_call.call_type.clone(),
+                                function: OllamaToolFunctionCall {
+                                    name: tool_call.function.name.clone(),
+                                    arguments: Some(arguments),
+                                    index: Some(index as u32),
+                                },
+                            });
+                        }
+
+                        if !converted.is_empty() {
+                            payload_message.tool_calls = Some(converted);
+                            if payload_message.content.is_none() {
+                                payload_message.content = Some(String::new());
+                            }
+                        }
+                    }
+
+                    messages.push(payload_message);
                 }
             }
         }
@@ -211,7 +281,72 @@ impl OllamaProvider {
             messages,
             stream,
             options,
+            tools: request.tools.clone(),
+            think: Self::think_value(request),
         })
+    }
+
+    fn parse_tool_arguments(arguments: &str) -> Result<Value, LLMError> {
+        if arguments.trim().is_empty() {
+            return Ok(Value::Object(Map::new()));
+        }
+
+        serde_json::from_str(arguments).map_err(|err| {
+            LLMError::InvalidRequest(format!("Failed to parse tool arguments for Ollama: {err}"))
+        })
+    }
+
+    fn think_value(request: &LLMRequest) -> Option<Value> {
+        let model_id = request.model.as_str();
+        if !models::ollama::REASONING_MODELS.contains(&model_id) {
+            return None;
+        }
+
+        let effort = request.reasoning_effort?;
+        if models::ollama::REASONING_LEVEL_MODELS.contains(&model_id) {
+            Some(Value::String(effort.as_str().to_string()))
+        } else {
+            Some(Value::Bool(true))
+        }
+    }
+
+    fn convert_tool_calls(
+        tool_calls: Option<Vec<OllamaResponseToolCall>>,
+    ) -> Result<Option<Vec<ToolCall>>, LLMError> {
+        let Some(tool_calls) = tool_calls else {
+            return Ok(None);
+        };
+
+        if tool_calls.is_empty() {
+            return Ok(None);
+        }
+
+        let mut converted = Vec::new();
+        for (index, call) in tool_calls.into_iter().enumerate() {
+            let function = call.function.ok_or_else(|| {
+                LLMError::Provider(
+                    "Ollama response missing function details for tool call".to_string(),
+                )
+            })?;
+
+            let name = function.name.ok_or_else(|| {
+                LLMError::Provider("Ollama response missing tool function name".to_string())
+            })?;
+
+            let arguments_value = function.arguments.unwrap_or(Value::Null);
+            let arguments = serde_json::to_string(&arguments_value).map_err(|err| {
+                LLMError::Provider(format!("Failed to serialize Ollama tool arguments: {err}"))
+            })?;
+
+            let id = function
+                .index
+                .map(|value| format!("tool_call_{value}"))
+                .unwrap_or_else(|| format!("tool_call_{index}"));
+
+            converted.push(ToolCall::function(id, name, arguments));
+        }
+
+        Ok(Some(converted))
     }
 
     fn usage_from_counts(
@@ -245,16 +380,23 @@ impl OllamaProvider {
 
     fn build_response(
         content: Option<String>,
+        tool_calls: Option<Vec<ToolCall>>,
+        reasoning: Option<String>,
         finish_reason: Option<&str>,
         prompt_tokens: Option<u32>,
         completion_tokens: Option<u32>,
     ) -> LLMResponse {
+        let mut finish = Self::finish_reason_from(finish_reason);
+        if tool_calls.as_ref().map_or(false, |calls| !calls.is_empty()) {
+            finish = FinishReason::ToolCalls;
+        }
+
         LLMResponse {
             content,
-            tool_calls: None,
+            tool_calls,
             usage: Self::usage_from_counts(prompt_tokens, completion_tokens),
-            finish_reason: Self::finish_reason_from(finish_reason),
-            reasoning: None,
+            finish_reason: finish,
+            reasoning,
         }
     }
 
@@ -272,12 +414,23 @@ struct OllamaChatRequest {
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<OllamaChatOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ToolDefinition>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    think: Option<Value>,
 }
 
 #[derive(Debug, Serialize)]
 struct OllamaChatMessage {
     role: String,
-    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<OllamaToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_name: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -286,6 +439,22 @@ struct OllamaChatOptions {
     temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     num_predict: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+struct OllamaToolCall {
+    #[serde(rename = "type")]
+    call_type: String,
+    function: OllamaToolFunctionCall,
+}
+
+#[derive(Debug, Serialize)]
+struct OllamaToolFunctionCall {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arguments: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -305,7 +474,33 @@ struct OllamaChatResponse {
 
 #[derive(Debug, Deserialize)]
 struct OllamaResponseMessage {
-    content: String,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    thinking: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<OllamaResponseToolCall>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaResponseToolCall {
+    #[serde(default)]
+    #[serde(rename = "type")]
+    call_type: Option<String>,
+    #[serde(default)]
+    function: Option<OllamaResponseFunctionCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaResponseFunctionCall {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<Value>,
+    #[serde(default)]
+    index: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -337,7 +532,15 @@ impl LLMProvider for OllamaProvider {
     }
 
     fn supports_tools(&self, _model: &str) -> bool {
-        false
+        true
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        models::ollama::REASONING_MODELS.contains(&model)
+    }
+
+    fn supports_reasoning_effort(&self, model: &str) -> bool {
+        models::ollama::REASONING_LEVEL_MODELS.contains(&model)
     }
 
     async fn generate(&self, mut request: LLMRequest) -> Result<LLMResponse, LLMError> {
@@ -349,8 +552,7 @@ impl LLMProvider for OllamaProvider {
         let url = self.chat_url();
 
         let response = self
-            .http_client
-            .post(url)
+            .authorized_post(url)
             .json(&payload)
             .send()
             .await
@@ -373,13 +575,23 @@ impl LLMProvider for OllamaProvider {
             return Err(LLMError::Provider(error));
         }
 
-        let content = parsed
-            .message
-            .map(|message| message.content)
-            .filter(|content| !content.is_empty());
+        let (content, reasoning, tool_calls) = if let Some(message) = parsed.message {
+            let content = message
+                .content
+                .and_then(|value| (!value.is_empty()).then_some(value));
+            let reasoning = message
+                .thinking
+                .and_then(|value| (!value.is_empty()).then_some(value));
+            let tool_calls = Self::convert_tool_calls(message.tool_calls)?;
+            (content, reasoning, tool_calls)
+        } else {
+            (None, None, None)
+        };
 
         Ok(Self::build_response(
             content,
+            tool_calls,
+            reasoning,
             parsed.done_reason.as_deref(),
             parsed.prompt_eval_count,
             parsed.eval_count,
@@ -395,8 +607,7 @@ impl LLMProvider for OllamaProvider {
         let url = self.chat_url();
 
         let response = self
-            .http_client
-            .post(url)
+            .authorized_post(url)
             .json(&payload)
             .send()
             .await
@@ -413,11 +624,13 @@ impl LLMProvider for OllamaProvider {
         let byte_stream = response.bytes_stream();
         let mut buffer: Vec<u8> = Vec::new();
         let mut accumulated = String::new();
+        let mut reasoning_buffer = String::new();
         let stream = try_stream! {
             let mut prompt_tokens: Option<u32> = None;
             let mut completion_tokens: Option<u32> = None;
             let mut finish_reason: Option<String> = None;
             let mut completed = false;
+            let mut tool_calls: Option<Vec<ToolCall>> = None;
 
             futures::pin_mut!(byte_stream);
             while let Some(chunk) = byte_stream.next().await {
@@ -441,11 +654,24 @@ impl LLMProvider for OllamaProvider {
                     }
 
                     if let Some(message) = parsed.message {
-                        if !message.content.is_empty() {
-                            accumulated.push_str(&message.content);
-                            yield LLMStreamEvent::Token {
-                                delta: message.content,
-                            };
+                        if let Some(thinking) = message
+                            .thinking
+                            .and_then(|value| (!value.is_empty()).then_some(value))
+                        {
+                            reasoning_buffer.push_str(&thinking);
+                            yield LLMStreamEvent::Reasoning { delta: thinking };
+                        }
+
+                        if let Some(content) = message
+                            .content
+                            .and_then(|value| (!value.is_empty()).then_some(value))
+                        {
+                            accumulated.push_str(&content);
+                            yield LLMStreamEvent::Token { delta: content };
+                        }
+
+                        if let Some(parsed_calls) = Self::convert_tool_calls(message.tool_calls)? {
+                            tool_calls = Some(parsed_calls);
                         }
                     }
 
@@ -475,6 +701,12 @@ impl LLMProvider for OllamaProvider {
                 } else {
                     Some(accumulated.clone())
                 },
+                tool_calls,
+                if reasoning_buffer.is_empty() {
+                    None
+                } else {
+                    Some(reasoning_buffer.clone())
+                },
                 finish_reason.as_deref(),
                 prompt_tokens,
                 completion_tokens,
@@ -494,20 +726,24 @@ impl LLMProvider for OllamaProvider {
     }
 
     fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
-        if request.tools.is_some() {
+        if request.tool_choice.is_some() {
             return Err(LLMError::InvalidRequest(
-                "Ollama does not support structured tool calling".to_string(),
+                "Ollama does not support the tool_choice parameter".to_string(),
             ));
         }
 
-        if request
-            .messages
-            .iter()
-            .any(|message| matches!(message.role, MessageRole::Tool))
-        {
+        if request.parallel_tool_calls.is_some() || request.parallel_tool_config.is_some() {
             return Err(LLMError::InvalidRequest(
-                "Ollama does not support tool response messages".to_string(),
+                "Ollama does not support parallel tool configuration".to_string(),
             ));
+        }
+
+        for message in &request.messages {
+            if matches!(message.role, MessageRole::Tool) && message.tool_call_id.is_none() {
+                return Err(LLMError::InvalidRequest(
+                    "Ollama tool responses must include tool_call_id".to_string(),
+                ));
+            }
         }
 
         Ok(())

--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -3,7 +3,7 @@ use crate::config::core::PromptCachingConfig;
 use crate::llm::client::LLMClient;
 use crate::llm::provider::{
     FinishReason, LLMError, LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent,
-    Message, MessageRole, ToolCall, ToolDefinition, Usage,
+    Message, MessageRole, ToolCall, ToolChoice, ToolDefinition, Usage,
 };
 use crate::llm::types as llm_types;
 use async_stream::try_stream;
@@ -302,9 +302,10 @@ impl OllamaProvider {
             return None;
         }
 
-        let effort = request.reasoning_effort?;
         if models::ollama::REASONING_LEVEL_MODELS.contains(&model_id) {
-            Some(Value::String(effort.as_str().to_string()))
+            request
+                .reasoning_effort
+                .map(|effort| Value::String(effort.as_str().to_string()))
         } else {
             Some(Value::Bool(true))
         }
@@ -726,10 +727,15 @@ impl LLMProvider for OllamaProvider {
     }
 
     fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
-        if request.tool_choice.is_some() {
-            return Err(LLMError::InvalidRequest(
-                "Ollama does not support the tool_choice parameter".to_string(),
-            ));
+        if let Some(tool_choice) = &request.tool_choice {
+            match tool_choice {
+                ToolChoice::Auto | ToolChoice::None => {}
+                _ => {
+                    return Err(LLMError::InvalidRequest(
+                        "Ollama does not support explicit tool_choice overrides".to_string(),
+                    ));
+                }
+            }
         }
 
         if request.parallel_tool_calls.is_some() || request.parallel_tool_config.is_some() {

--- a/vtcode-core/src/llm/providers/zai.rs
+++ b/vtcode-core/src/llm/providers/zai.rs
@@ -1,4 +1,4 @@
-use crate::config::constants::{headers, env_vars, models, urls};
+use crate::config::constants::{env_vars, headers, models, urls};
 use crate::config::core::PromptCachingConfig;
 use crate::llm::client::LLMClient;
 use crate::llm::error_display;


### PR DESCRIPTION
## Summary
- update the Ollama provider guide and catalog docs to highlight tool calling, reasoning, streaming, and include the curated model picker list
- expand the Ollama constants and core model registry so all local/cloud IDs advertise reasoning metadata and surface in the picker
- overhaul the Ollama provider to translate tool calls, stream thinking traces, and adjust tests for tool support expectations

## Testing
- cargo fmt
- cargo clippy
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68f9a58dcb9c8323b824ae4b7f77f41e