### PR TITLE
Add lifecycle hook engine integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ dialoguer = "0.11"
 crossterm = "0.27"
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
 which = "5.0"
+regex = "1.10"
 
 [features]
 default = ["tool-chat"]
@@ -151,7 +152,6 @@ criterion = "0.5"
 tempfile = "3.0"
 indexmap = { version = "2.2", features = ["serde"] }
 rand = "0.8"
-regex = "1.10"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -74,6 +74,9 @@ use super::workspace_links::{
     LinkedDirectory, handle_workspace_directory_command, remove_directory_symlink,
 };
 use crate::agent::runloop::mcp_events;
+use crate::hooks::lifecycle::{
+    HookMessage, HookMessageLevel, LifecycleHookEngine, SessionEndReason, SessionStartTrigger,
+};
 
 enum TurnLoopResult {
     Completed,
@@ -234,6 +237,18 @@ pub(crate) async fn run_single_agent_loop_unified(
     let mut config = config.clone();
     let resume_ref = resume.as_ref();
 
+    let session_trigger = if resume_ref.is_some() {
+        SessionStartTrigger::Resume
+    } else {
+        SessionStartTrigger::Startup
+    };
+
+    let lifecycle_hooks = if let Some(vt) = vt_cfg.as_ref() {
+        LifecycleHookEngine::new(config.workspace.clone(), &vt.hooks, session_trigger)?
+    } else {
+        None
+    };
+
     let SessionState {
         session_bootstrap,
         mut provider_client,
@@ -254,6 +269,8 @@ pub(crate) async fn run_single_agent_loop_unified(
         custom_prompts,
         mut sandbox,
     } = initialize_session(&config, vt_cfg.as_ref(), full_auto, resume_ref).await?;
+
+    let mut session_end_reason = SessionEndReason::Completed;
 
     let curator_tool_catalog = build_curator_tools(&tools);
     let mut context_manager = ContextManager::new(
@@ -355,6 +372,12 @@ pub(crate) async fn run_single_agent_loop_unified(
         }
     };
 
+    if let (Some(hooks), Some(archive)) = (&lifecycle_hooks, session_archive.as_ref()) {
+        hooks
+            .update_transcript_path(Some(archive.path().to_path_buf()))
+            .await;
+    }
+
     let mut checkpoint_config = SnapshotConfig::new(config.workspace.clone());
     checkpoint_config.enabled = config.checkpointing_enabled;
     checkpoint_config.storage_dir = config.checkpointing_storage_dir.clone();
@@ -389,6 +412,25 @@ pub(crate) async fn run_single_agent_loop_unified(
         &config.model,
         &reasoning_label,
     )?;
+
+    if let Some(hooks) = &lifecycle_hooks {
+        match hooks.run_session_start().await {
+            Ok(outcome) => {
+                render_hook_messages(&mut renderer, &outcome.messages)?;
+                for context in outcome.additional_context {
+                    if !context.trim().is_empty() {
+                        conversation_history.push(uni::Message::system(context));
+                    }
+                }
+            }
+            Err(err) => {
+                renderer.line(
+                    MessageStyle::Error,
+                    &format!("Failed to run session start hooks: {}", err),
+                )?;
+            }
+        }
+    }
     let mode_label = resolve_mode_label(config.ui_surface, full_auto);
     let header_context = build_inline_header_context(
         &config,
@@ -493,11 +535,13 @@ pub(crate) async fn run_single_agent_loop_unified(
             );
         }
         if ctrl_c_state.is_exit_requested() {
+            session_end_reason = SessionEndReason::Exit;
             break;
         }
 
         if ctrl_c_state.is_cancel_requested() {
             if ctrl_c_state.is_exit_requested() {
+                session_end_reason = SessionEndReason::Exit;
                 break;
             }
 
@@ -526,6 +570,7 @@ pub(crate) async fn run_single_agent_loop_unified(
             };
 
             if ctrl_c_state.is_exit_requested() {
+                session_end_reason = SessionEndReason::Exit;
                 break;
             }
 
@@ -617,9 +662,11 @@ pub(crate) async fn run_single_agent_loop_unified(
                 }
                 InlineEvent::Exit => {
                     renderer.line(MessageStyle::Info, "Goodbye!")?;
+                    session_end_reason = SessionEndReason::Exit;
                     break;
                 }
                 InlineEvent::Interrupt => {
+                    session_end_reason = SessionEndReason::Cancelled;
                     break;
                 }
                 InlineEvent::ScrollLineUp
@@ -644,6 +691,7 @@ pub(crate) async fn run_single_agent_loop_unified(
             "" => continue,
             "exit" | "quit" => {
                 renderer.line(MessageStyle::Info, "Goodbye!")?;
+                session_end_reason = SessionEndReason::Exit;
                 break;
             }
             "help" => {
@@ -972,6 +1020,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                                 default_placeholder.clone(),
                                 &ctrl_c_state,
                                 &ctrl_c_notify,
+                                lifecycle_hooks.as_ref(),
                             )
                             .await
                             {
@@ -980,7 +1029,10 @@ pub(crate) async fn run_single_agent_loop_unified(
                                     continue;
                                 }
                                 Ok(ToolPermissionFlow::Denied) => continue,
-                                Ok(ToolPermissionFlow::Exit) => break,
+                                Ok(ToolPermissionFlow::Exit) => {
+                                    session_end_reason = SessionEndReason::Exit;
+                                    break;
+                                }
                                 Ok(ToolPermissionFlow::Interrupted) => break,
                                 Err(err) => {
                                     renderer.line(
@@ -1099,6 +1151,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                         }
                         SlashCommandOutcome::Exit => {
                             renderer.line(MessageStyle::Info, "Goodbye!")?;
+                            session_end_reason = SessionEndReason::Exit;
                             break;
                         }
                     }
@@ -1109,6 +1162,29 @@ pub(crate) async fn run_single_agent_loop_unified(
                 }
             }
             _ => {}
+        }
+
+        if let Some(hooks) = &lifecycle_hooks {
+            match hooks.run_user_prompt_submit(input_owned.as_str()).await {
+                Ok(outcome) => {
+                    render_hook_messages(&mut renderer, &outcome.messages)?;
+                    if !outcome.allow_prompt {
+                        handle.clear_input();
+                        continue;
+                    }
+                    for context in outcome.additional_context {
+                        if !context.trim().is_empty() {
+                            conversation_history.push(uni::Message::system(context));
+                        }
+                    }
+                }
+                Err(err) => {
+                    renderer.line(
+                        MessageStyle::Error,
+                        &format!("Failed to run prompt hooks: {}", err),
+                    )?;
+                }
+            }
         }
 
         if let Some(picker) = model_picker_state.as_mut() {
@@ -1581,6 +1657,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                         default_placeholder.clone(),
                         &ctrl_c_state,
                         &ctrl_c_notify,
+                        lifecycle_hooks.as_ref(),
                     )
                     .await
                     {
@@ -1720,6 +1797,44 @@ pub(crate) async fn run_single_agent_loop_unified(
                                         call.id.clone(),
                                         content,
                                     ));
+
+                                    if let Some(hooks) = &lifecycle_hooks {
+                                        match hooks
+                                            .run_post_tool_use(name, Some(&args_val), &output)
+                                            .await
+                                        {
+                                            Ok(outcome) => {
+                                                render_hook_messages(
+                                                    &mut renderer,
+                                                    &outcome.messages,
+                                                )?;
+                                                for context in outcome.additional_context {
+                                                    if !context.trim().is_empty() {
+                                                        working_history
+                                                            .push(uni::Message::system(context));
+                                                    }
+                                                }
+                                                if let Some(reason) = outcome.block_reason {
+                                                    if !reason.trim().is_empty() {
+                                                        renderer.line(
+                                                            MessageStyle::Info,
+                                                            reason.trim(),
+                                                        )?;
+                                                    }
+                                                }
+                                            }
+                                            Err(err) => {
+                                                renderer.line(
+                                                    MessageStyle::Error,
+                                                    &format!(
+                                                        "Failed to run post-tool hooks: {}",
+                                                        err
+                                                    ),
+                                                )?;
+                                            }
+                                        }
+                                    }
+
                                     {
                                         let mut ledger = decision_ledger.write().await;
                                         ledger.record_outcome(
@@ -1979,6 +2094,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                         }
                         Ok(ToolPermissionFlow::Exit) => {
                             renderer.line(MessageStyle::Info, "Goodbye!")?;
+                            session_end_reason = SessionEndReason::Exit;
                             break 'outer TurnLoopResult::Cancelled;
                         }
                         Ok(ToolPermissionFlow::Interrupted) => {
@@ -2111,6 +2227,7 @@ pub(crate) async fn run_single_agent_loop_unified(
         match turn_result {
             TurnLoopResult::Cancelled => {
                 if ctrl_c_state.is_exit_requested() {
+                    session_end_reason = SessionEndReason::Exit;
                     break;
                 }
 
@@ -2122,6 +2239,7 @@ pub(crate) async fn run_single_agent_loop_unified(
                 handle.clear_input();
                 handle.set_placeholder(default_placeholder.clone());
                 ctrl_c_state.clear_cancel();
+                session_end_reason = SessionEndReason::Cancelled;
                 continue;
             }
             TurnLoopResult::Aborted => {
@@ -2205,6 +2323,9 @@ pub(crate) async fn run_single_agent_loop_unified(
             session_messages,
         ) {
             Ok(path) => {
+                if let Some(hooks) = &lifecycle_hooks {
+                    hooks.update_transcript_path(Some(path.clone())).await;
+                }
                 renderer.line(
                     MessageStyle::Info,
                     &format!("Session saved to {}", path.display()),
@@ -2228,6 +2349,20 @@ pub(crate) async fn run_single_agent_loop_unified(
                 linked.link_path.display(),
                 err
             );
+        }
+    }
+
+    if let Some(hooks) = &lifecycle_hooks {
+        match hooks.run_session_end(session_end_reason).await {
+            Ok(messages) => {
+                render_hook_messages(&mut renderer, &messages)?;
+            }
+            Err(err) => {
+                renderer.line(
+                    MessageStyle::Error,
+                    &format!("Failed to run session end hooks: {}", err),
+                )?;
+            }
         }
     }
 
@@ -2259,6 +2394,25 @@ fn safe_force_redraw(handle: &InlineHandle, last_forced_redraw: &mut Instant) {
         handle.force_redraw();
         *last_forced_redraw = Instant::now();
     }
+}
+
+fn render_hook_messages(renderer: &mut AnsiRenderer, messages: &[HookMessage]) -> Result<()> {
+    for message in messages {
+        let text = message.text.trim();
+        if text.is_empty() {
+            continue;
+        }
+
+        let style = match message.level {
+            HookMessageLevel::Info => MessageStyle::Info,
+            HookMessageLevel::Warning => MessageStyle::Info,
+            HookMessageLevel::Error => MessageStyle::Error,
+        };
+
+        renderer.line(style, text)?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/hooks/lifecycle.rs
+++ b/src/hooks/lifecycle.rs
@@ -1,0 +1,1096 @@
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde_json::{Value, json};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio::time;
+
+use vtcode_core::config::{HookCommandConfig, HookGroupConfig, HooksConfig, LifecycleHooksConfig};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+#[derive(Clone)]
+pub struct LifecycleHookEngine {
+    inner: Arc<LifecycleHookInner>,
+}
+
+impl LifecycleHookEngine {
+    pub fn new(
+        workspace: PathBuf,
+        config: &HooksConfig,
+        trigger: SessionStartTrigger,
+    ) -> Result<Option<Self>> {
+        if config.lifecycle.is_empty() {
+            return Ok(None);
+        }
+
+        let compiled = CompiledLifecycleHooks::from_config(&config.lifecycle)?;
+        if compiled.is_empty() {
+            return Ok(None);
+        }
+
+        let session_id = generate_session_id();
+        Ok(Some(Self {
+            inner: Arc::new(LifecycleHookInner {
+                workspace,
+                session_id,
+                trigger,
+                hooks: compiled,
+                state: Mutex::new(LifecycleHookState {
+                    transcript_path: None,
+                }),
+            }),
+        }))
+    }
+
+    pub async fn run_session_start(&self) -> Result<SessionStartHookOutcome> {
+        let mut messages = Vec::new();
+        let mut additional_context = Vec::new();
+
+        if self.inner.hooks.session_start.is_empty() {
+            return Ok(SessionStartHookOutcome {
+                messages,
+                additional_context,
+            });
+        }
+
+        let trigger_value = self.inner.trigger.as_str().to_string();
+        let payload = self.build_session_start_payload().await?;
+
+        for group in &self.inner.hooks.session_start {
+            if !group.matcher.matches(&trigger_value) {
+                continue;
+            }
+
+            for command in &group.commands {
+                match self
+                    .execute_command("SessionStart", command, &payload)
+                    .await
+                {
+                    Ok(result) => interpret_session_start(
+                        command,
+                        &result,
+                        &mut messages,
+                        &mut additional_context,
+                    ),
+                    Err(err) => messages.push(HookMessage::error(format!(
+                        "SessionStart hook `{}` failed: {err}",
+                        command.command
+                    ))),
+                }
+            }
+        }
+
+        Ok(SessionStartHookOutcome {
+            messages,
+            additional_context,
+        })
+    }
+
+    pub async fn run_session_end(&self, reason: SessionEndReason) -> Result<Vec<HookMessage>> {
+        let mut messages = Vec::new();
+
+        if self.inner.hooks.session_end.is_empty() {
+            return Ok(messages);
+        }
+
+        let payload = self.build_session_end_payload(reason).await?;
+        let reason_value = reason.as_str().to_string();
+
+        for group in &self.inner.hooks.session_end {
+            if !group.matcher.matches(&reason_value) {
+                continue;
+            }
+
+            for command in &group.commands {
+                match self.execute_command("SessionEnd", command, &payload).await {
+                    Ok(result) => interpret_session_end(command, &result, &mut messages),
+                    Err(err) => messages.push(HookMessage::error(format!(
+                        "SessionEnd hook `{}` failed: {err}",
+                        command.command
+                    ))),
+                }
+            }
+        }
+
+        Ok(messages)
+    }
+
+    pub async fn run_user_prompt_submit(&self, prompt: &str) -> Result<UserPromptHookOutcome> {
+        let mut outcome = UserPromptHookOutcome::default();
+
+        if self.inner.hooks.user_prompt_submit.is_empty() {
+            return Ok(outcome);
+        }
+
+        let payload = self.build_user_prompt_payload(prompt).await?;
+
+        for group in &self.inner.hooks.user_prompt_submit {
+            if !group.matcher.matches(prompt) {
+                continue;
+            }
+
+            for command in &group.commands {
+                match self
+                    .execute_command("UserPromptSubmit", command, &payload)
+                    .await
+                {
+                    Ok(result) => {
+                        interpret_user_prompt(command, &result, &mut outcome);
+                        if !outcome.allow_prompt {
+                            return Ok(outcome);
+                        }
+                    }
+                    Err(err) => outcome.messages.push(HookMessage::error(format!(
+                        "UserPromptSubmit hook `{}` failed: {err}",
+                        command.command
+                    ))),
+                }
+            }
+        }
+
+        Ok(outcome)
+    }
+
+    pub async fn run_pre_tool_use(
+        &self,
+        tool_name: &str,
+        tool_input: Option<&Value>,
+    ) -> Result<PreToolHookOutcome> {
+        let mut outcome = PreToolHookOutcome::default();
+
+        if self.inner.hooks.pre_tool_use.is_empty() {
+            return Ok(outcome);
+        }
+
+        let payload = self.build_pre_tool_payload(tool_name, tool_input).await?;
+
+        for group in &self.inner.hooks.pre_tool_use {
+            if !group.matcher.matches(tool_name) {
+                continue;
+            }
+
+            for command in &group.commands {
+                match self.execute_command("PreToolUse", command, &payload).await {
+                    Ok(result) => {
+                        interpret_pre_tool(command, &result, &mut outcome);
+                        match outcome.decision {
+                            PreToolHookDecision::Allow | PreToolHookDecision::Deny => {
+                                return Ok(outcome);
+                            }
+                            _ => {}
+                        }
+                    }
+                    Err(err) => outcome.messages.push(HookMessage::error(format!(
+                        "PreToolUse hook `{}` failed: {err}",
+                        command.command
+                    ))),
+                }
+            }
+        }
+
+        Ok(outcome)
+    }
+
+    pub async fn run_post_tool_use(
+        &self,
+        tool_name: &str,
+        tool_input: Option<&Value>,
+        tool_output: &Value,
+    ) -> Result<PostToolHookOutcome> {
+        let mut outcome = PostToolHookOutcome::default();
+
+        if self.inner.hooks.post_tool_use.is_empty() {
+            return Ok(outcome);
+        }
+
+        let payload = self
+            .build_post_tool_payload(tool_name, tool_input, tool_output)
+            .await?;
+
+        for group in &self.inner.hooks.post_tool_use {
+            if !group.matcher.matches(tool_name) {
+                continue;
+            }
+
+            for command in &group.commands {
+                match self.execute_command("PostToolUse", command, &payload).await {
+                    Ok(result) => interpret_post_tool(command, &result, &mut outcome),
+                    Err(err) => outcome.messages.push(HookMessage::error(format!(
+                        "PostToolUse hook `{}` failed: {err}",
+                        command.command
+                    ))),
+                }
+            }
+        }
+
+        Ok(outcome)
+    }
+
+    pub async fn update_transcript_path(&self, path: Option<PathBuf>) {
+        let mut state = self.inner.state.lock().await;
+        state.transcript_path = path;
+    }
+
+    async fn build_session_start_payload(&self) -> Result<Value> {
+        let cwd = self.inner.workspace.to_string_lossy().to_string();
+        let transcript_path = self.current_transcript_path().await;
+        Ok(json!({
+            "session_id": self.inner.session_id,
+            "cwd": cwd,
+            "hook_event_name": "SessionStart",
+            "source": self.inner.trigger.as_str(),
+            "transcript_path": transcript_path,
+        }))
+    }
+
+    async fn build_session_end_payload(&self, reason: SessionEndReason) -> Result<Value> {
+        let cwd = self.inner.workspace.to_string_lossy().to_string();
+        let transcript_path = self.current_transcript_path().await;
+        Ok(json!({
+            "session_id": self.inner.session_id,
+            "cwd": cwd,
+            "hook_event_name": "SessionEnd",
+            "reason": reason.as_str(),
+            "transcript_path": transcript_path,
+        }))
+    }
+
+    async fn build_user_prompt_payload(&self, prompt: &str) -> Result<Value> {
+        let cwd = self.inner.workspace.to_string_lossy().to_string();
+        let transcript_path = self.current_transcript_path().await;
+        Ok(json!({
+            "session_id": self.inner.session_id,
+            "cwd": cwd,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": prompt,
+            "transcript_path": transcript_path,
+        }))
+    }
+
+    async fn build_pre_tool_payload(
+        &self,
+        tool_name: &str,
+        tool_input: Option<&Value>,
+    ) -> Result<Value> {
+        let cwd = self.inner.workspace.to_string_lossy().to_string();
+        let transcript_path = self.current_transcript_path().await;
+        Ok(json!({
+            "session_id": self.inner.session_id,
+            "cwd": cwd,
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input.cloned().unwrap_or(Value::Null),
+            "transcript_path": transcript_path,
+        }))
+    }
+
+    async fn build_post_tool_payload(
+        &self,
+        tool_name: &str,
+        tool_input: Option<&Value>,
+        tool_output: &Value,
+    ) -> Result<Value> {
+        let cwd = self.inner.workspace.to_string_lossy().to_string();
+        let transcript_path = self.current_transcript_path().await;
+        Ok(json!({
+            "session_id": self.inner.session_id,
+            "cwd": cwd,
+            "hook_event_name": "PostToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input.cloned().unwrap_or(Value::Null),
+            "tool_response": tool_output.clone(),
+            "transcript_path": transcript_path,
+        }))
+    }
+
+    async fn execute_command(
+        &self,
+        event_name: &str,
+        command: &HookCommandConfig,
+        payload: &Value,
+    ) -> Result<HookCommandResult> {
+        let mut process = Command::new("sh");
+        process.arg("-c").arg(&command.command);
+        process.current_dir(&self.inner.workspace);
+        process.stdin(Stdio::piped());
+        process.stdout(Stdio::piped());
+        process.stderr(Stdio::piped());
+        process.kill_on_drop(true);
+
+        let workspace_str = self.inner.workspace.to_string_lossy().to_string();
+        process.env("VT_PROJECT_DIR", &workspace_str);
+        process.env("CLAUDE_PROJECT_DIR", &workspace_str);
+        process.env("VT_SESSION_ID", &self.inner.session_id);
+        process.env("CLAUDE_SESSION_ID", &self.inner.session_id);
+        process.env("VT_HOOK_EVENT", event_name);
+
+        if let Some(transcript_path) = self.current_transcript_path().await {
+            process.env("VT_TRANSCRIPT_PATH", &transcript_path);
+            process.env("CLAUDE_TRANSCRIPT_PATH", &transcript_path);
+        }
+
+        let mut child = process
+            .spawn()
+            .with_context(|| format!("failed to spawn lifecycle hook `{}`", command.command))?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            let mut payload_bytes = serde_json::to_vec(payload)
+                .context("failed to serialize lifecycle hook payload")?;
+            payload_bytes.push(b'\n');
+            stdin
+                .write_all(&payload_bytes)
+                .await
+                .context("failed to write lifecycle hook payload")?;
+            stdin
+                .shutdown()
+                .await
+                .context("failed to close lifecycle hook stdin")?;
+        }
+
+        let mut stdout_pipe = child
+            .stdout
+            .take()
+            .context("lifecycle hook missing stdout pipe")?;
+        let mut stderr_pipe = child
+            .stderr
+            .take()
+            .context("lifecycle hook missing stderr pipe")?;
+
+        let stdout_task = tokio::spawn(async move {
+            let mut buffer = Vec::new();
+            stdout_pipe.read_to_end(&mut buffer).await.map(|_| buffer)
+        });
+        let stderr_task = tokio::spawn(async move {
+            let mut buffer = Vec::new();
+            stderr_pipe.read_to_end(&mut buffer).await.map(|_| buffer)
+        });
+
+        let timeout_secs = command
+            .timeout_seconds
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+            .max(1);
+        let wait_result = time::timeout(Duration::from_secs(timeout_secs), child.wait()).await;
+
+        let (exit_code, timed_out) = match wait_result {
+            Ok(status_res) => {
+                let status = status_res.context("failed to wait for lifecycle hook")?;
+                (status.code(), false)
+            }
+            Err(_) => {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                (None, true)
+            }
+        };
+
+        let stdout_bytes = stdout_task
+            .await
+            .unwrap_or_else(|_| Ok(Vec::new()))
+            .unwrap_or_default();
+        let stderr_bytes = stderr_task
+            .await
+            .unwrap_or_else(|_| Ok(Vec::new()))
+            .unwrap_or_default();
+
+        Ok(HookCommandResult {
+            exit_code,
+            stdout: String::from_utf8_lossy(&stdout_bytes).to_string(),
+            stderr: String::from_utf8_lossy(&stderr_bytes).to_string(),
+            timed_out,
+            timeout_seconds: timeout_secs,
+        })
+    }
+
+    async fn current_transcript_path(&self) -> Option<String> {
+        let state = self.inner.state.lock().await;
+        state
+            .transcript_path
+            .as_ref()
+            .and_then(|path| path_to_string(path))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HookMessage {
+    pub level: HookMessageLevel,
+    pub text: String,
+}
+
+impl HookMessage {
+    pub fn info(text: impl Into<String>) -> Self {
+        Self {
+            level: HookMessageLevel::Info,
+            text: text.into(),
+        }
+    }
+
+    pub fn warning(text: impl Into<String>) -> Self {
+        Self {
+            level: HookMessageLevel::Warning,
+            text: text.into(),
+        }
+    }
+
+    pub fn error(text: impl Into<String>) -> Self {
+        Self {
+            level: HookMessageLevel::Error,
+            text: text.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum HookMessageLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Default)]
+pub struct SessionStartHookOutcome {
+    pub messages: Vec<HookMessage>,
+    pub additional_context: Vec<String>,
+}
+
+pub struct UserPromptHookOutcome {
+    pub allow_prompt: bool,
+    pub block_reason: Option<String>,
+    pub additional_context: Vec<String>,
+    pub messages: Vec<HookMessage>,
+}
+
+impl Default for UserPromptHookOutcome {
+    fn default() -> Self {
+        Self {
+            allow_prompt: true,
+            block_reason: None,
+            additional_context: Vec::new(),
+            messages: Vec::new(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct PreToolHookOutcome {
+    pub decision: PreToolHookDecision,
+    pub messages: Vec<HookMessage>,
+}
+
+#[derive(Default)]
+pub struct PostToolHookOutcome {
+    pub messages: Vec<HookMessage>,
+    pub additional_context: Vec<String>,
+    pub block_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PreToolHookDecision {
+    Continue,
+    Allow,
+    Deny,
+    Ask,
+}
+
+impl Default for PreToolHookDecision {
+    fn default() -> Self {
+        Self::Continue
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub enum SessionStartTrigger {
+    Startup,
+    Resume,
+    Clear,
+    Compact,
+}
+
+impl SessionStartTrigger {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Startup => "startup",
+            Self::Resume => "resume",
+            Self::Clear => "clear",
+            Self::Compact => "compact",
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub enum SessionEndReason {
+    Completed,
+    Exit,
+    Cancelled,
+    Error,
+    Other,
+}
+
+impl SessionEndReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Exit => "exit",
+            Self::Cancelled => "cancelled",
+            Self::Error => "error",
+            Self::Other => "other",
+        }
+    }
+}
+
+struct LifecycleHookInner {
+    workspace: PathBuf,
+    session_id: String,
+    trigger: SessionStartTrigger,
+    hooks: CompiledLifecycleHooks,
+    state: Mutex<LifecycleHookState>,
+}
+
+struct LifecycleHookState {
+    transcript_path: Option<PathBuf>,
+}
+
+struct CompiledLifecycleHooks {
+    session_start: Vec<CompiledHookGroup>,
+    session_end: Vec<CompiledHookGroup>,
+    user_prompt_submit: Vec<CompiledHookGroup>,
+    pre_tool_use: Vec<CompiledHookGroup>,
+    post_tool_use: Vec<CompiledHookGroup>,
+}
+
+impl CompiledLifecycleHooks {
+    fn from_config(config: &LifecycleHooksConfig) -> Result<Self> {
+        Ok(Self {
+            session_start: compile_groups(&config.session_start)?,
+            session_end: compile_groups(&config.session_end)?,
+            user_prompt_submit: compile_groups(&config.user_prompt_submit)?,
+            pre_tool_use: compile_groups(&config.pre_tool_use)?,
+            post_tool_use: compile_groups(&config.post_tool_use)?,
+        })
+    }
+
+    fn is_empty(&self) -> bool {
+        self.session_start.is_empty()
+            && self.session_end.is_empty()
+            && self.user_prompt_submit.is_empty()
+            && self.pre_tool_use.is_empty()
+            && self.post_tool_use.is_empty()
+    }
+}
+
+struct CompiledHookGroup {
+    matcher: HookMatcher,
+    commands: Vec<HookCommandConfig>,
+}
+
+#[derive(Clone)]
+enum HookMatcher {
+    Any,
+    Pattern(Regex),
+}
+
+impl HookMatcher {
+    fn matches(&self, value: &str) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Pattern(regex) => regex.is_match(value),
+        }
+    }
+}
+
+struct HookCommandResult {
+    exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+    timed_out: bool,
+    timeout_seconds: u64,
+}
+
+fn compile_groups(groups: &[HookGroupConfig]) -> Result<Vec<CompiledHookGroup>> {
+    let mut compiled = Vec::new();
+    for group in groups {
+        let matcher = if let Some(pattern) = group.matcher.as_ref() {
+            let trimmed = pattern.trim();
+            if trimmed.is_empty() || trimmed == "*" {
+                HookMatcher::Any
+            } else {
+                let regex = Regex::new(&format!("^(?:{})$", trimmed))
+                    .with_context(|| format!("invalid lifecycle hook matcher: {pattern}"))?;
+                HookMatcher::Pattern(regex)
+            }
+        } else {
+            HookMatcher::Any
+        };
+
+        compiled.push(CompiledHookGroup {
+            matcher,
+            commands: group.hooks.clone(),
+        });
+    }
+
+    Ok(compiled)
+}
+
+fn generate_session_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    format!("vt-{}-{nanos}", std::process::id())
+}
+
+fn path_to_string(path: &Path) -> Option<String> {
+    Some(path.to_string_lossy().to_string())
+}
+
+fn parse_json_output(stdout: &str) -> Option<Value> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    serde_json::from_str(trimmed).ok()
+}
+
+struct CommonJsonFields {
+    continue_decision: Option<bool>,
+    stop_reason: Option<String>,
+    suppress_stdout: bool,
+    decision: Option<String>,
+    decision_reason: Option<String>,
+    hook_specific: Option<Value>,
+}
+
+fn extract_common_fields(json: &Value, messages: &mut Vec<HookMessage>) -> CommonJsonFields {
+    if let Some(system_message) = json
+        .get("systemMessage")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        messages.push(HookMessage::info(system_message.to_string()));
+    }
+
+    let continue_decision = json.get("continue").and_then(|value| value.as_bool());
+    let stop_reason = json
+        .get("stopReason")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+    let suppress_stdout = json
+        .get("suppressOutput")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let decision = json
+        .get("decision")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+    let decision_reason = json
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+    let hook_specific = json.get("hookSpecificOutput").cloned();
+
+    CommonJsonFields {
+        continue_decision,
+        stop_reason,
+        suppress_stdout,
+        decision,
+        decision_reason,
+        hook_specific,
+    }
+}
+
+fn matches_hook_event(spec: &serde_json::Map<String, Value>, event_name: &str) -> bool {
+    match spec.get("hookEventName").and_then(|value| value.as_str()) {
+        Some(name) => name.eq_ignore_ascii_case(event_name),
+        None => true,
+    }
+}
+
+fn handle_timeout(
+    command: &HookCommandConfig,
+    result: &HookCommandResult,
+    messages: &mut Vec<HookMessage>,
+) {
+    if result.timed_out {
+        messages.push(HookMessage::error(format!(
+            "Hook `{}` timed out after {}s",
+            command.command, result.timeout_seconds
+        )));
+    }
+}
+
+fn handle_non_zero_exit(
+    command: &HookCommandConfig,
+    result: &HookCommandResult,
+    code: i32,
+    messages: &mut Vec<HookMessage>,
+    warn: bool,
+) {
+    let level = if warn {
+        HookMessageLevel::Warning
+    } else {
+        HookMessageLevel::Error
+    };
+
+    let text = if result.stderr.trim().is_empty() {
+        format!("Hook `{}` exited with status {code}", command.command)
+    } else {
+        format!(
+            "Hook `{}` exited with status {code}: {}",
+            command.command,
+            result.stderr.trim()
+        )
+    };
+
+    messages.push(HookMessage { level, text });
+}
+
+fn select_message<'a>(stderr: &'a str, fallback: &'a str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn interpret_session_start(
+    command: &HookCommandConfig,
+    result: &HookCommandResult,
+    messages: &mut Vec<HookMessage>,
+    additional_context: &mut Vec<String>,
+) {
+    handle_timeout(command, result, messages);
+    if result.timed_out {
+        return;
+    }
+
+    if let Some(code) = result.exit_code {
+        if code != 0 {
+            handle_non_zero_exit(command, result, code, messages, false);
+        }
+    }
+
+    if !result.stderr.trim().is_empty() {
+        messages.push(HookMessage::error(format!(
+            "SessionStart hook `{}` stderr: {}",
+            command.command,
+            result.stderr.trim()
+        )));
+    }
+
+    if let Some(json) = parse_json_output(&result.stdout) {
+        let common = extract_common_fields(&json, messages);
+        if let Some(Value::Object(spec)) = common.hook_specific {
+            if matches_hook_event(&spec, "SessionStart") {
+                if let Some(additional) = spec
+                    .get("additionalContext")
+                    .and_then(|value| value.as_str())
+                {
+                    if !additional.trim().is_empty() {
+                        additional_context.push(additional.trim().to_string());
+                    }
+                }
+            }
+        }
+
+        if !common.suppress_stdout {
+            if let Some(text) = json
+                .get("additional_context")
+                .and_then(|value| value.as_str())
+            {
+                if !text.trim().is_empty() {
+                    additional_context.push(text.trim().to_string());
+                }
+            }
+        }
+    } else if !result.stdout.trim().is_empty() {
+        additional_context.push(result.stdout.trim().to_string());
+    }
+}
+
+fn interpret_session_end(
+    command: &HookCommandConfig,
+    result: &HookCommandResult,
+    messages: &mut Vec<HookMessage>,
+) {
+    handle_timeout(command, result, messages);
+    if result.timed_out {
+        return;
+    }
+
+    if let Some(code) = result.exit_code {
+        if code != 0 {
+            handle_non_zero_exit(command, result, code, messages, false);
+        }
+    }
+
+    if !result.stderr.trim().is_empty() {
+        messages.push(HookMessage::error(format!(
+            "SessionEnd hook `{}` stderr: {}",
+            command.command,
+            result.stderr.trim()
+        )));
+    }
+
+    if let Some(json) = parse_json_output(&result.stdout) {
+        let _ = extract_common_fields(&json, messages);
+    } else if !result.stdout.trim().is_empty() {
+        messages.push(HookMessage::info(result.stdout.trim().to_string()));
+    }
+}
+
+fn interpret_user_prompt(
+    command: &HookCommandConfig,
+    result: &HookCommandResult,
+    outcome: &mut UserPromptHookOutcome,
+) {
+    handle_timeout(command, result, &mut outcome.messages);
+    if result.timed_out {
+        return;
+    }
+
+    if let Some(code) = result.exit_code {
+        if code == 2 {
+            outcome.allow_prompt = false;
+            let reason = select_message(result.stderr.trim(), "Prompt blocked by lifecycle hook.");
+            outcome.block_reason = Some(reason.clone());
+            outcome.messages.push(HookMessage::error(reason));
+            return;
+        } else if code != 0 {
+            handle_non_zero_exit(command, result, code, &mut outcome.messages, true);
+        }
+    }
+
+    if !result.stderr.trim().is_empty() {
+        outcome.messages.push(HookMessage::warning(format!(
+            "UserPromptSubmit hook `{}` stderr: {}",
+            command.command,
+            result.stderr.trim()
+        )));
+    }
+
+    if let Some(json) = parse_json_output(&result.stdout) {
+        let common = extract_common_fields(&json, &mut outcome.messages);
+        if let Some(false) = common.continue_decision {
+            outcome.allow_prompt = false;
+            outcome.block_reason = common
+                .stop_reason
+                .clone()
+                .or(common.decision_reason.clone())
+                .or_else(|| Some("Prompt blocked by lifecycle hook.".to_string()));
+        }
+
+        if let Some(decision) = common.decision.as_deref() {
+            if decision.eq_ignore_ascii_case("block") {
+                outcome.allow_prompt = false;
+                outcome.block_reason = common
+                    .decision_reason
+                    .clone()
+                    .or_else(|| Some("Prompt blocked by lifecycle hook.".to_string()));
+            }
+        }
+
+        if let Some(Value::Object(spec)) = common.hook_specific {
+            if matches_hook_event(&spec, "UserPromptSubmit") {
+                if let Some(additional) = spec
+                    .get("additionalContext")
+                    .and_then(|value| value.as_str())
+                {
+                    if !additional.trim().is_empty() {
+                        outcome
+                            .additional_context
+                            .push(additional.trim().to_string());
+                    }
+                }
+            }
+        }
+
+        if !common.suppress_stdout {
+            if let Some(text) = json
+                .get("additional_context")
+                .and_then(|value| value.as_str())
+            {
+                if !text.trim().is_empty() {
+                    outcome.additional_context.push(text.trim().to_string());
+                }
+            }
+        }
+
+        if !outcome.allow_prompt {
+            if let Some(reason) = outcome.block_reason.clone() {
+                outcome.messages.push(HookMessage::error(reason));
+            }
+        }
+    } else if !result.stdout.trim().is_empty() {
+        outcome
+            .additional_context
+            .push(result.stdout.trim().to_string());
+    }
+}
+
+fn interpret_pre_tool(
+    command: &HookCommandConfig,
+    result: &HookCommandResult,
+    outcome: &mut PreToolHookOutcome,
+) {
+    handle_timeout(command, result, &mut outcome.messages);
+    if result.timed_out {
+        if matches!(outcome.decision, PreToolHookDecision::Continue) {
+            outcome.decision = PreToolHookDecision::Deny;
+            outcome.messages.push(HookMessage::error(format!(
+                "Tool call blocked because hook `{}` timed out",
+                command.command
+            )));
+        }
+        return;
+    }
+
+    if let Some(code) = result.exit_code {
+        if code == 2 {
+            outcome.decision = PreToolHookDecision::Deny;
+            let reason =
+                select_message(result.stderr.trim(), "Tool call blocked by lifecycle hook.");
+            outcome.messages.push(HookMessage::error(reason));
+            return;
+        } else if code != 0 {
+            handle_non_zero_exit(command, result, code, &mut outcome.messages, true);
+        }
+    }
+
+    if !result.stderr.trim().is_empty() {
+        outcome.messages.push(HookMessage::warning(format!(
+            "PreToolUse hook `{}` stderr: {}",
+            command.command,
+            result.stderr.trim()
+        )));
+    }
+
+    if let Some(json) = parse_json_output(&result.stdout) {
+        let common = extract_common_fields(&json, &mut outcome.messages);
+        if let Some(false) = common.continue_decision {
+            outcome.decision = PreToolHookDecision::Deny;
+            if let Some(reason) = common.stop_reason.or(common.decision_reason) {
+                outcome.messages.push(HookMessage::error(reason));
+            }
+            return;
+        }
+
+        if let Some(Value::Object(spec)) = common.hook_specific {
+            if matches_hook_event(&spec, "PreToolUse") {
+                if let Some(decision) = spec
+                    .get("permissionDecision")
+                    .and_then(|value| value.as_str())
+                {
+                    match decision {
+                        "allow" => outcome.decision = PreToolHookDecision::Allow,
+                        "deny" => outcome.decision = PreToolHookDecision::Deny,
+                        "ask" => {
+                            if matches!(outcome.decision, PreToolHookDecision::Continue) {
+                                outcome.decision = PreToolHookDecision::Ask;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                if let Some(reason) = spec
+                    .get("permissionDecisionReason")
+                    .and_then(|value| value.as_str())
+                {
+                    if !reason.trim().is_empty() {
+                        outcome
+                            .messages
+                            .push(HookMessage::info(reason.trim().to_string()));
+                    }
+                }
+            }
+        }
+
+        if !common.suppress_stdout && !result.stdout.trim().is_empty() {
+            outcome
+                .messages
+                .push(HookMessage::info(result.stdout.trim().to_string()));
+        }
+    } else if !result.stdout.trim().is_empty() {
+        outcome
+            .messages
+            .push(HookMessage::info(result.stdout.trim().to_string()));
+    }
+}
+
+fn interpret_post_tool(
+    command: &HookCommandConfig,
+    result: &HookCommandResult,
+    outcome: &mut PostToolHookOutcome,
+) {
+    handle_timeout(command, result, &mut outcome.messages);
+    if result.timed_out {
+        return;
+    }
+
+    if let Some(code) = result.exit_code {
+        if code != 0 {
+            handle_non_zero_exit(command, result, code, &mut outcome.messages, true);
+        }
+    }
+
+    if !result.stderr.trim().is_empty() {
+        outcome.messages.push(HookMessage::warning(format!(
+            "PostToolUse hook `{}` stderr: {}",
+            command.command,
+            result.stderr.trim()
+        )));
+    }
+
+    if let Some(json) = parse_json_output(&result.stdout) {
+        let common = extract_common_fields(&json, &mut outcome.messages);
+        if let Some(decision) = common.decision.as_deref() {
+            if decision.eq_ignore_ascii_case("block") {
+                outcome.block_reason = common
+                    .decision_reason
+                    .clone()
+                    .or_else(|| Some("Tool execution requires attention.".to_string()));
+            }
+        }
+
+        if let Some(Value::Object(spec)) = common.hook_specific {
+            if matches_hook_event(&spec, "PostToolUse") {
+                if let Some(additional) = spec
+                    .get("additionalContext")
+                    .and_then(|value| value.as_str())
+                {
+                    if !additional.trim().is_empty() {
+                        outcome
+                            .additional_context
+                            .push(additional.trim().to_string());
+                    }
+                }
+            }
+        }
+
+        if !common.suppress_stdout {
+            if let Some(text) = json
+                .get("additional_context")
+                .and_then(|value| value.as_str())
+            {
+                if !text.trim().is_empty() {
+                    outcome.additional_context.push(text.trim().to_string());
+                }
+            }
+        }
+    } else if !result.stdout.trim().is_empty() {
+        outcome
+            .messages
+            .push(HookMessage::info(result.stdout.trim().to_string()));
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,1 @@
+pub mod lifecycle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use vtcode_core::config::api_keys::load_dotenv;
 
 mod agent;
 mod cli; // local CLI handlers in src/cli // agent runloops (single-agent only)
+mod hooks;
 mod process_hardening;
 mod workspace_trust;
 

--- a/vtcode-bash-runner/src/runner.rs
+++ b/vtcode-bash-runner/src/runner.rs
@@ -387,9 +387,7 @@ where
             if metadata.file_type().is_symlink() {
                 let canonical = candidate
                     .canonicalize()
-                    .with_context(|| {
-                        format!("failed to canonicalize `{}`", candidate.display())
-                    })?;
+                    .with_context(|| format!("failed to canonicalize `{}`", candidate.display()))?;
                 return self.ensure_within_workspace(&canonical);
             }
         }

--- a/vtcode-config/src/hooks.rs
+++ b/vtcode-config/src/hooks.rs
@@ -1,0 +1,136 @@
+use anyhow::{Context, Result, ensure};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct HooksConfig {
+    #[serde(default)]
+    pub lifecycle: LifecycleHooksConfig,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct LifecycleHooksConfig {
+    #[serde(default)]
+    pub session_start: Vec<HookGroupConfig>,
+    #[serde(default)]
+    pub session_end: Vec<HookGroupConfig>,
+    #[serde(default)]
+    pub user_prompt_submit: Vec<HookGroupConfig>,
+    #[serde(default)]
+    pub pre_tool_use: Vec<HookGroupConfig>,
+    #[serde(default)]
+    pub post_tool_use: Vec<HookGroupConfig>,
+}
+
+impl LifecycleHooksConfig {
+    pub fn is_empty(&self) -> bool {
+        self.session_start.is_empty()
+            && self.session_end.is_empty()
+            && self.user_prompt_submit.is_empty()
+            && self.pre_tool_use.is_empty()
+            && self.post_tool_use.is_empty()
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct HookGroupConfig {
+    #[serde(default)]
+    pub matcher: Option<String>,
+    #[serde(default)]
+    pub hooks: Vec<HookCommandConfig>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HookCommandKind {
+    Command,
+}
+
+impl Default for HookCommandKind {
+    fn default() -> Self {
+        Self::Command
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct HookCommandConfig {
+    #[serde(default)]
+    #[serde(rename = "type")]
+    pub kind: HookCommandKind,
+    #[serde(default)]
+    pub command: String,
+    #[serde(default)]
+    pub timeout_seconds: Option<u64>,
+}
+
+impl HooksConfig {
+    pub fn validate(&self) -> Result<()> {
+        self.lifecycle
+            .validate()
+            .context("Invalid lifecycle hooks configuration")
+    }
+}
+
+impl LifecycleHooksConfig {
+    pub fn validate(&self) -> Result<()> {
+        validate_groups(&self.session_start, "session_start")?;
+        validate_groups(&self.session_end, "session_end")?;
+        validate_groups(&self.user_prompt_submit, "user_prompt_submit")?;
+        validate_groups(&self.pre_tool_use, "pre_tool_use")?;
+        validate_groups(&self.post_tool_use, "post_tool_use")?;
+        Ok(())
+    }
+}
+
+fn validate_groups(groups: &[HookGroupConfig], context_name: &str) -> Result<()> {
+    for (index, group) in groups.iter().enumerate() {
+        if let Some(pattern) = group.matcher.as_ref() {
+            validate_matcher(pattern).with_context(|| {
+                format!("Invalid matcher in hooks.{context_name}[{index}] -> matcher")
+            })?;
+        }
+
+        ensure!(
+            !group.hooks.is_empty(),
+            "hooks.{context_name}[{index}] must define at least one hook command"
+        );
+
+        for (hook_index, hook) in group.hooks.iter().enumerate() {
+            ensure!(
+                matches!(hook.kind, HookCommandKind::Command),
+                "hooks.{context_name}[{index}].hooks[{hook_index}] has unsupported type"
+            );
+
+            ensure!(
+                !hook.command.trim().is_empty(),
+                "hooks.{context_name}[{index}].hooks[{hook_index}] must specify a command"
+            );
+
+            if let Some(timeout) = hook.timeout_seconds {
+                ensure!(
+                    timeout > 0,
+                    "hooks.{context_name}[{index}].hooks[{hook_index}].timeout_seconds must be positive"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_matcher(pattern: &str) -> Result<()> {
+    let trimmed = pattern.trim();
+    if trimmed.is_empty() || trimmed == "*" {
+        return Ok(());
+    }
+
+    let regex_pattern = format!("^(?:{})$", trimmed);
+    Regex::new(&regex_pattern)
+        .with_context(|| format!("failed to compile lifecycle hook matcher: {pattern}"))?;
+    Ok(())
+}

--- a/vtcode-config/src/lib.rs
+++ b/vtcode-config/src/lib.rs
@@ -29,6 +29,7 @@ pub mod constants;
 pub mod context;
 pub mod core;
 pub mod defaults;
+pub mod hooks;
 pub mod loader;
 pub mod mcp;
 pub mod models;
@@ -55,6 +56,9 @@ pub use defaults::{
     ConfigDefaultsProvider, ContextStoreDefaults, PerformanceDefaults, ScenarioDefaults,
     SyntaxHighlightingDefaults, WorkspacePathsDefaults, current_config_defaults,
     install_config_defaults_provider, reset_to_default_config_defaults, with_config_defaults,
+};
+pub use hooks::{
+    HookCommandConfig, HookCommandKind, HookGroupConfig, HooksConfig, LifecycleHooksConfig,
 };
 pub use loader::{ConfigManager, SyntaxHighlightingConfig, VTCodeConfig};
 pub use mcp::{

--- a/vtcode-config/src/loader/mod.rs
+++ b/vtcode-config/src/loader/mod.rs
@@ -7,6 +7,7 @@ use crate::core::{
     AgentConfig, AutomationConfig, CommandsConfig, PromptCachingConfig, SecurityConfig, ToolsConfig,
 };
 use crate::defaults::{self, ConfigDefaultsProvider, SyntaxHighlightingDefaults};
+use crate::hooks::HooksConfig;
 use crate::mcp::McpClientConfig;
 use crate::root::{PtyConfig, UiConfig};
 use crate::router::RouterConfig;
@@ -151,6 +152,10 @@ pub struct VTCodeConfig {
     /// Agent Client Protocol configuration
     #[serde(default)]
     pub acp: AgentClientProtocolConfig,
+
+    /// Lifecycle hooks configuration
+    #[serde(default)]
+    pub hooks: HooksConfig,
 }
 
 impl VTCodeConfig {
@@ -166,6 +171,10 @@ impl VTCodeConfig {
         self.router
             .validate()
             .context("Invalid router configuration")?;
+
+        self.hooks
+            .validate()
+            .context("Invalid hooks configuration")?;
 
         Ok(())
     }

--- a/vtcode-core/src/config/hooks.rs
+++ b/vtcode-core/src/config/hooks.rs
@@ -1,0 +1,3 @@
+pub use vtcode_config::hooks::{
+    HookCommandConfig, HookCommandKind, HookGroupConfig, HooksConfig, LifecycleHooksConfig,
+};

--- a/vtcode-core/src/config/mod.rs
+++ b/vtcode-core/src/config/mod.rs
@@ -10,6 +10,7 @@ pub mod constants;
 pub mod context;
 pub mod core;
 pub mod defaults;
+pub mod hooks;
 pub mod loader;
 pub mod mcp;
 pub mod models;
@@ -33,6 +34,9 @@ pub use defaults::{
     ConfigDefaultsProvider, ContextStoreDefaults, PerformanceDefaults, ScenarioDefaults,
     SyntaxHighlightingDefaults, WorkspacePathsDefaults, current_config_defaults,
     install_config_defaults_provider, reset_to_default_config_defaults, with_config_defaults,
+};
+pub use hooks::{
+    HookCommandConfig, HookCommandKind, HookGroupConfig, HooksConfig, LifecycleHooksConfig,
 };
 pub use loader::{ConfigManager, SyntaxHighlightingConfig, VTCodeConfig};
 pub use mcp::{


### PR DESCRIPTION
## Summary
- add configuration structures for lifecycle hooks and re-export them through vtcode-core
- implement a lifecycle hook engine that executes command hooks and interprets their results
- integrate lifecycle hooks into the agent runloop for session start/end, user prompts, and tool execution

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68fa4615b96883239c8de984e2fb5027