### PR TITLE
Align release automation with nextest validation

### DIFF
--- a/docs/component_extraction_todo.md
+++ b/docs/component_extraction_todo.md
@@ -66,6 +66,7 @@ This list tracks actionable tasks spawned from the component extraction plan as 
 - [x] Run `cargo publish --dry-run -p <crate>` for each extracted crate to validate manifests before release (revisit `vtcode-bash-runner` once `vtcode-commons` is published to crates.io).
 - [x] Schedule the sequential publishes, tag pushes, and dependency updates outlined in the release plan.
 - [ ] Execute the sequential publishes, push tags, rerun the `vtcode-bash-runner` dry run after releasing `vtcode-commons`, and merge the dependency bump PRs to finish the extraction effort.
+  - [x] Ensure the release automation enforces the fmt/clippy/nextest validation suite before publishing (falls back to `cargo test` when `cargo-nextest` is unavailable).
   - New helper script `scripts/publish_extracted_crates.sh` automates the release order with optional dry-run coverage; use it when the release window opens.
 
 

--- a/scripts/publish_extracted_crates.sh
+++ b/scripts/publish_extracted_crates.sh
@@ -102,7 +102,12 @@ publish_cmd() {
 if [[ $RUN_TESTS -eq 1 ]]; then
     run_cmd "cargo fmt"
     run_cmd "cargo clippy --all-targets --all-features"
-    run_cmd "cargo test"
+    if cargo nextest --version >/dev/null 2>&1; then
+        run_cmd "cargo nextest run --workspace"
+    else
+        echo "cargo nextest not found; falling back to cargo test"
+        run_cmd "cargo test"
+    fi
 fi
 
 for crate in "${CRATES[@]}"; do


### PR DESCRIPTION
## Summary
- update `scripts/publish_extracted_crates.sh` to prefer `cargo nextest run --workspace` when available and fall back to `cargo test`
- note the release automation enhancement in `docs/component_extraction_todo.md` under the release execution milestone

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68fa45dc07f48323a1ba96dfabfe5b33