### PR TITLE
Address review feedback for Ollama reasoning and tool choice

### DIFF
--- a/vtcode-core/src/llm/providers/ollama.rs
+++ b/vtcode-core/src/llm/providers/ollama.rs
@@ -3,7 +3,7 @@ use crate::config::core::PromptCachingConfig;
 use crate::llm::client::LLMClient;
 use crate::llm::provider::{
     FinishReason, LLMError, LLMProvider, LLMRequest, LLMResponse, LLMStream, LLMStreamEvent,
-    Message, MessageRole, ToolCall, ToolDefinition, Usage,
+    Message, MessageRole, ToolCall, ToolChoice, ToolDefinition, Usage,
 };
 use crate::llm::types as llm_types;
 use async_stream::try_stream;
@@ -302,9 +302,10 @@ impl OllamaProvider {
             return None;
         }
 
-        let effort = request.reasoning_effort?;
         if models::ollama::REASONING_LEVEL_MODELS.contains(&model_id) {
-            Some(Value::String(effort.as_str().to_string()))
+            request
+                .reasoning_effort
+                .map(|effort| Value::String(effort.as_str().to_string()))
         } else {
             Some(Value::Bool(true))
         }
@@ -726,10 +727,15 @@ impl LLMProvider for OllamaProvider {
     }
 
     fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
-        if request.tool_choice.is_some() {
-            return Err(LLMError::InvalidRequest(
-                "Ollama does not support the tool_choice parameter".to_string(),
-            ));
+        if let Some(tool_choice) = &request.tool_choice {
+            match tool_choice {
+                ToolChoice::Auto | ToolChoice::None => {}
+                _ => {
+                    return Err(LLMError::InvalidRequest(
+                        "Ollama does not support explicit tool_choice overrides".to_string(),
+                    ));
+                }
+            }
         }
 
         if request.parallel_tool_calls.is_some() || request.parallel_tool_config.is_some() {


### PR DESCRIPTION
## Summary
- keep think traces enabled for boolean-only reasoning models without requiring reasoning_effort
- relax Ollama validation so agent-provided auto/none tool choices are accepted while other overrides still error

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68f9e7f0171c8323b76caf7f4695771e