### PR TITLE
Add LM Studio local provider support

### DIFF
--- a/docs/PROVIDER_GUIDES.md
+++ b/docs/PROVIDER_GUIDES.md
@@ -42,7 +42,7 @@ This index collects provider-specific guides for configuring VT Code with differ
 - **Server:** Enable the OpenAI-compatible Developer server in LM Studio (defaults to `http://localhost:1234/v1`)
 - **Environment:** Optional `LMSTUDIO_API_KEY` when auth is enabled; override host/port via `LMSTUDIO_BASE_URL`
 - **Default model:** `lmstudio-community/meta-llama-3.1-8b-instruct` (local inference)
-- **Catalog:** Also ships with `lmstudio-community/qwen2.5-7b-instruct` and `lmstudio-community/gemma-2-2b-it`, plus any custom GGUF models you expose
+- **Catalog:** Also ships with `lmstudio-community/meta-llama-3-8b-instruct`, `lmstudio-community/qwen2.5-7b-instruct`, `lmstudio-community/gemma-2-2b-it`, `lmstudio-community/gemma-2-9b-it`, and `lmstudio-community/phi-3.1-mini-4k-instruct`, plus any custom GGUF models you expose
 - **Features:** Streaming, tool calling, structured output, and reasoning effort passthrough via the shared OpenAI surface
 
 > ℹ️ Additional provider-specific guides will be added as new integrations land in VT Code.

--- a/docs/PROVIDER_GUIDES.md
+++ b/docs/PROVIDER_GUIDES.md
@@ -36,4 +36,13 @@ This index collects provider-specific guides for configuring VT Code with differ
 - **Base URL:** Configurable via `OLLAMA_BASE_URL` environment variable (defaults to `http://localhost:11434`)
 - **Features:** Streaming, structured tool calling (including Ollama's web search tools), and thinking traces when `reasoning_effort` is enabled
 
+## LM Studio Local Server
+
+- **Guide:** [LM Studio Provider Guide](./providers/lmstudio.md)
+- **Server:** Enable the OpenAI-compatible Developer server in LM Studio (defaults to `http://localhost:1234/v1`)
+- **Environment:** Optional `LMSTUDIO_API_KEY` when auth is enabled; override host/port via `LMSTUDIO_BASE_URL`
+- **Default model:** `lmstudio-community/meta-llama-3.1-8b-instruct` (local inference)
+- **Catalog:** Also ships with `lmstudio-community/qwen2.5-7b-instruct` and `lmstudio-community/gemma-2-2b-it`, plus any custom GGUF models you expose
+- **Features:** Streaming, tool calling, structured output, and reasoning effort passthrough via the shared OpenAI surface
+
 > ℹ️ Additional provider-specific guides will be added as new integrations land in VT Code.

--- a/docs/models.json
+++ b/docs/models.json
@@ -2069,6 +2069,21 @@
     "name": "LM Studio",
     "doc": "https://lmstudio.ai/docs/developer/openai-compat",
     "models": {
+      "lmstudio-community/meta-llama-3-8b-instruct": {
+        "id": "lmstudio-community/meta-llama-3-8b-instruct",
+        "name": "Meta Llama 3 8B (local)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8192
+      },
       "lmstudio-community/meta-llama-3.1-8b-instruct": {
         "id": "lmstudio-community/meta-llama-3.1-8b-instruct",
         "name": "Meta Llama 3.1 8B (local)",
@@ -2113,6 +2128,36 @@
           ]
         },
         "context": 8192
+      },
+      "lmstudio-community/gemma-2-9b-it": {
+        "id": "lmstudio-community/gemma-2-9b-it",
+        "name": "Gemma 2 9B (local)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8192
+      },
+      "lmstudio-community/phi-3.1-mini-4k-instruct": {
+        "id": "lmstudio-community/phi-3.1-mini-4k-instruct",
+        "name": "Phi-3.1 Mini 4K (local)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 4096
       }
     }
   }

--- a/docs/models.json
+++ b/docs/models.json
@@ -2058,5 +2058,62 @@
         "context": 131072
       }
     }
+  },
+  "lmstudio": {
+    "id": "lmstudio",
+    "env": [
+      "LMSTUDIO_API_KEY (optional)",
+      "LMSTUDIO_BASE_URL (optional)"
+    ],
+    "api": "http://localhost:1234/v1",
+    "name": "LM Studio",
+    "doc": "https://lmstudio.ai/docs/developer/openai-compat",
+    "models": {
+      "lmstudio-community/meta-llama-3.1-8b-instruct": {
+        "id": "lmstudio-community/meta-llama-3.1-8b-instruct",
+        "name": "Meta Llama 3.1 8B (local)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 131072
+      },
+      "lmstudio-community/qwen2.5-7b-instruct": {
+        "id": "lmstudio-community/qwen2.5-7b-instruct",
+        "name": "Qwen2.5 7B (local)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 32768
+      },
+      "lmstudio-community/gemma-2-2b-it": {
+        "id": "lmstudio-community/gemma-2-2b-it",
+        "name": "Gemma 2 2B (local)",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "context": 8192
+      }
+    }
   }
 }

--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -10,16 +10,17 @@ outputs work the same way while keeping inference on your own hardware.
 - LM Studio installed on your machine ([download](https://lmstudio.ai/download))
 - Enable the Developer HTTP server via the LM Studio desktop app or CLI
   ([docs](https://lmstudio.ai/docs/developer/core/server))
-- At least one model downloaded inside LM Studio (e.g., Meta Llama 3.1 8B Instruct,
-  Qwen2.5 7B, Gemma 2 2B IT)
+- At least one model downloaded inside LM Studio (e.g., Meta Llama 3.1 8B or 3 8B,
+  Qwen2.5 7B, Gemma 2 2B/9B IT, or Phi-3.1 Mini 4K)
 
 ## Installation and Setup
 
 1. **Install LM Studio**: Follow the platform-specific installer from
    [lmstudio.ai/download](https://lmstudio.ai/download).
 2. **Download a model**: In the app, open the "Models" tab and pull one of the
-   supported open models (Meta Llama 3.1 8B, Qwen2.5 7B, Gemma 2 2B IT, or any other
-   compatible model hosted in the LM Studio catalog).
+   supported open models (Meta Llama 3.1 8B, Meta Llama 3 8B, Qwen2.5 7B, Gemma 2
+   2B/9B IT, Phi-3.1 Mini 4K, or any other compatible model hosted in the LM Studio
+   catalog).
 3. **Start the Developer server**:
    - **GUI**: From the "Developer" panel, enable the OpenAI-compatible server and
      confirm the port (defaults to `1234`).

--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -1,0 +1,105 @@
+# LM Studio Provider Guide
+
+LM Studio exposes an OpenAI-compatible HTTP server so you can run local or LAN-hosted
+models without changing your existing API integration. VT Code reuses its OpenAI
+adapter to talk to LM Studio, which means streaming, tool calling, and structured
+outputs work the same way while keeping inference on your own hardware.
+
+## Prerequisites
+
+- LM Studio installed on your machine ([download](https://lmstudio.ai/download))
+- Enable the Developer HTTP server via the LM Studio desktop app or CLI
+  ([docs](https://lmstudio.ai/docs/developer/core/server))
+- At least one model downloaded inside LM Studio (e.g., Meta Llama 3.1 8B Instruct,
+  Qwen2.5 7B, Gemma 2 2B IT)
+
+## Installation and Setup
+
+1. **Install LM Studio**: Follow the platform-specific installer from
+   [lmstudio.ai/download](https://lmstudio.ai/download).
+2. **Download a model**: In the app, open the "Models" tab and pull one of the
+   supported open models (Meta Llama 3.1 8B, Qwen2.5 7B, Gemma 2 2B IT, or any other
+   compatible model hosted in the LM Studio catalog).
+3. **Start the Developer server**:
+   - **GUI**: From the "Developer" panel, enable the OpenAI-compatible server and
+     confirm the port (defaults to `1234`).
+   - **CLI**: Run `lmstudio server start --port 1234 --openai` to launch the server
+     manually. Append `--host 0.0.0.0` to expose it to other machines on your network.
+4. **Verify the server**: Send a quick health check:
+   ```bash
+   curl http://localhost:1234/v1/models
+   ```
+   The response lists every model LM Studio currently exposes through the API.
+
+## Configuration
+
+### Environment Variables
+
+- `LMSTUDIO_BASE_URL` (optional): Override the API endpoint (defaults to
+  `http://localhost:1234/v1`). Useful when the server runs on another port or host.
+- `LMSTUDIO_API_KEY` (optional): Set when you enable key-based auth in the LM Studio
+  server. Leave unset for local testing without authentication.
+
+### VT Code Configuration
+
+Configure `vtcode.toml` in your workspace to point at LM Studio:
+
+```toml
+[agent]
+provider = "lmstudio"                     # LM Studio provider
+default_model = "lmstudio-community/meta-llama-3.1-8b-instruct"
+
+[tools]
+default_policy = "prompt"
+
+[tools.policies]
+read_file = "allow"
+write_file = "prompt"
+run_terminal_cmd = "prompt"
+```
+
+You can also override the provider and model via CLI:
+
+```bash
+vtcode --provider lmstudio --model lmstudio-community/qwen2.5-7b-instruct
+```
+
+## Using Custom LM Studio Models
+
+The `/model` picker now lists LM Studio's default catalog so you can select a model
+without typing IDs manually. Choose "Custom LM Studio model" to enter any other model
+ID exposed by the LM Studio server.
+
+When you sideload a GGUF or add a local GGML/ONNX pipeline through LM Studio, make sure
+it appears under the server's `GET /v1/models` response. Once listed, VT Code can target
+it by passing the exact model ID via CLI or configuration.
+
+## Tool Calling, Structured Output, and Streaming
+
+LM Studio's OpenAI-compatible stack supports the Chat Completions, Responses, and
+Embeddings APIs ([docs](https://lmstudio.ai/docs/developer/openai-compat)). VT Code
+forwards tool definitions, function-calling metadata, and JSON schema expectations so
+models can call tools or produce structured output exactly like the hosted OpenAI
+provider. Streaming is enabled by default, and you will see incremental tokens in the
+TUI just as you would with remote OpenAI deployments.
+
+Because the provider shares the OpenAI surface area, features such as
+`parallel_tool_calls`, reasoning effort flags, and JSON Schema validation behave
+consistently—subject to the capabilities of the model you are running locally.
+
+## Troubleshooting
+
+1. **Connection refused**: Ensure the LM Studio server is running and that
+   `LMSTUDIO_BASE_URL` points to the correct host/port.
+2. **Model not found**: Confirm the model appears in the LM Studio catalog and that the
+   server exposes it via `GET /v1/models`.
+3. **401 Unauthorized**: Provide the configured API key through `LMSTUDIO_API_KEY` if
+   authentication is enabled.
+4. **Slow responses**: Local inference speed depends on your hardware and the model
+   size. Consider using smaller models (Gemma 2 2B, Qwen2.5 7B) for faster iteration.
+5. **Tool payload errors**: Check the LM Studio server logs to ensure your runtime
+   supports the tools and structured outputs you are invoking.
+
+Refer to the official [LM Studio developer docs](https://lmstudio.ai/docs/developer)
+for deeper configuration details, including structured output schemas, tool
+registration, and server customization.

--- a/docs/vtcode_llm_environment.md
+++ b/docs/vtcode_llm_environment.md
@@ -21,6 +21,7 @@ the secret values.
 | `xai` | `XAI_API_KEY` | – | Required for xAI Grok models. |
 | `zai` | `ZAI_API_KEY` | – | Required for Zhipu AI (Z.AI) models. |
 | `moonshot` | `MOONSHOT_API_KEY` | – | Required for Moonshot AI models. |
+| `lmstudio` | `LMSTUDIO_API_KEY` | – | Optional; provide when the LM Studio developer server enforces auth. Override host/port with `LMSTUDIO_BASE_URL`. |
 | `ollama` | _N/A_ | – | Ollama uses a local runtime and does not require an API key. |
 
 When multiple providers are enabled, populate the variables you plan to use. Downstream

--- a/examples/self_update_example.rs
+++ b/examples/self_update_example.rs
@@ -14,9 +14,7 @@ use vtcode_core::update::{UpdateChannel, UpdateConfig, UpdateFrequency, UpdateMa
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize tracing for debug output
-    tracing_subscriber::fmt()
-        .with_env_filter("info")
-        .init();
+    tracing_subscriber::fmt().with_env_filter("info").init();
 
     println!("VTCode Self-Update Example\n");
 
@@ -191,7 +189,10 @@ async fn complete_update_workflow() -> Result<()> {
         return Ok(());
     }
 
-    println!("Update available: {}", status.latest_version.as_ref().unwrap());
+    println!(
+        "Update available: {}",
+        status.latest_version.as_ref().unwrap()
+    );
 
     // Step 2: Perform update
     println!("\nStep 2: Downloading and installing update...");
@@ -199,7 +200,10 @@ async fn complete_update_workflow() -> Result<()> {
 
     if result.success {
         println!("\nUpdate successful!");
-        println!("Updated from {} to {}", result.old_version, result.new_version);
+        println!(
+            "Updated from {} to {}",
+            result.old_version, result.new_version
+        );
 
         if let Some(backup) = result.backup_path {
             println!("Backup created at: {:?}", backup);

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -1,20 +1,29 @@
 use anyhow::{Context, Result, anyhow};
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use vtcode_core::config::constants::{reasoning, ui};
+use serde::{Deserialize, Serialize};
+use serde_json;
+use vtcode_core::config::constants::{env_vars, reasoning, ui, urls};
 use vtcode_core::config::loader::{ConfigManager, VTCodeConfig};
 use vtcode_core::config::models::{ModelId, Provider};
 use vtcode_core::config::types::ReasoningEffortLevel;
 use vtcode_core::ui::{InlineListItem, InlineListSearchConfig, InlineListSelection};
 use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
-use vtcode_core::utils::dot_config::update_model_preference;
+use vtcode_core::utils::dot_config::{
+    DotConfig, get_dot_manager, load_user_config, update_model_preference,
+};
 
 use vtcode::interactive_list::{SelectionEntry, SelectionInterrupted, run_interactive_selection};
 use vtcode_core::llm::providers::lmstudio::fetch_lmstudio_models;
+use vtcode_core::llm::providers::ollama::fetch_ollama_models;
+
+use tokio::fs;
 
 #[derive(Clone, Copy)]
 struct ModelOption {
@@ -42,6 +51,19 @@ static MODEL_OPTIONS: Lazy<Vec<ModelOption>> = Lazy::new(|| {
     }
     options
 });
+
+fn picker_provider_order() -> Vec<Provider> {
+    let mut providers: Vec<Provider> = Provider::all_providers()
+        .into_iter()
+        .filter(|provider| !matches!(provider, Provider::LmStudio | Provider::Ollama))
+        .collect();
+    providers.push(Provider::LmStudio);
+    providers.push(Provider::Ollama);
+    providers
+}
+
+const DYNAMIC_MODEL_CACHE_FILENAME: &str = "dynamic_local_models.json";
+const DYNAMIC_MODEL_CACHE_TTL_SECS: u64 = 300;
 
 const STEP_ONE_TITLE: &str = "Model picker – Step 1";
 const STEP_TWO_TITLE: &str = "Model picker – Step 2";
@@ -107,6 +129,7 @@ pub struct ModelSelectionResult {
 
 pub enum ModelPickerProgress {
     InProgress,
+    NeedsRefresh,
     Completed(ModelSelectionResult),
     Cancelled,
 }
@@ -120,7 +143,25 @@ pub struct ModelPickerState {
     selected_reasoning: Option<ReasoningEffortLevel>,
     pending_api_key: Option<String>,
     workspace: Option<PathBuf>,
+    dynamic_models: DynamicModelRegistry,
+    plain_mode_active: bool,
 }
+
+#[derive(Clone, Default)]
+struct DynamicModelRegistry {
+    entries: Vec<SelectionDetail>,
+    provider_models: HashMap<Provider, Vec<usize>>,
+    provider_errors: HashMap<Provider, String>,
+    provider_warnings: HashMap<Provider, String>,
+}
+
+struct ProviderEndpointConfig {
+    lmstudio: Option<String>,
+    ollama: Option<String>,
+}
+
+type StaticModelIndex = HashMap<Provider, HashSet<String>>;
+type CacheEntries = HashMap<String, CachedDynamicModelEntry>;
 
 pub enum ModelPickerStart {
     Completed {
@@ -131,16 +172,14 @@ pub enum ModelPickerStart {
 }
 
 impl ModelPickerState {
-    pub fn new(
+    pub async fn new(
         renderer: &mut AnsiRenderer,
         current_reasoning: ReasoningEffortLevel,
         workspace: Option<PathBuf>,
     ) -> Result<ModelPickerStart> {
         let options = MODEL_OPTIONS.as_slice();
         let inline_enabled = renderer.supports_inline_ui();
-        if inline_enabled {
-            render_step_one_inline(renderer, options, current_reasoning)?;
-        }
+        let dynamic_models = DynamicModelRegistry::load(options, workspace.as_deref()).await;
 
         let mut state = Self {
             options,
@@ -151,53 +190,110 @@ impl ModelPickerState {
             selected_reasoning: None,
             pending_api_key: None,
             workspace,
+            dynamic_models,
+            plain_mode_active: false,
         };
 
+        if inline_enabled {
+            render_step_one_inline(renderer, options, current_reasoning, &state.dynamic_models)?;
+        }
+
         if !inline_enabled {
-            match select_model_with_ratatui_list(options, current_reasoning) {
-                Ok(ModelSelectionListOutcome::Predefined(detail)) => {
-                    match state.process_model_selection(renderer, detail)? {
-                        ModelPickerProgress::Completed(result) => {
-                            return Ok(ModelPickerStart::Completed {
-                                state,
-                                selection: result,
-                            });
-                        }
-                        ModelPickerProgress::InProgress => {
-                            return Ok(ModelPickerStart::InProgress(state));
-                        }
-                        ModelPickerProgress::Cancelled => {
-                            renderer.line(MessageStyle::Info, "Model picker cancelled.")?;
-                            return Ok(ModelPickerStart::InProgress(state));
+            loop {
+                match select_model_with_ratatui_list(
+                    options,
+                    current_reasoning,
+                    &state.dynamic_models,
+                ) {
+                    Ok(ModelSelectionListOutcome::Predefined(detail)) => {
+                        match state.process_model_selection(renderer, detail)? {
+                            ModelPickerProgress::Completed(result) => {
+                                return Ok(ModelPickerStart::Completed {
+                                    state,
+                                    selection: result,
+                                });
+                            }
+                            ModelPickerProgress::InProgress => {
+                                return Ok(ModelPickerStart::InProgress(state));
+                            }
+                            ModelPickerProgress::Cancelled => {
+                                renderer.line(MessageStyle::Info, "Model picker cancelled.")?;
+                                return Ok(ModelPickerStart::InProgress(state));
+                            }
+                            ModelPickerProgress::NeedsRefresh => {
+                                state
+                                    .refresh_dynamic_models(renderer)
+                                    .await
+                                    .context("Failed to refresh local models")?;
+                                continue;
+                            }
                         }
                     }
-                }
-                Ok(ModelSelectionListOutcome::Manual) => {
-                    render_step_one_plain(renderer, options)?;
-                    prompt_custom_model_entry(renderer)?;
-                }
-                Ok(ModelSelectionListOutcome::Cancelled) => {
-                    render_step_one_plain(renderer, options)?;
-                    prompt_custom_model_entry(renderer)?;
-                }
-                Err(err) => {
-                    if err.is::<SelectionInterrupted>() {
-                        return Err(err);
+                    Ok(ModelSelectionListOutcome::Manual) => {
+                        state.plain_mode_active = true;
+                        render_step_one_plain(renderer, options, &state.dynamic_models)?;
+                        prompt_custom_model_entry(renderer)?;
+                        break;
                     }
-                    renderer.line(
-                        MessageStyle::Info,
-                        &format!(
-                            "Interactive model picker unavailable ({}). Falling back to manual input.",
-                            err
-                        ),
-                    )?;
-                    render_step_one_plain(renderer, options)?;
-                    prompt_custom_model_entry(renderer)?;
+                    Ok(ModelSelectionListOutcome::Cancelled) => {
+                        state.plain_mode_active = true;
+                        render_step_one_plain(renderer, options, &state.dynamic_models)?;
+                        prompt_custom_model_entry(renderer)?;
+                        break;
+                    }
+                    Ok(ModelSelectionListOutcome::Refresh) => {
+                        state
+                            .refresh_dynamic_models(renderer)
+                            .await
+                            .context("Failed to refresh local models")?;
+                        continue;
+                    }
+                    Err(err) => {
+                        if err.is::<SelectionInterrupted>() {
+                            return Err(err);
+                        }
+                        renderer.line(
+                            MessageStyle::Info,
+                            &format!(
+                                "Interactive model picker unavailable ({}). Falling back to manual input.",
+                                err
+                            ),
+                        )?;
+                        state.plain_mode_active = true;
+                        render_step_one_plain(renderer, options, &state.dynamic_models)?;
+                        prompt_custom_model_entry(renderer)?;
+                        break;
+                    }
                 }
             }
         }
 
         Ok(ModelPickerStart::InProgress(state))
+    }
+
+    pub async fn refresh_dynamic_models(&mut self, renderer: &mut AnsiRenderer) -> Result<()> {
+        self.dynamic_models =
+            DynamicModelRegistry::load(self.options, self.workspace.as_deref()).await;
+        self.selection = None;
+        self.selected_reasoning = None;
+        self.pending_api_key = None;
+        self.step = PickerStep::AwaitModel;
+        if self.inline_enabled {
+            renderer.line(MessageStyle::Info, "Refreshing local model inventory...")?;
+            render_step_one_inline(
+                renderer,
+                self.options,
+                self.current_reasoning,
+                &self.dynamic_models,
+            )?;
+        } else if self.plain_mode_active {
+            renderer.line(MessageStyle::Info, "Refreshing local model inventory...")?;
+            render_step_one_plain(renderer, self.options, &self.dynamic_models)?;
+            if matches!(self.step, PickerStep::AwaitModel) {
+                prompt_custom_model_entry(renderer)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn handle_input(
@@ -216,6 +312,10 @@ impl ModelPickerState {
         if is_cancel_command(trimmed) {
             renderer.line(MessageStyle::Info, "Model picker cancelled.")?;
             return Ok(ModelPickerProgress::Cancelled);
+        }
+
+        if matches!(self.step, PickerStep::AwaitModel) && trimmed.eq_ignore_ascii_case("refresh") {
+            return Ok(ModelPickerProgress::NeedsRefresh);
         }
 
         match self.step {
@@ -305,6 +405,17 @@ impl ModelPickerState {
                     let detail = selection_from_option(option);
                     self.process_model_selection(renderer, detail)
                 }
+                InlineListSelection::DynamicModel(entry_index) => {
+                    let Some(detail) = self.dynamic_models.dynamic_detail(entry_index) else {
+                        renderer.line(
+                            MessageStyle::Error,
+                            "Unable to locate the selected dynamic model.",
+                        )?;
+                        return Ok(ModelPickerProgress::InProgress);
+                    };
+                    self.process_model_selection(renderer, detail)
+                }
+                InlineListSelection::RefreshDynamicModels => Ok(ModelPickerProgress::NeedsRefresh),
                 InlineListSelection::CustomModel => {
                     renderer.close_modal();
                     prompt_custom_model_entry(renderer)?;
@@ -345,6 +456,8 @@ impl ModelPickerState {
                 }
                 InlineListSelection::CustomModel
                 | InlineListSelection::Model(_)
+                | InlineListSelection::RefreshDynamicModels
+                | InlineListSelection::DynamicModel(_)
                 | InlineListSelection::ToolApproval(_)
                 | InlineListSelection::ToolApprovalSession
                 | InlineListSelection::ToolApprovalPermanent => {
@@ -742,151 +855,134 @@ impl ModelPickerState {
     }
 }
 
-// Helper function to fetch LMStudio models synchronously (blocking call)
-fn fetch_lmstudio_models_sync() -> Result<Vec<String>, anyhow::Error> {
-    use tokio::runtime::Handle;
-    
-    match Handle::try_current() {
-        Ok(handle) => {
-            // We're already in a tokio runtime, so we can use block_on if needed
-            // But it's better to use Handle::block_on for nested contexts
-            let result = handle.block_on(async { fetch_lmstudio_models(None).await });
-            result
-        }
-        Err(_) => {
-            // No tokio runtime available, create a temporary one
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async { fetch_lmstudio_models(None).await })
-        }
-    }
+// Helper function that returns LMStudio setup instructions
+fn get_lmstudio_setup_instructions() -> String {
+    "LM Studio server is not running. To start:\n  1. Download and install LM Studio from https://lmstudio.ai\n  2. Launch LM Studio\n  3. Click the 'Local Server' toggle to start the server\n  4. Select and load a model in the 'Local Server' tab\n  5. Make sure the server runs on port 1234 (default)"
+        .to_string()
+}
+
+// Helper function that returns Ollama setup instructions
+fn get_ollama_setup_instructions() -> String {
+    "Ollama server is not running. To start:\n  1. Install Ollama from https://ollama.com\n  2. Run 'ollama serve' in a terminal\n  3. Pull models using 'ollama pull <model-name>' (e.g., 'ollama pull llama3:8b')"
+        .to_string()
 }
 
 fn render_step_one_inline(
     renderer: &mut AnsiRenderer,
     options: &[ModelOption],
     current_reasoning: ReasoningEffortLevel,
+    dynamic_models: &DynamicModelRegistry,
 ) -> Result<()> {
     let mut items = Vec::new();
     let mut first_section = true;
-    for provider in Provider::all_providers() {
-        // Get static models from the options
+    for provider in picker_provider_order() {
         let provider_models: Vec<(usize, &ModelOption)> = options
             .iter()
             .enumerate()
             .filter(|(_, candidate)| candidate.provider == provider)
             .collect();
-        
-        // Handle LM Studio specially by fetching dynamic models
-        if provider == Provider::LmStudio {
-            if !first_section {
-                items.push(provider_group_divider_item());
-            }
-            first_section = false;
+        let dynamic_indexes = dynamic_models.indexes_for(provider);
+        let has_error = dynamic_models.error_for(provider).is_some();
+        let has_warning = dynamic_models.warning_for(provider).is_some();
+
+        if provider_models.is_empty() && dynamic_indexes.is_empty() && !has_error && !has_warning {
+            continue;
+        }
+
+        if !first_section {
+            items.push(provider_group_divider_item());
+        }
+        first_section = false;
+        items.push(InlineListItem {
+            title: provider.label().to_string(),
+            subtitle: None,
+            badge: None,
+            indent: 0,
+            selection: None,
+            search_value: Some(provider.label().to_string()),
+        });
+
+        for (idx, option) in &provider_models {
+            let badge = option
+                .supports_reasoning
+                .then(|| REASONING_BADGE.to_string());
             items.push(InlineListItem {
-                title: provider.label().to_string(),
-                subtitle: None,
-                badge: None,
-                indent: 0,
-                selection: None,
-                search_value: Some(provider.label().to_string()),
+                title: option.display.to_string(),
+                subtitle: Some(option.description.to_string()),
+                badge,
+                indent: 2,
+                selection: Some(InlineListSelection::Model(*idx)),
+                search_value: Some(format!("{} {}", provider.label(), option.display)),
             });
-            
-            // Add static LM Studio models first
-            for (idx, option) in &provider_models {
-                let badge = option
-                    .supports_reasoning
-                    .then(|| REASONING_BADGE.to_string());
-                items.push(InlineListItem {
-                    title: option.display.to_string(),
-                    subtitle: Some(option.description.to_string()),
-                    badge,
-                    indent: 2,
-                    selection: Some(InlineListSelection::Model(*idx)),
-                    search_value: Some(format!("{} {}", provider.label(), option.display)),
-                });
-            }
-            
-            // Add dynamically fetched LM Studio models
-            match fetch_lmstudio_models_sync() {
-                Ok(dynamic_models) => {
-                    for model_id in dynamic_models {
-                        // Skip if it's already in the static list
-                        if provider_models.iter().any(|(_, option)| option.id == model_id) {
-                            continue;
-                        }
-                        
-                        items.push(InlineListItem {
-                            title: model_id.clone(),
-                            subtitle: Some("Locally available LM Studio model".to_string()),
-                            badge: None,
-                            indent: 2,
-                            selection: Some(InlineListSelection::CustomModel), // Use custom selection for dynamic models
-                            search_value: Some(format!("{} {}", provider.label(), model_id)),
-                        });
-                    }
-                }
-                Err(_) => {
-                    // If we can't fetch dynamic models, still show a custom LM Studio option
+        }
+
+        if matches!(provider, Provider::LmStudio | Provider::Ollama) {
+            let subtitle = if provider == Provider::LmStudio {
+                "Locally available LM Studio model"
+            } else {
+                "Locally available Ollama model"
+            };
+            for entry_index in &dynamic_indexes {
+                if let Some(detail) = dynamic_models.detail(*entry_index) {
                     items.push(InlineListItem {
-                        title: "Custom LM Studio model".to_string(),
-                        subtitle: Some(
-                            "Enter a custom LM Studio model ID (requires LM Studio server running)"
-                                .to_string(),
-                        ),
+                        title: detail.model_display.clone(),
+                        subtitle: Some(subtitle.to_string()),
                         badge: Some("Local".to_string()),
                         indent: 2,
-                        selection: Some(InlineListSelection::CustomModel),
-                        search_value: Some("lmstudio custom".to_string()),
+                        selection: Some(InlineListSelection::DynamicModel(*entry_index)),
+                        search_value: Some(format!(
+                            "{} {}",
+                            provider.label(),
+                            detail.model_display
+                        )),
                     });
                 }
             }
-        } else {
-            // Handle other providers as before (including static models only)
-            if provider_models.is_empty() {
-                continue;
-            }
-            if !first_section {
-                items.push(provider_group_divider_item());
-            }
-            first_section = false;
-            items.push(InlineListItem {
-                title: provider.label().to_string(),
-                subtitle: None,
-                badge: None,
-                indent: 0,
-                selection: None,
-                search_value: Some(provider.label().to_string()),
-            });
-            for (idx, option) in provider_models {
-                let badge = option
-                    .supports_reasoning
-                    .then(|| REASONING_BADGE.to_string());
+
+            if let Some(warning) = dynamic_models.warning_for(provider) {
                 items.push(InlineListItem {
-                    title: option.display.to_string(),
-                    subtitle: Some(option.description.to_string()),
-                    badge,
+                    title: format!("{} cache notice", provider.label()),
+                    subtitle: Some(warning.to_string()),
+                    badge: Some("Info".to_string()),
                     indent: 2,
-                    selection: Some(InlineListSelection::Model(idx)),
-                    search_value: Some(format!("{} {}", provider.label(), option.display)),
+                    selection: Some(InlineListSelection::RefreshDynamicModels),
+                    search_value: Some(format!("{} cache", provider.label())),
                 });
             }
 
-            // Add custom Ollama model option when in the Ollama provider section
-            if provider == Provider::Ollama {
-                items.push(InlineListItem {
-                    title: "Custom Ollama model".to_string(),
-                    subtitle: Some(
-                        "Enter a custom Ollama model ID (e.g., qwen3:1.7b, llama3:8b, etc.)"
-                            .to_string(),
-                    ),
-                    badge: Some("Local".to_string()),
-                    indent: 2,
-                    selection: Some(InlineListSelection::CustomModel),
-                    search_value: Some("ollama custom".to_string()),
-                });
+            if dynamic_indexes.is_empty() {
+                if let Some(error) = dynamic_models.error_for(provider) {
+                    let instructions = if provider == Provider::LmStudio {
+                        get_lmstudio_setup_instructions()
+                    } else {
+                        get_ollama_setup_instructions()
+                    };
+                    items.push(InlineListItem {
+                        title: format!("{} server unreachable", provider.label()),
+                        subtitle: Some(format!("{error}\n{instructions}")),
+                        badge: Some("Info".to_string()),
+                        indent: 2,
+                        selection: Some(InlineListSelection::CustomModel),
+                        search_value: Some(format!(
+                            "{} setup",
+                            provider.label().to_ascii_lowercase()
+                        )),
+                    });
+                }
             }
         }
     }
+
+    items.push(InlineListItem {
+        title: "Refresh local LM Studio/Ollama models".to_string(),
+        subtitle: Some(
+            "Re-query LM Studio and Ollama servers without closing the picker.".to_string(),
+        ),
+        badge: Some("Action".to_string()),
+        indent: 0,
+        selection: Some(InlineListSelection::RefreshDynamicModels),
+        search_value: Some("refresh local models".to_string()),
+    });
 
     items.push(InlineListItem {
         title: CUSTOM_PROVIDER_TITLE.to_string(),
@@ -911,7 +1007,11 @@ fn render_step_one_inline(
     Ok(())
 }
 
-fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -> Result<()> {
+fn render_step_one_plain(
+    renderer: &mut AnsiRenderer,
+    options: &[ModelOption],
+    dynamic_models: &DynamicModelRegistry,
+) -> Result<()> {
     renderer.line(
         MessageStyle::Info,
         "Model picker – Step 1: select the model you want to use.",
@@ -924,6 +1024,10 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
         MessageStyle::Info,
         "Type 'cancel' to exit the picker at any time.",
     )?;
+    renderer.line(
+        MessageStyle::Info,
+        "Type 'refresh' to re-query LM Studio and Ollama servers.",
+    )?;
 
     let mut grouped: HashMap<Provider, Vec<&ModelOption>> = HashMap::new();
     for option in options {
@@ -931,7 +1035,7 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
     }
 
     let mut first_section = true;
-    for provider in Provider::all_providers() {
+    for provider in picker_provider_order() {
         if provider == Provider::LmStudio {
             // Handle LM Studio specially by fetching dynamic models
             if !first_section {
@@ -939,8 +1043,6 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
             }
             first_section = false;
             renderer.line(MessageStyle::Info, &format!("[{}]", provider.label()))?;
-            
-            // Show static LM Studio models first
             if let Some(list) = grouped.get(&provider) {
                 for option in list {
                     let reasoning_marker = if option.supports_reasoning {
@@ -955,21 +1057,27 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
                     renderer.line(MessageStyle::Info, &format!("      {}", option.description))?;
                 }
             }
-            
-            // Add dynamically fetched LM Studio models
-            match fetch_lmstudio_models_sync() {
-                Ok(dynamic_models) => {
-                    for model_id in dynamic_models {
-                        // Skip if it's already in the static list
-                        if let Some(list) = grouped.get(&provider) {
-                            if list.iter().any(|option| option.id == model_id) {
-                                continue;
-                            }
-                        }
-                        
+
+            if let Some(warning) = dynamic_models.warning_for(provider) {
+                renderer.line(MessageStyle::Info, &format!("      note: {}", warning))?;
+            }
+            let dynamic_indexes = dynamic_models.indexes_for(provider);
+            if dynamic_indexes.is_empty() {
+                if let Some(error) = dynamic_models.error_for(provider) {
+                    renderer.line(
+                        MessageStyle::Info,
+                        &format!("LM Studio server not reachable ({error}) • Setup instructions:"),
+                    )?;
+                    for line in get_lmstudio_setup_instructions().lines() {
+                        renderer.line(MessageStyle::Info, &format!("      {}", line))?;
+                    }
+                }
+            } else {
+                for entry_index in dynamic_indexes {
+                    if let Some(detail) = dynamic_models.detail(entry_index) {
                         renderer.line(
                             MessageStyle::Info,
-                            &format!("  {} • {} (dynamic)", model_id, model_id),
+                            &format!("  {} • {} (dynamic)", detail.model_display, detail.model_id),
                         )?;
                         renderer.line(
                             MessageStyle::Info,
@@ -977,16 +1085,53 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
                         )?;
                     }
                 }
-                Err(_) => {
-                    // If we can't fetch dynamic models, still mention custom option
+            }
+        } else if provider == Provider::Ollama {
+            // Handle Ollama specially by fetching dynamic local models
+            if !first_section {
+                renderer.line(MessageStyle::Info, &provider_group_divider_line())?;
+            }
+            first_section = false;
+            renderer.line(MessageStyle::Info, &format!("[{}]", provider.label()))?;
+            if let Some(list) = grouped.get(&provider) {
+                for option in list {
+                    let reasoning_marker = if option.supports_reasoning {
+                        " [reasoning]"
+                    } else {
+                        ""
+                    };
                     renderer.line(
                         MessageStyle::Info,
-                        "Custom LM Studio model • Enter any LM Studio model ID",
+                        &format!("  {} • {}{}", option.display, option.id, reasoning_marker),
                     )?;
+                    renderer.line(MessageStyle::Info, &format!("      {}", option.description))?;
+                }
+            }
+
+            if let Some(warning) = dynamic_models.warning_for(provider) {
+                renderer.line(MessageStyle::Info, &format!("      note: {}", warning))?;
+            }
+            let dynamic_indexes = dynamic_models.indexes_for(provider);
+            if dynamic_indexes.is_empty() {
+                if let Some(error) = dynamic_models.error_for(provider) {
                     renderer.line(
                         MessageStyle::Info,
-                        "      Enter a custom LM Studio model ID (requires LM Studio server running)",
+                        &format!("Ollama server not reachable ({error}) • Setup instructions:"),
                     )?;
+                    for line in get_ollama_setup_instructions().lines() {
+                        renderer.line(MessageStyle::Info, &format!("      {}", line))?;
+                    }
+                }
+            } else {
+                for entry_index in dynamic_indexes {
+                    if let Some(detail) = dynamic_models.detail(entry_index) {
+                        renderer.line(
+                            MessageStyle::Info,
+                            &format!("  {} • {} (local)", detail.model_display, detail.model_id),
+                        )?;
+                        renderer
+                            .line(MessageStyle::Info, "      Locally available Ollama model")?;
+                    }
                 }
             }
         } else {
@@ -1011,18 +1156,6 @@ fn render_step_one_plain(renderer: &mut AnsiRenderer, options: &[ModelOption]) -
                 )?;
                 renderer.line(MessageStyle::Info, &format!("      {}", option.description))?;
             }
-
-            // Add custom Ollama model option when in the Ollama provider section
-            if provider == Provider::Ollama {
-                renderer.line(
-                    MessageStyle::Info,
-                    "Custom Ollama model • Enter any Ollama model ID",
-                )?;
-                renderer.line(
-                    MessageStyle::Info,
-                    "      Enter a custom Ollama model ID (e.g., qwen3:1.7b, llama3:8b, etc.)",
-                )?;
-            }
         }
     }
 
@@ -1039,30 +1172,33 @@ struct ModelSelectionChoice {
 enum ModelSelectionChoiceOutcome {
     Predefined(SelectionDetail),
     Manual,
+    Refresh,
 }
 
 enum ModelSelectionListOutcome {
     Predefined(SelectionDetail),
     Manual,
+    Refresh,
     Cancelled,
 }
 
 fn select_model_with_ratatui_list(
     options: &[ModelOption],
     current_reasoning: ReasoningEffortLevel,
+    dynamic_models: &DynamicModelRegistry,
 ) -> Result<ModelSelectionListOutcome> {
     if options.is_empty() {
         return Err(anyhow!("No models available for selection"));
     }
 
     let mut choices = Vec::new();
-    for provider in Provider::all_providers() {
+    for provider in picker_provider_order() {
         if provider == Provider::LmStudio {
             let provider_models: Vec<&ModelOption> = options
                 .iter()
                 .filter(|option| option.provider == provider)
                 .collect();
-            
+
             // Add static LM Studio models first
             for option in &provider_models {
                 let mut title = format!("{} • {}", provider.label(), option.display);
@@ -1075,44 +1211,53 @@ fn select_model_with_ratatui_list(
                     outcome: ModelSelectionChoiceOutcome::Predefined(selection_from_option(option)),
                 });
             }
-            
-            // Add dynamically fetched LM Studio models
-            match fetch_lmstudio_models_sync() {
-                Ok(dynamic_models) => {
-                    for model_id in dynamic_models {
-                        // Skip if it's already in the static list
-                        if provider_models.iter().any(|option| option.id == model_id) {
-                            continue;
-                        }
-                        
-                        let title = format!("{} • {} (dynamic)", provider.label(), model_id);
-                        let description = format!("ID: {} — Locally available LM Studio model", model_id);
-                        choices.push(ModelSelectionChoice {
-                            entry: SelectionEntry::new(title, Some(description)),
-                            outcome: ModelSelectionChoiceOutcome::Manual,
-                        });
-                    }
-                }
-                Err(_) => {
-                    // If we can't fetch dynamic models, still add a custom option
+            let dynamic_indexes = dynamic_models.indexes_for(provider);
+            if dynamic_indexes.is_empty() {
+                if let Some(error) = dynamic_models.error_for(provider) {
                     choices.push(ModelSelectionChoice {
                         entry: SelectionEntry::new(
-                            "Custom LM Studio model",
-                            Some(
-                                "Type 'lmstudio <model>' to use any model from your LM Studio server."
-                                    .to_string(),
-                            ),
+                            "LM Studio server not running - Setup instructions",
+                            Some(format!("{error}\n{}", get_lmstudio_setup_instructions())),
                         ),
                         outcome: ModelSelectionChoiceOutcome::Manual,
                     });
                 }
+            } else {
+                for entry_index in dynamic_indexes {
+                    if let Some(detail) = dynamic_models.detail(entry_index) {
+                        let title =
+                            format!("{} • {} (dynamic)", provider.label(), detail.model_display);
+                        let description = format!(
+                            "ID: {} — Locally available LM Studio model",
+                            detail.model_id
+                        );
+                        choices.push(ModelSelectionChoice {
+                            entry: SelectionEntry::new(title, Some(description)),
+                            outcome: ModelSelectionChoiceOutcome::Predefined(detail.clone()),
+                        });
+                    }
+                }
             }
-        } else {
+
+            if let Some(warning) = dynamic_models.warning_for(provider) {
+                choices.push(ModelSelectionChoice {
+                    entry: SelectionEntry::new(
+                        format!("{} cache notice", provider.label()),
+                        Some(format!(
+                            "{warning} Select 'Refresh local models' to re-query."
+                        )),
+                    ),
+                    outcome: ModelSelectionChoiceOutcome::Refresh,
+                });
+            }
+        } else if provider == Provider::Ollama {
             let provider_models: Vec<&ModelOption> = options
                 .iter()
                 .filter(|option| option.provider == provider)
                 .collect();
-            for option in provider_models {
+
+            // Add static Ollama models first
+            for option in &provider_models {
                 let mut title = format!("{} • {}", provider.label(), option.display);
                 if option.supports_reasoning {
                     title.push_str(" [Reasoning]");
@@ -1123,21 +1268,69 @@ fn select_model_with_ratatui_list(
                     outcome: ModelSelectionChoiceOutcome::Predefined(selection_from_option(option)),
                 });
             }
+            let dynamic_indexes = dynamic_models.indexes_for(provider);
+            if dynamic_indexes.is_empty() {
+                if let Some(error) = dynamic_models.error_for(provider) {
+                    choices.push(ModelSelectionChoice {
+                        entry: SelectionEntry::new(
+                            "Ollama server not running - Setup instructions",
+                            Some(format!("{error}\n{}", get_ollama_setup_instructions())),
+                        ),
+                        outcome: ModelSelectionChoiceOutcome::Manual,
+                    });
+                }
+            } else {
+                for entry_index in dynamic_indexes {
+                    if let Some(detail) = dynamic_models.detail(entry_index) {
+                        let title =
+                            format!("{} • {} (local)", provider.label(), detail.model_display);
+                        let description =
+                            format!("ID: {} — Locally available Ollama model", detail.model_id);
+                        choices.push(ModelSelectionChoice {
+                            entry: SelectionEntry::new(title, Some(description)),
+                            outcome: ModelSelectionChoiceOutcome::Predefined(detail.clone()),
+                        });
+                    }
+                }
+            }
 
-            if provider == Provider::Ollama {
+            if let Some(warning) = dynamic_models.warning_for(provider) {
                 choices.push(ModelSelectionChoice {
                     entry: SelectionEntry::new(
-                        "Custom Ollama model",
-                        Some(
-                            "Type 'ollama <model>' to use any local model (e.g., qwen3:1.7b, llama3:8b)."
-                                .to_string(),
-                        ),
+                        format!("{} cache notice", provider.label()),
+                        Some(format!(
+                            "{warning} Select 'Refresh local models' to re-query."
+                        )),
                     ),
-                    outcome: ModelSelectionChoiceOutcome::Manual,
+                    outcome: ModelSelectionChoiceOutcome::Refresh,
+                });
+            }
+        } else {
+            let provider_models: Vec<&ModelOption> = options
+                .iter()
+                .filter(|option| option.provider == provider)
+                .collect();
+            for option in &provider_models {
+                let mut title = format!("{} • {}", provider.label(), option.display);
+                if option.supports_reasoning {
+                    title.push_str(" [Reasoning]");
+                }
+                let description = format!("ID: {} — {}", option.id, option.description);
+                choices.push(ModelSelectionChoice {
+                    entry: SelectionEntry::new(title, Some(description)),
+                    outcome: ModelSelectionChoiceOutcome::Predefined(selection_from_option(option)),
                 });
             }
         }
     }
+
+    choices.push(ModelSelectionChoice {
+        entry: SelectionEntry::new(
+            "Refresh local LM Studio/Ollama models",
+            Some("Re-query local servers without closing the picker.".to_string()),
+        ),
+        outcome: ModelSelectionChoiceOutcome::Refresh,
+    });
 
     choices.push(ModelSelectionChoice {
         entry: SelectionEntry::new(
@@ -1165,6 +1358,7 @@ fn select_model_with_ratatui_list(
             Ok(ModelSelectionListOutcome::Predefined(detail.clone()))
         }
         ModelSelectionChoiceOutcome::Manual => Ok(ModelSelectionListOutcome::Manual),
+        ModelSelectionChoiceOutcome::Refresh => Ok(ModelSelectionListOutcome::Refresh),
     }
 }
 
@@ -1464,6 +1658,373 @@ impl ModelPickerState {
     }
 }
 
+impl DynamicModelRegistry {
+    async fn load(options: &[ModelOption], workspace: Option<&Path>) -> Self {
+        let endpoints = ProviderEndpointConfig::gather(workspace).await;
+        let static_index = build_static_model_index(options);
+        let mut cache_store = CachedDynamicModelStore::load().await;
+        let (lmstudio_result, lmstudio_warning) = cache_store
+            .fetch_with_cache(
+                Provider::LmStudio,
+                endpoints.lmstudio.clone(),
+                fetch_lmstudio_models,
+            )
+            .await;
+        let (ollama_result, ollama_warning) = cache_store
+            .fetch_with_cache(
+                Provider::Ollama,
+                endpoints.ollama.clone(),
+                fetch_ollama_models,
+            )
+            .await;
+        let _ = cache_store.persist().await;
+        let mut registry = Self::default();
+        registry.process_fetch(
+            Provider::LmStudio,
+            lmstudio_result,
+            endpoints
+                .lmstudio
+                .clone()
+                .unwrap_or_else(|| urls::LMSTUDIO_API_BASE.to_string()),
+            &static_index,
+        );
+        if let Some(warning) = lmstudio_warning {
+            registry.record_warning(Provider::LmStudio, warning);
+        }
+        registry.process_fetch(
+            Provider::Ollama,
+            ollama_result,
+            endpoints
+                .ollama
+                .clone()
+                .unwrap_or_else(|| urls::OLLAMA_API_BASE.to_string()),
+            &static_index,
+        );
+        if let Some(warning) = ollama_warning {
+            registry.record_warning(Provider::Ollama, warning);
+        }
+        registry
+    }
+
+    fn indexes_for(&self, provider: Provider) -> Vec<usize> {
+        self.provider_models
+            .get(&provider)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn detail(&self, index: usize) -> Option<&SelectionDetail> {
+        self.entries.get(index)
+    }
+
+    fn dynamic_detail(&self, index: usize) -> Option<SelectionDetail> {
+        self.entries.get(index).cloned()
+    }
+
+    fn error_for(&self, provider: Provider) -> Option<&str> {
+        self.provider_errors.get(&provider).map(|msg| msg.as_str())
+    }
+
+    fn warning_for(&self, provider: Provider) -> Option<&str> {
+        self.provider_warnings
+            .get(&provider)
+            .map(|msg| msg.as_str())
+    }
+
+    fn process_fetch(
+        &mut self,
+        provider: Provider,
+        result: Result<Vec<String>>,
+        base_url: String,
+        static_index: &StaticModelIndex,
+    ) {
+        match result {
+            Ok(models) => self.register_provider_models(provider, models, static_index),
+            Err(err) => {
+                self.record_error(
+                    provider,
+                    format!(
+                        "Failed to query {} at {} ({})",
+                        provider.label(),
+                        base_url,
+                        err
+                    ),
+                );
+            }
+        }
+    }
+
+    fn register_provider_models(
+        &mut self,
+        provider: Provider,
+        models: Vec<String>,
+        static_index: &StaticModelIndex,
+    ) {
+        if !models.is_empty() {
+            self.provider_errors.remove(&provider);
+            self.provider_warnings.remove(&provider);
+        }
+        for model_id in models {
+            let trimmed = model_id.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let lower = trimmed.to_ascii_lowercase();
+            if static_index
+                .get(&provider)
+                .map_or(false, |set| set.contains(&lower))
+            {
+                continue;
+            }
+            if self.has_model(provider, trimmed) {
+                continue;
+            }
+            if provider == Provider::Ollama
+                && (trimmed.contains(":cloud") || trimmed.contains("-cloud"))
+            {
+                continue;
+            }
+            let detail = selection_from_dynamic(provider, trimmed);
+            self.register_model(provider, detail);
+        }
+    }
+
+    fn register_model(&mut self, provider: Provider, detail: SelectionDetail) {
+        let index = self.entries.len();
+        self.entries.push(detail);
+        self.provider_models
+            .entry(provider)
+            .or_default()
+            .push(index);
+    }
+
+    fn has_model(&self, provider: Provider, candidate: &str) -> bool {
+        if let Some(indexes) = self.provider_models.get(&provider) {
+            for index in indexes {
+                if let Some(entry) = self.entries.get(*index) {
+                    if entry.model_id.eq_ignore_ascii_case(candidate) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn record_error(&mut self, provider: Provider, message: String) {
+        self.provider_errors.insert(provider, message);
+        self.provider_warnings.remove(&provider);
+    }
+
+    fn record_warning(&mut self, provider: Provider, message: String) {
+        self.provider_warnings.insert(provider, message);
+    }
+}
+
+#[derive(Default)]
+struct CachedDynamicModelStore {
+    path: Option<PathBuf>,
+    entries: CacheEntries,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct CachedDynamicModelEntry {
+    provider: String,
+    base_url: String,
+    fetched_at: u64,
+    models: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct CachedDynamicModelFile {
+    version: u32,
+    entries: Vec<CachedDynamicModelEntry>,
+}
+
+impl CachedDynamicModelStore {
+    async fn load() -> Self {
+        let path = dynamic_model_cache_path();
+        let mut store = Self {
+            path: path.clone(),
+            entries: HashMap::new(),
+        };
+        if let Some(path) = path {
+            if let Ok(bytes) = fs::read(&path).await {
+                if let Ok(file) = serde_json::from_slice::<CachedDynamicModelFile>(&bytes) {
+                    for entry in file.entries {
+                        let key = format!("{}::{}", entry.provider, entry.base_url);
+                        store.entries.insert(key, entry);
+                    }
+                }
+            }
+        }
+        store
+    }
+
+    async fn persist(&self) -> Result<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.ok();
+        }
+        let file = CachedDynamicModelFile {
+            version: 1,
+            entries: self.entries.values().cloned().collect(),
+        };
+        let payload = serde_json::to_vec_pretty(&file)?;
+        fs::write(path, payload).await?;
+        Ok(())
+    }
+
+    async fn fetch_with_cache<F, Fut>(
+        &mut self,
+        provider: Provider,
+        mut base_url: Option<String>,
+        fetch_fn: F,
+    ) -> (Result<Vec<String>>, Option<String>)
+    where
+        F: Fn(Option<String>) -> Fut,
+        Fut: Future<Output = Result<Vec<String>, anyhow::Error>>,
+    {
+        if let Some(value) = base_url.take() {
+            let trimmed = value.trim().trim_end_matches('/').to_string();
+            if trimmed.is_empty() {
+                base_url = None;
+            } else {
+                base_url = Some(trimmed);
+            }
+        }
+
+        let resolved_base = base_url
+            .clone()
+            .unwrap_or_else(|| default_provider_base(provider).to_string());
+        let key = Self::cache_key(provider, &resolved_base);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        if let Some(entry) = self.entries.get(&key) {
+            if now.saturating_sub(entry.fetched_at) <= DYNAMIC_MODEL_CACHE_TTL_SECS {
+                return (Ok(entry.models.clone()), None);
+            }
+        }
+
+        match fetch_fn(base_url.clone()).await {
+            Ok(models) => {
+                self.entries.insert(
+                    key,
+                    CachedDynamicModelEntry {
+                        provider: provider.to_string(),
+                        base_url: resolved_base,
+                        fetched_at: now,
+                        models: models.clone(),
+                    },
+                );
+                (Ok(models), None)
+            }
+            Err(err) => {
+                if let Some(entry) = self.entries.get(&key) {
+                    let warning = format!(
+                        "Using cached {} models fetched {}s ago because {} was unreachable ({}).",
+                        provider.label(),
+                        now.saturating_sub(entry.fetched_at),
+                        resolved_base,
+                        err
+                    );
+                    return (Ok(entry.models.clone()), Some(warning));
+                }
+                (Err(err), None)
+            }
+        }
+    }
+
+    fn cache_key(provider: Provider, base_url: &str) -> String {
+        format!("{}::{}", provider, base_url)
+    }
+}
+
+fn dynamic_model_cache_path() -> Option<PathBuf> {
+    let manager = get_dot_manager().lock().ok()?.clone();
+    Some(
+        manager
+            .cache_dir("models")
+            .join(DYNAMIC_MODEL_CACHE_FILENAME),
+    )
+}
+
+fn default_provider_base(provider: Provider) -> &'static str {
+    match provider {
+        Provider::LmStudio => urls::LMSTUDIO_API_BASE,
+        Provider::Ollama => urls::OLLAMA_API_BASE,
+        _ => "",
+    }
+}
+
+impl ProviderEndpointConfig {
+    async fn gather(workspace: Option<&Path>) -> Self {
+        let _ = workspace;
+        let dot_config = load_user_config().await.ok();
+        Self {
+            lmstudio: Self::extract_base_url(Provider::LmStudio, dot_config.as_ref()),
+            ollama: Self::extract_base_url(Provider::Ollama, dot_config.as_ref()),
+        }
+    }
+
+    fn extract_base_url(provider: Provider, dot_config: Option<&DotConfig>) -> Option<String> {
+        let from_config = dot_config.and_then(|cfg| match provider {
+            Provider::LmStudio => cfg
+                .providers
+                .lmstudio
+                .as_ref()
+                .and_then(|c| c.base_url.clone()),
+            Provider::Ollama => cfg
+                .providers
+                .ollama
+                .as_ref()
+                .and_then(|c| c.base_url.clone()),
+            _ => None,
+        });
+
+        from_config
+            .and_then(Self::sanitize_owned)
+            .or_else(|| Self::env_override(provider))
+    }
+
+    fn sanitize_owned(value: String) -> Option<String> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    fn env_override(provider: Provider) -> Option<String> {
+        let key = match provider {
+            Provider::LmStudio => env_vars::LMSTUDIO_BASE_URL,
+            Provider::Ollama => env_vars::OLLAMA_BASE_URL,
+            _ => return None,
+        };
+        std::env::var(key)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    }
+}
+
+fn build_static_model_index(options: &[ModelOption]) -> StaticModelIndex {
+    let mut index = HashMap::new();
+    for option in options {
+        index
+            .entry(option.provider)
+            .or_insert_with(HashSet::new)
+            .insert(option.id.to_ascii_lowercase());
+    }
+    index
+}
+
 fn prompt_custom_model_entry(renderer: &mut AnsiRenderer) -> Result<()> {
     renderer.line(
         MessageStyle::Info,
@@ -1476,6 +2037,10 @@ fn prompt_custom_model_entry(renderer: &mut AnsiRenderer) -> Result<()> {
     renderer.line(
         MessageStyle::Info,
         "Type 'cancel' to exit the picker at any time.",
+    )?;
+    renderer.line(
+        MessageStyle::Info,
+        "Type 'refresh' to reload LM Studio and Ollama model lists.",
     )?;
     Ok(())
 }
@@ -1540,18 +2105,8 @@ fn parse_model_selection(options: &[ModelOption], input: &str) -> Result<Selecti
     let reasoning_supported = provider_enum
         .map(|provider| provider.supports_reasoning_effort(model_token.trim()))
         .unwrap_or(false);
-    let requires_api_key = if provider_enum == Some(Provider::Ollama) {
-        // For Ollama, only cloud models (containing ":cloud" or "-cloud") require API keys
-        let is_cloud_model =
-            model_token.trim().contains(":cloud") || model_token.trim().contains("-cloud");
-        if is_cloud_model {
-            match std::env::var(&env_key) {
-                Ok(value) => value.trim().is_empty(),
-                Err(_) => true,
-            }
-        } else {
-            false // Local Ollama models don't require an API key
-        }
+    let requires_api_key = if let Some(provider) = provider_enum {
+        provider_requires_api_key(provider, model_token.trim(), &env_key)
     } else {
         match std::env::var(&env_key) {
             Ok(value) => value.trim().is_empty(),
@@ -1576,23 +2131,7 @@ fn parse_model_selection(options: &[ModelOption], input: &str) -> Result<Selecti
 
 fn selection_from_option(option: &ModelOption) -> SelectionDetail {
     let env_key = option.provider.default_api_key_env().to_string();
-    let requires_api_key = if option.provider == Provider::Ollama {
-        // For Ollama, only cloud models (containing ":cloud" or "-cloud") require API keys
-        let is_cloud_model = option.id.contains(":cloud") || option.id.contains("-cloud");
-        if is_cloud_model {
-            match std::env::var(&env_key) {
-                Ok(value) => value.trim().is_empty(),
-                Err(_) => true,
-            }
-        } else {
-            false // Local Ollama models don't require an API key
-        }
-    } else {
-        match std::env::var(&env_key) {
-            Ok(value) => value.trim().is_empty(),
-            Err(_) => true,
-        }
-    };
+    let requires_api_key = provider_requires_api_key(option.provider, option.id, &env_key);
     SelectionDetail {
         provider_key: option.provider.to_string(),
         provider_label: option.provider.label().to_string(),
@@ -1603,6 +2142,24 @@ fn selection_from_option(option: &ModelOption) -> SelectionDetail {
         reasoning_supported: option.supports_reasoning,
         reasoning_optional: false,
         reasoning_off_model: option.reasoning_alternative,
+        requires_api_key,
+        env_key,
+    }
+}
+
+fn selection_from_dynamic(provider: Provider, model_id: &str) -> SelectionDetail {
+    let env_key = provider.default_api_key_env().to_string();
+    let requires_api_key = provider_requires_api_key(provider, model_id, &env_key);
+    SelectionDetail {
+        provider_key: provider.to_string(),
+        provider_label: provider.label().to_string(),
+        provider_enum: Some(provider),
+        model_id: model_id.to_string(),
+        model_display: model_id.to_string(),
+        known_model: false,
+        reasoning_supported: provider.supports_reasoning_effort(model_id),
+        reasoning_optional: true,
+        reasoning_off_model: None,
         requires_api_key,
         env_key,
     }
@@ -1634,6 +2191,23 @@ fn derive_env_key(provider: &str) -> String {
         key.push_str("API_KEY");
     }
     key
+}
+
+fn provider_requires_api_key(provider: Provider, model_id: &str, env_key: &str) -> bool {
+    if provider == Provider::Ollama {
+        let is_cloud_model = model_id.contains(":cloud") || model_id.contains("-cloud");
+        if !is_cloud_model {
+            return false;
+        }
+    }
+    if provider == Provider::LmStudio {
+        return false;
+    }
+
+    match std::env::var(env_key) {
+        Ok(value) => value.trim().is_empty(),
+        Err(_) => true,
+    }
 }
 
 fn title_case(value: &str) -> String {

--- a/src/agent/runloop/slash_commands.rs
+++ b/src/agent/runloop/slash_commands.rs
@@ -502,10 +502,8 @@ pub async fn handle_slash_command(
                     "install" => UpdateAction::Install,
                     "status" => UpdateAction::Status,
                     _ => {
-                        renderer.line(
-                            MessageStyle::Error,
-                            "Usage: /update [check|install|status]",
-                        )?;
+                        renderer
+                            .line(MessageStyle::Error, "Usage: /update [check|install|status]")?;
                         return Ok(SlashCommandOutcome::Handled);
                     }
                 }

--- a/src/agent/runloop/unified/turn.rs
+++ b/src/agent/runloop/unified/turn.rs
@@ -2373,7 +2373,8 @@ async fn handle_update_command_async(
                     )?;
 
                     if let Some(latest) = &status.latest_version {
-                        renderer.line(MessageStyle::Info, &format!("Latest version:  {}", latest))?;
+                        renderer
+                            .line(MessageStyle::Info, &format!("Latest version:  {}", latest))?;
                     }
 
                     if status.update_available {
@@ -2385,7 +2386,10 @@ async fn handle_update_command_async(
                                 renderer.line(MessageStyle::Info, "Release highlights:")?;
                                 for line in lines {
                                     if !line.trim().is_empty() {
-                                        renderer.line(MessageStyle::Info, &format!("  {}", line.trim()))?;
+                                        renderer.line(
+                                            MessageStyle::Info,
+                                            &format!("  {}", line.trim()),
+                                        )?;
                                     }
                                 }
                             }
@@ -2396,7 +2400,8 @@ async fn handle_update_command_async(
                             "Run '/update install' or 'vtcode update install' to install the update.",
                         )?;
                     } else {
-                        renderer.line(MessageStyle::Status, "You are running the latest version.")?;
+                        renderer
+                            .line(MessageStyle::Status, "You are running the latest version.")?;
                     }
                 }
                 Err(e) => {

--- a/src/startup/first_run.rs
+++ b/src/startup/first_run.rs
@@ -584,6 +584,7 @@ fn default_model_for_provider(provider: Provider) -> &'static str {
         Provider::DeepSeek => models::deepseek::DEFAULT_MODEL,
         Provider::OpenRouter => models::openrouter::DEFAULT_MODEL,
         Provider::Ollama => models::ollama::DEFAULT_MODEL,
+        Provider::LmStudio => models::lmstudio::DEFAULT_MODEL,
         Provider::Moonshot => models::moonshot::DEFAULT_MODEL,
         Provider::XAI => models::xai::DEFAULT_MODEL,
         Provider::ZAI => models::zai::DEFAULT_MODEL,

--- a/src/startup/update_check.rs
+++ b/src/startup/update_check.rs
@@ -72,10 +72,7 @@ fn display_update_notification(status: &UpdateStatus) -> Result<()> {
     // Print prominent header
     println!();
     println!("{}", style("═".repeat(80)).cyan().bold());
-    println!(
-        "{}",
-        style("  UPDATE AVAILABLE").cyan().bold().on_black()
-    );
+    println!("{}", style("  UPDATE AVAILABLE").cyan().bold().on_black());
     println!("{}", style("═".repeat(80)).cyan().bold());
     println!();
     println!(
@@ -124,7 +121,10 @@ async fn prompt_for_update(manager: UpdateManager, status: &UpdateStatus) -> Res
 
     // Check if auto-install is enabled
     if manager.config().auto_install {
-        println!("  {} Auto-install is enabled. Installing update...", style("→").cyan());
+        println!(
+            "  {} Auto-install is enabled. Installing update...",
+            style("→").cyan()
+        );
         return perform_update(manager, status).await;
     }
 
@@ -174,7 +174,10 @@ async fn perform_update(mut manager: UpdateManager, _status: &UpdateStatus) -> R
         Ok(update_result) => {
             if update_result.success {
                 println!();
-                println!("  {} Update installed successfully!", style("✓").green().bold());
+                println!(
+                    "  {} Update installed successfully!",
+                    style("✓").green().bold()
+                );
                 println!(
                     "  {} Updated from {} to {}",
                     style("→").cyan(),
@@ -204,10 +207,7 @@ async fn perform_update(mut manager: UpdateManager, _status: &UpdateStatus) -> R
 
                 println!();
             } else {
-                println!(
-                    "  {} Update installation failed.",
-                    style("✗").red().bold()
-                );
+                println!("  {} Update installation failed.", style("✗").red().bold());
             }
         }
         Err(e) => {

--- a/tests/integration_modular.rs
+++ b/tests/integration_modular.rs
@@ -46,6 +46,7 @@ fn test_config_module_integration() {
                 | "moonshot"
                 | "deepseek"
                 | "ollama"
+                | "lmstudio"
         ),
         "unexpected provider '{}' in loaded config",
         loaded_config.agent.provider

--- a/tests/llm_focused_test.rs
+++ b/tests/llm_focused_test.rs
@@ -5,8 +5,8 @@ use vtcode_core::llm::{
     factory::{LLMFactory, create_provider_for_model},
     provider::{LLMProvider, LLMRequest, Message, MessageRole},
     providers::{
-        AnthropicProvider, GeminiProvider, MoonshotProvider, OllamaProvider, OpenAIProvider,
-        OpenRouterProvider, XAIProvider,
+        AnthropicProvider, GeminiProvider, LmStudioProvider, MoonshotProvider, OllamaProvider,
+        OpenAIProvider, OpenRouterProvider, XAIProvider,
     },
 };
 
@@ -24,7 +24,8 @@ fn test_provider_factory_basic() {
     assert!(providers.contains(&"deepseek".to_string()));
     assert!(providers.contains(&"zai".to_string()));
     assert!(providers.contains(&"ollama".to_string()));
-    assert_eq!(providers.len(), 9);
+    assert!(providers.contains(&"lmstudio".to_string()));
+    assert_eq!(providers.len(), 10);
 }
 
 #[test]
@@ -58,6 +59,10 @@ fn test_provider_auto_detection() {
     assert_eq!(
         factory.provider_from_model(models::MOONSHOT_KIMI_K2_TURBO_PREVIEW),
         Some("moonshot".to_string())
+    );
+    assert_eq!(
+        factory.provider_from_model(models::lmstudio::META_LLAMA_31_8B_INSTRUCT),
+        Some("lmstudio".to_string())
     );
     assert_eq!(factory.provider_from_model("unknown-model"), None);
 }
@@ -98,6 +103,9 @@ fn test_unified_client_creation() {
 
     let ollama = create_provider_for_model(models::ollama::DEFAULT_MODEL, String::new(), None);
     assert!(ollama.is_ok());
+
+    let lmstudio = create_provider_for_model(models::lmstudio::DEFAULT_MODEL, String::new(), None);
+    assert!(lmstudio.is_ok());
 }
 
 #[test]
@@ -133,6 +141,9 @@ fn test_provider_names() {
 
     let ollama = OllamaProvider::new(String::new());
     assert_eq!(ollama.name(), "ollama");
+
+    let lmstudio = LmStudioProvider::new(String::new());
+    assert_eq!(lmstudio.name(), "lmstudio");
 }
 
 #[test]

--- a/tests/llm_providers_test.rs
+++ b/tests/llm_providers_test.rs
@@ -7,8 +7,8 @@ use vtcode_core::llm::{
     factory::{LLMFactory, create_provider_for_model, infer_provider},
     provider::{LLMProvider, LLMRequest, Message, MessageRole, ToolDefinition},
     providers::{
-        AnthropicProvider, GeminiProvider, MoonshotProvider, OllamaProvider, OpenAIProvider,
-        OpenRouterProvider, XAIProvider,
+        AnthropicProvider, GeminiProvider, LmStudioProvider, MoonshotProvider, OllamaProvider,
+        OpenAIProvider, OpenRouterProvider, XAIProvider,
     },
 };
 
@@ -27,7 +27,8 @@ fn test_provider_factory_creation() {
     assert!(providers.contains(&"deepseek".to_string()));
     assert!(providers.contains(&"zai".to_string()));
     assert!(providers.contains(&"ollama".to_string()));
-    assert_eq!(providers.len(), 9);
+    assert!(providers.contains(&"lmstudio".to_string()));
+    assert_eq!(providers.len(), 10);
 }
 
 #[test]
@@ -84,6 +85,12 @@ fn test_provider_auto_detection() {
     assert_eq!(
         factory.provider_from_model(models::OPENROUTER_ANTHROPIC_CLAUDE_SONNET_4_5),
         Some("openrouter".to_string())
+    );
+
+    // Test LM Studio models
+    assert_eq!(
+        factory.provider_from_model(models::lmstudio::META_LLAMA_31_8B_INSTRUCT),
+        Some("lmstudio".to_string())
     );
 
     // Test xAI models
@@ -218,6 +225,13 @@ fn test_unified_client_creation() {
     if let Ok(client) = ollama_client {
         assert_eq!(client.name(), "ollama");
     }
+
+    let lmstudio_client =
+        create_provider_for_model(models::lmstudio::DEFAULT_MODEL, String::new(), None);
+    assert!(lmstudio_client.is_ok());
+    if let Ok(client) = lmstudio_client {
+        assert_eq!(client.name(), "lmstudio");
+    }
 }
 
 #[test]
@@ -309,6 +323,9 @@ fn test_provider_names() {
 
     let ollama = OllamaProvider::new(String::new());
     assert_eq!(ollama.name(), "ollama");
+
+    let lmstudio = LmStudioProvider::new(String::new());
+    assert_eq!(lmstudio.name(), "lmstudio");
 }
 
 #[test]

--- a/tests/tool_call_verification.rs
+++ b/tests/tool_call_verification.rs
@@ -7,7 +7,8 @@ use vtcode_core::llm::{
         LLMProvider, LLMRequest, Message, MessageRole, ToolCall, ToolChoice, ToolDefinition,
     },
     providers::{
-        AnthropicProvider, GeminiProvider, OllamaProvider, OpenAIProvider, OpenRouterProvider,
+        AnthropicProvider, GeminiProvider, LmStudioProvider, OllamaProvider, OpenAIProvider,
+        OpenRouterProvider,
     },
 };
 
@@ -200,6 +201,7 @@ fn test_all_providers_tool_validation() {
     let anthropic = AnthropicProvider::new("test_key".to_string());
     let openrouter = OpenRouterProvider::new("test_key".to_string());
     let ollama = OllamaProvider::from_config(None, None, None, None);
+    let lmstudio = LmStudioProvider::from_config(None, None, None, None);
 
     // Test valid requests with tools
     let tool = ToolDefinition::function(
@@ -268,6 +270,22 @@ fn test_all_providers_tool_validation() {
     assert!(openai.validate_request(&openai_request).is_ok());
     assert!(anthropic.validate_request(&anthropic_request).is_ok());
     assert!(openrouter.validate_request(&openrouter_request).is_ok());
+
+    let lmstudio_request = LLMRequest {
+        messages: vec![Message::user("test".to_string())],
+        system_prompt: None,
+        tools: Some(vec![tool.clone()]),
+        model: models::lmstudio::DEFAULT_MODEL.to_string(),
+        max_tokens: Some(1024),
+        temperature: Some(0.1),
+        stream: true,
+        tool_choice: Some(ToolChoice::auto()),
+        parallel_tool_calls: None,
+        parallel_tool_config: None,
+        reasoning_effort: None,
+    };
+
+    assert!(lmstudio.validate_request(&lmstudio_request).is_ok());
 
     let ollama_request = LLMRequest {
         messages: vec![Message::user("test".to_string())],

--- a/vtcode-config/src/constants.rs
+++ b/vtcode-config/src/constants.rs
@@ -112,12 +112,21 @@ pub mod models {
     // LM Studio models (OpenAI-compatible local server)
     pub mod lmstudio {
         pub const DEFAULT_MODEL: &str = META_LLAMA_31_8B_INSTRUCT;
-        pub const SUPPORTED_MODELS: &[&str] =
-            &[META_LLAMA_31_8B_INSTRUCT, QWEN25_7B_INSTRUCT, GEMMA_2_2B_IT];
+        pub const SUPPORTED_MODELS: &[&str] = &[
+            META_LLAMA_3_8B_INSTRUCT,
+            META_LLAMA_31_8B_INSTRUCT,
+            QWEN25_7B_INSTRUCT,
+            GEMMA_2_2B_IT,
+            GEMMA_2_9B_IT,
+            PHI_31_MINI_4K_INSTRUCT,
+        ];
 
+        pub const META_LLAMA_3_8B_INSTRUCT: &str = "lmstudio-community/meta-llama-3-8b-instruct";
         pub const META_LLAMA_31_8B_INSTRUCT: &str = "lmstudio-community/meta-llama-3.1-8b-instruct";
         pub const QWEN25_7B_INSTRUCT: &str = "lmstudio-community/qwen2.5-7b-instruct";
         pub const GEMMA_2_2B_IT: &str = "lmstudio-community/gemma-2-2b-it";
+        pub const GEMMA_2_9B_IT: &str = "lmstudio-community/gemma-2-9b-it";
+        pub const PHI_31_MINI_4K_INSTRUCT: &str = "lmstudio-community/phi-3.1-mini-4k-instruct";
     }
 
     pub mod ollama {

--- a/vtcode-config/src/constants.rs
+++ b/vtcode-config/src/constants.rs
@@ -109,6 +109,17 @@ pub mod models {
         include!(concat!(env!("OUT_DIR"), "/openrouter_constants.rs"));
     }
 
+    // LM Studio models (OpenAI-compatible local server)
+    pub mod lmstudio {
+        pub const DEFAULT_MODEL: &str = META_LLAMA_31_8B_INSTRUCT;
+        pub const SUPPORTED_MODELS: &[&str] =
+            &[META_LLAMA_31_8B_INSTRUCT, QWEN25_7B_INSTRUCT, GEMMA_2_2B_IT];
+
+        pub const META_LLAMA_31_8B_INSTRUCT: &str = "lmstudio-community/meta-llama-3.1-8b-instruct";
+        pub const QWEN25_7B_INSTRUCT: &str = "lmstudio-community/qwen2.5-7b-instruct";
+        pub const GEMMA_2_2B_IT: &str = "lmstudio-community/gemma-2-2b-it";
+    }
+
     pub mod ollama {
         pub const DEFAULT_LOCAL_MODEL: &str = "gpt-oss:20b";
         pub const DEFAULT_CLOUD_MODEL: &str = "gpt-oss:120b-cloud";
@@ -498,6 +509,7 @@ pub mod urls {
     pub const DEEPSEEK_API_BASE: &str = "https://api.deepseek.com/v1";
     pub const Z_AI_API_BASE: &str = "https://api.z.ai/api";
     pub const MOONSHOT_API_BASE: &str = "https://api.moonshot.cn/v1";
+    pub const LMSTUDIO_API_BASE: &str = "http://localhost:1234/v1";
     pub const OLLAMA_API_BASE: &str = "http://localhost:11434";
     pub const OLLAMA_CLOUD_API_BASE: &str = "https://ollama.com";
 }
@@ -512,6 +524,7 @@ pub mod env_vars {
     pub const DEEPSEEK_BASE_URL: &str = "DEEPSEEK_BASE_URL";
     pub const Z_AI_BASE_URL: &str = "ZAI_BASE_URL";
     pub const MOONSHOT_BASE_URL: &str = "MOONSHOT_BASE_URL";
+    pub const LMSTUDIO_BASE_URL: &str = "LMSTUDIO_BASE_URL";
     pub const OLLAMA_BASE_URL: &str = "OLLAMA_BASE_URL";
 }
 

--- a/vtcode-config/src/models.rs
+++ b/vtcode-config/src/models.rs
@@ -258,12 +258,18 @@ pub enum ModelId {
     OllamaQwen317b,
 
     // LM Studio models
+    /// Meta Llama 3 8B Instruct served locally via LM Studio
+    LmStudioMetaLlama38BInstruct,
     /// Meta Llama 3.1 8B Instruct served locally via LM Studio
     LmStudioMetaLlama318BInstruct,
     /// Qwen2.5 7B Instruct served locally via LM Studio
     LmStudioQwen257BInstruct,
     /// Gemma 2 2B IT served locally via LM Studio
     LmStudioGemma22BIt,
+    /// Gemma 2 9B IT served locally via LM Studio
+    LmStudioGemma29BIt,
+    /// Phi-3.1 Mini 4K Instruct served locally via LM Studio
+    LmStudioPhi31Mini4kInstruct,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model powered by xAI Grok
@@ -439,9 +445,12 @@ impl ModelId {
             ModelId::OllamaGptOss120bCloud => models::ollama::GPT_OSS_120B_CLOUD,
             ModelId::OllamaQwen317b => models::ollama::QWEN3_1_7B,
             // LM Studio models
+            ModelId::LmStudioMetaLlama38BInstruct => models::lmstudio::META_LLAMA_3_8B_INSTRUCT,
             ModelId::LmStudioMetaLlama318BInstruct => models::lmstudio::META_LLAMA_31_8B_INSTRUCT,
             ModelId::LmStudioQwen257BInstruct => models::lmstudio::QWEN25_7B_INSTRUCT,
             ModelId::LmStudioGemma22BIt => models::lmstudio::GEMMA_2_2B_IT,
+            ModelId::LmStudioGemma29BIt => models::lmstudio::GEMMA_2_9B_IT,
+            ModelId::LmStudioPhi31Mini4kInstruct => models::lmstudio::PHI_31_MINI_4K_INSTRUCT,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -491,9 +500,12 @@ impl ModelId {
             ModelId::OllamaGptOss20b | ModelId::OllamaGptOss120bCloud | ModelId::OllamaQwen317b => {
                 Provider::Ollama
             }
-            ModelId::LmStudioMetaLlama318BInstruct
+            ModelId::LmStudioMetaLlama38BInstruct
+            | ModelId::LmStudioMetaLlama318BInstruct
             | ModelId::LmStudioQwen257BInstruct
-            | ModelId::LmStudioGemma22BIt => Provider::LmStudio,
+            | ModelId::LmStudioGemma22BIt
+            | ModelId::LmStudioGemma29BIt
+            | ModelId::LmStudioPhi31Mini4kInstruct => Provider::LmStudio,
             _ => unreachable!(),
         }
     }
@@ -554,9 +566,12 @@ impl ModelId {
             ModelId::OllamaGptOss20b => "GPT-OSS 20B (local)",
             ModelId::OllamaGptOss120bCloud => "GPT-OSS 120B (cloud)",
             ModelId::OllamaQwen317b => "Qwen3 1.7B (local)",
+            ModelId::LmStudioMetaLlama38BInstruct => "Meta Llama 3 8B (LM Studio)",
             ModelId::LmStudioMetaLlama318BInstruct => "Meta Llama 3.1 8B (LM Studio)",
             ModelId::LmStudioQwen257BInstruct => "Qwen2.5 7B (LM Studio)",
             ModelId::LmStudioGemma22BIt => "Gemma 2 2B (LM Studio)",
+            ModelId::LmStudioGemma29BIt => "Gemma 2 9B (LM Studio)",
+            ModelId::LmStudioPhi31Mini4kInstruct => "Phi-3.1 Mini 4K (LM Studio)",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -660,6 +675,9 @@ impl ModelId {
             ModelId::OllamaQwen317b => {
                 "Qwen3 1.7B served locally through Ollama without external API requirements"
             }
+            ModelId::LmStudioMetaLlama38BInstruct => {
+                "Meta Llama 3 8B running through LM Studio's local OpenAI-compatible server"
+            }
             ModelId::LmStudioMetaLlama318BInstruct => {
                 "Meta Llama 3.1 8B running through LM Studio's local OpenAI-compatible server"
             }
@@ -668,6 +686,12 @@ impl ModelId {
             }
             ModelId::LmStudioGemma22BIt => {
                 "Gemma 2 2B IT deployed via LM Studio for lightweight on-device assistance"
+            }
+            ModelId::LmStudioGemma29BIt => {
+                "Gemma 2 9B IT served locally via LM Studio when you need additional capacity"
+            }
+            ModelId::LmStudioPhi31Mini4kInstruct => {
+                "Phi-3.1 Mini 4K hosted in LM Studio for compact reasoning and experimentation"
             }
             _ => unreachable!(),
         }
@@ -727,9 +751,12 @@ impl ModelId {
             ModelId::OllamaGptOss120bCloud,
             ModelId::OllamaQwen317b,
             // LM Studio models
+            ModelId::LmStudioMetaLlama38BInstruct,
             ModelId::LmStudioMetaLlama318BInstruct,
             ModelId::LmStudioQwen257BInstruct,
             ModelId::LmStudioGemma22BIt,
+            ModelId::LmStudioGemma29BIt,
+            ModelId::LmStudioPhi31Mini4kInstruct,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -956,9 +983,12 @@ impl ModelId {
             ModelId::OllamaGptOss20b => "oss",
             ModelId::OllamaGptOss120bCloud => "oss-cloud",
             ModelId::OllamaQwen317b => "oss",
+            ModelId::LmStudioMetaLlama38BInstruct => "meta-llama-3",
             ModelId::LmStudioMetaLlama318BInstruct => "meta-llama-3.1",
             ModelId::LmStudioQwen257BInstruct => "qwen2.5",
             ModelId::LmStudioGemma22BIt => "gemma-2",
+            ModelId::LmStudioGemma29BIt => "gemma-2",
+            ModelId::LmStudioPhi31Mini4kInstruct => "phi-3.1",
             _ => unreachable!(),
         }
     }
@@ -1028,11 +1058,18 @@ impl FromStr for ModelId {
             s if s == models::ollama::GPT_OSS_20B => Ok(ModelId::OllamaGptOss20b),
             s if s == models::ollama::GPT_OSS_120B_CLOUD => Ok(ModelId::OllamaGptOss120bCloud),
             s if s == models::ollama::QWEN3_1_7B => Ok(ModelId::OllamaQwen317b),
+            s if s == models::lmstudio::META_LLAMA_3_8B_INSTRUCT => {
+                Ok(ModelId::LmStudioMetaLlama38BInstruct)
+            }
             s if s == models::lmstudio::META_LLAMA_31_8B_INSTRUCT => {
                 Ok(ModelId::LmStudioMetaLlama318BInstruct)
             }
             s if s == models::lmstudio::QWEN25_7B_INSTRUCT => Ok(ModelId::LmStudioQwen257BInstruct),
             s if s == models::lmstudio::GEMMA_2_2B_IT => Ok(ModelId::LmStudioGemma22BIt),
+            s if s == models::lmstudio::GEMMA_2_9B_IT => Ok(ModelId::LmStudioGemma29BIt),
+            s if s == models::lmstudio::PHI_31_MINI_4K_INSTRUCT => {
+                Ok(ModelId::LmStudioPhi31Mini4kInstruct)
+            }
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -1353,6 +1390,10 @@ mod tests {
         assert_eq!(ModelId::OllamaGptOss120bCloud.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaQwen317b.provider(), Provider::Ollama);
         assert_eq!(
+            ModelId::LmStudioMetaLlama38BInstruct.provider(),
+            Provider::LmStudio
+        );
+        assert_eq!(
             ModelId::LmStudioMetaLlama318BInstruct.provider(),
             Provider::LmStudio
         );
@@ -1361,6 +1402,11 @@ mod tests {
             Provider::LmStudio
         );
         assert_eq!(ModelId::LmStudioGemma22BIt.provider(), Provider::LmStudio);
+        assert_eq!(ModelId::LmStudioGemma29BIt.provider(), Provider::LmStudio);
+        assert_eq!(
+            ModelId::LmStudioPhi31Mini4kInstruct.provider(),
+            Provider::LmStudio
+        );
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -1591,11 +1637,17 @@ mod tests {
         assert_eq!(ModelId::MoonshotKimiLatest32k.generation(), "latest");
         assert_eq!(ModelId::MoonshotKimiLatest128k.generation(), "latest");
         assert_eq!(
+            ModelId::LmStudioMetaLlama38BInstruct.generation(),
+            "meta-llama-3"
+        );
+        assert_eq!(
             ModelId::LmStudioMetaLlama318BInstruct.generation(),
             "meta-llama-3.1"
         );
         assert_eq!(ModelId::LmStudioQwen257BInstruct.generation(), "qwen2.5");
         assert_eq!(ModelId::LmStudioGemma22BIt.generation(), "gemma-2");
+        assert_eq!(ModelId::LmStudioGemma29BIt.generation(), "gemma-2");
+        assert_eq!(ModelId::LmStudioPhi31Mini4kInstruct.generation(), "phi-3.1");
 
         for entry in openrouter_generated::ENTRIES {
             assert_eq!(entry.variant.generation(), entry.generation);
@@ -1661,10 +1713,13 @@ mod tests {
         assert_eq!(ollama_models.len(), 3);
 
         let lmstudio_models = ModelId::models_for_provider(Provider::LmStudio);
+        assert!(lmstudio_models.contains(&ModelId::LmStudioMetaLlama38BInstruct));
         assert!(lmstudio_models.contains(&ModelId::LmStudioMetaLlama318BInstruct));
         assert!(lmstudio_models.contains(&ModelId::LmStudioQwen257BInstruct));
         assert!(lmstudio_models.contains(&ModelId::LmStudioGemma22BIt));
-        assert_eq!(lmstudio_models.len(), 3);
+        assert!(lmstudio_models.contains(&ModelId::LmStudioGemma29BIt));
+        assert!(lmstudio_models.contains(&ModelId::LmStudioPhi31Mini4kInstruct));
+        assert_eq!(lmstudio_models.len(), 6);
     }
 
     #[test]

--- a/vtcode-config/src/models.rs
+++ b/vtcode-config/src/models.rs
@@ -38,6 +38,8 @@ pub enum Provider {
     OpenRouter,
     /// Local Ollama models
     Ollama,
+    /// LM Studio local server (OpenAI-compatible)
+    LmStudio,
     /// Moonshot.ai models
     Moonshot,
     /// xAI Grok models
@@ -56,6 +58,7 @@ impl Provider {
             Provider::DeepSeek => "DEEPSEEK_API_KEY",
             Provider::OpenRouter => "OPENROUTER_API_KEY",
             Provider::Ollama => "OLLAMA_API_KEY",
+            Provider::LmStudio => "LMSTUDIO_API_KEY",
             Provider::Moonshot => "MOONSHOT_API_KEY",
             Provider::XAI => "XAI_API_KEY",
             Provider::ZAI => "ZAI_API_KEY",
@@ -71,6 +74,7 @@ impl Provider {
             Provider::DeepSeek,
             Provider::OpenRouter,
             Provider::Ollama,
+            Provider::LmStudio,
             Provider::Moonshot,
             Provider::XAI,
             Provider::ZAI,
@@ -86,6 +90,7 @@ impl Provider {
             Provider::DeepSeek => "DeepSeek",
             Provider::OpenRouter => "OpenRouter",
             Provider::Ollama => "Ollama",
+            Provider::LmStudio => "LM Studio",
             Provider::Moonshot => "Moonshot",
             Provider::XAI => "xAI",
             Provider::ZAI => "Z.AI",
@@ -108,6 +113,7 @@ impl Provider {
                 models::openrouter::REASONING_MODELS.contains(&model)
             }
             Provider::Ollama => false,
+            Provider::LmStudio => false,
             Provider::Moonshot => false,
             Provider::XAI => model == models::xai::GROK_4 || model == models::xai::GROK_4_CODE,
             Provider::ZAI => model == models::zai::GLM_4_6,
@@ -124,6 +130,7 @@ impl fmt::Display for Provider {
             Provider::DeepSeek => write!(f, "deepseek"),
             Provider::OpenRouter => write!(f, "openrouter"),
             Provider::Ollama => write!(f, "ollama"),
+            Provider::LmStudio => write!(f, "lmstudio"),
             Provider::Moonshot => write!(f, "moonshot"),
             Provider::XAI => write!(f, "xai"),
             Provider::ZAI => write!(f, "zai"),
@@ -142,6 +149,7 @@ impl FromStr for Provider {
             "deepseek" => Ok(Provider::DeepSeek),
             "openrouter" => Ok(Provider::OpenRouter),
             "ollama" => Ok(Provider::Ollama),
+            "lmstudio" => Ok(Provider::LmStudio),
             "moonshot" => Ok(Provider::Moonshot),
             "xai" => Ok(Provider::XAI),
             "zai" => Ok(Provider::ZAI),
@@ -248,6 +256,14 @@ pub enum ModelId {
     OllamaGptOss120bCloud,
     /// Qwen3 1.7B - Qwen3 1.7B model served via Ollama
     OllamaQwen317b,
+
+    // LM Studio models
+    /// Meta Llama 3.1 8B Instruct served locally via LM Studio
+    LmStudioMetaLlama318BInstruct,
+    /// Qwen2.5 7B Instruct served locally via LM Studio
+    LmStudioQwen257BInstruct,
+    /// Gemma 2 2B IT served locally via LM Studio
+    LmStudioGemma22BIt,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model powered by xAI Grok
@@ -422,6 +438,10 @@ impl ModelId {
             ModelId::OllamaGptOss20b => models::ollama::GPT_OSS_20B,
             ModelId::OllamaGptOss120bCloud => models::ollama::GPT_OSS_120B_CLOUD,
             ModelId::OllamaQwen317b => models::ollama::QWEN3_1_7B,
+            // LM Studio models
+            ModelId::LmStudioMetaLlama318BInstruct => models::lmstudio::META_LLAMA_31_8B_INSTRUCT,
+            ModelId::LmStudioQwen257BInstruct => models::lmstudio::QWEN25_7B_INSTRUCT,
+            ModelId::LmStudioGemma22BIt => models::lmstudio::GEMMA_2_2B_IT,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -471,6 +491,9 @@ impl ModelId {
             ModelId::OllamaGptOss20b | ModelId::OllamaGptOss120bCloud | ModelId::OllamaQwen317b => {
                 Provider::Ollama
             }
+            ModelId::LmStudioMetaLlama318BInstruct
+            | ModelId::LmStudioQwen257BInstruct
+            | ModelId::LmStudioGemma22BIt => Provider::LmStudio,
             _ => unreachable!(),
         }
     }
@@ -531,6 +554,9 @@ impl ModelId {
             ModelId::OllamaGptOss20b => "GPT-OSS 20B (local)",
             ModelId::OllamaGptOss120bCloud => "GPT-OSS 120B (cloud)",
             ModelId::OllamaQwen317b => "Qwen3 1.7B (local)",
+            ModelId::LmStudioMetaLlama318BInstruct => "Meta Llama 3.1 8B (LM Studio)",
+            ModelId::LmStudioQwen257BInstruct => "Qwen2.5 7B (LM Studio)",
+            ModelId::LmStudioGemma22BIt => "Gemma 2 2B (LM Studio)",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -634,6 +660,15 @@ impl ModelId {
             ModelId::OllamaQwen317b => {
                 "Qwen3 1.7B served locally through Ollama without external API requirements"
             }
+            ModelId::LmStudioMetaLlama318BInstruct => {
+                "Meta Llama 3.1 8B running through LM Studio's local OpenAI-compatible server"
+            }
+            ModelId::LmStudioQwen257BInstruct => {
+                "Qwen2.5 7B hosted in LM Studio for local experimentation and coding tasks"
+            }
+            ModelId::LmStudioGemma22BIt => {
+                "Gemma 2 2B IT deployed via LM Studio for lightweight on-device assistance"
+            }
             _ => unreachable!(),
         }
     }
@@ -691,6 +726,10 @@ impl ModelId {
             ModelId::OllamaGptOss20b,
             ModelId::OllamaGptOss120bCloud,
             ModelId::OllamaQwen317b,
+            // LM Studio models
+            ModelId::LmStudioMetaLlama318BInstruct,
+            ModelId::LmStudioQwen257BInstruct,
+            ModelId::LmStudioGemma22BIt,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -742,6 +781,7 @@ impl ModelId {
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::Ollama => ModelId::OllamaGptOss20b,
+            Provider::LmStudio => ModelId::LmStudioMetaLlama318BInstruct,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -757,6 +797,7 @@ impl ModelId {
             Provider::XAI => ModelId::XaiGrok4Code,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::Ollama => ModelId::OllamaQwen317b,
+            Provider::LmStudio => ModelId::LmStudioQwen257BInstruct,
             Provider::ZAI => ModelId::ZaiGlm45Flash,
         }
     }
@@ -772,6 +813,7 @@ impl ModelId {
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::Ollama => ModelId::OllamaGptOss20b,
+            Provider::LmStudio => ModelId::LmStudioMetaLlama318BInstruct,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -914,6 +956,9 @@ impl ModelId {
             ModelId::OllamaGptOss20b => "oss",
             ModelId::OllamaGptOss120bCloud => "oss-cloud",
             ModelId::OllamaQwen317b => "oss",
+            ModelId::LmStudioMetaLlama318BInstruct => "meta-llama-3.1",
+            ModelId::LmStudioQwen257BInstruct => "qwen2.5",
+            ModelId::LmStudioGemma22BIt => "gemma-2",
             _ => unreachable!(),
         }
     }
@@ -983,6 +1028,11 @@ impl FromStr for ModelId {
             s if s == models::ollama::GPT_OSS_20B => Ok(ModelId::OllamaGptOss20b),
             s if s == models::ollama::GPT_OSS_120B_CLOUD => Ok(ModelId::OllamaGptOss120bCloud),
             s if s == models::ollama::QWEN3_1_7B => Ok(ModelId::OllamaQwen317b),
+            s if s == models::lmstudio::META_LLAMA_31_8B_INSTRUCT => {
+                Ok(ModelId::LmStudioMetaLlama318BInstruct)
+            }
+            s if s == models::lmstudio::QWEN25_7B_INSTRUCT => Ok(ModelId::LmStudioQwen257BInstruct),
+            s if s == models::lmstudio::GEMMA_2_2B_IT => Ok(ModelId::LmStudioGemma22BIt),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -1280,6 +1330,7 @@ mod tests {
         assert_eq!("xai".parse::<Provider>().unwrap(), Provider::XAI);
         assert_eq!("zai".parse::<Provider>().unwrap(), Provider::ZAI);
         assert_eq!("moonshot".parse::<Provider>().unwrap(), Provider::Moonshot);
+        assert_eq!("lmstudio".parse::<Provider>().unwrap(), Provider::LmStudio);
         assert!("invalid-provider".parse::<Provider>().is_err());
     }
 
@@ -1301,6 +1352,15 @@ mod tests {
         assert_eq!(ModelId::OllamaGptOss20b.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaGptOss120bCloud.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaQwen317b.provider(), Provider::Ollama);
+        assert_eq!(
+            ModelId::LmStudioMetaLlama318BInstruct.provider(),
+            Provider::LmStudio
+        );
+        assert_eq!(
+            ModelId::LmStudioQwen257BInstruct.provider(),
+            Provider::LmStudio
+        );
+        assert_eq!(ModelId::LmStudioGemma22BIt.provider(), Provider::LmStudio);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -1346,6 +1406,10 @@ mod tests {
             ModelId::OllamaGptOss20b
         );
         assert_eq!(
+            ModelId::default_orchestrator_for_provider(Provider::LmStudio),
+            ModelId::LmStudioMetaLlama318BInstruct
+        );
+        assert_eq!(
             ModelId::default_orchestrator_for_provider(Provider::ZAI),
             ModelId::ZaiGlm46
         );
@@ -1383,6 +1447,10 @@ mod tests {
             ModelId::OllamaQwen317b
         );
         assert_eq!(
+            ModelId::default_subagent_for_provider(Provider::LmStudio),
+            ModelId::LmStudioQwen257BInstruct
+        );
+        assert_eq!(
             ModelId::default_subagent_for_provider(Provider::ZAI),
             ModelId::ZaiGlm45Flash
         );
@@ -1402,6 +1470,10 @@ mod tests {
         assert_eq!(
             ModelId::default_single_for_provider(Provider::Ollama),
             ModelId::OllamaGptOss20b
+        );
+        assert_eq!(
+            ModelId::default_single_for_provider(Provider::LmStudio),
+            ModelId::LmStudioMetaLlama318BInstruct
         );
     }
 
@@ -1518,6 +1590,12 @@ mod tests {
         assert_eq!(ModelId::MoonshotKimiLatest8k.generation(), "latest");
         assert_eq!(ModelId::MoonshotKimiLatest32k.generation(), "latest");
         assert_eq!(ModelId::MoonshotKimiLatest128k.generation(), "latest");
+        assert_eq!(
+            ModelId::LmStudioMetaLlama318BInstruct.generation(),
+            "meta-llama-3.1"
+        );
+        assert_eq!(ModelId::LmStudioQwen257BInstruct.generation(), "qwen2.5");
+        assert_eq!(ModelId::LmStudioGemma22BIt.generation(), "gemma-2");
 
         for entry in openrouter_generated::ENTRIES {
             assert_eq!(entry.variant.generation(), entry.generation);
@@ -1581,6 +1659,12 @@ mod tests {
         assert!(ollama_models.contains(&ModelId::OllamaGptOss120bCloud));
         assert!(ollama_models.contains(&ModelId::OllamaQwen317b));
         assert_eq!(ollama_models.len(), 3);
+
+        let lmstudio_models = ModelId::models_for_provider(Provider::LmStudio);
+        assert!(lmstudio_models.contains(&ModelId::LmStudioMetaLlama318BInstruct));
+        assert!(lmstudio_models.contains(&ModelId::LmStudioQwen257BInstruct));
+        assert!(lmstudio_models.contains(&ModelId::LmStudioGemma22BIt));
+        assert_eq!(lmstudio_models.len(), 3);
     }
 
     #[test]

--- a/vtcode-core/src/cli/args.rs
+++ b/vtcode-core/src/cli/args.rs
@@ -66,12 +66,13 @@ pub struct Cli {
     ///   • zai - Z.AI GLM models
     ///   • moonshot - Moonshot AI Kimi models
     ///   • ollama - Local Ollama server (default gpt-oss:20b)
+    ///   • lmstudio - Local LM Studio server (OpenAI-compatible)
     ///
     /// Example: --provider deepseek
     #[arg(long, global = true)]
     pub provider: Option<String>,
 
-    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n• Z.AI: `ZAI_API_KEY`\n• Ollama: (not required)\n\n**Override:** --api-key-env CUSTOM_KEY
+    /// **API key environment variable**\n\n**Auto-detects based on provider:**\n• Gemini: `GEMINI_API_KEY`\n• OpenAI: `OPENAI_API_KEY`\n• Anthropic: `ANTHROPIC_API_KEY`\n• DeepSeek: `DEEPSEEK_API_KEY`\n• OpenRouter: `OPENROUTER_API_KEY`\n• xAI: `XAI_API_KEY`\n• Z.AI: `ZAI_API_KEY`\n• Ollama: (not required)\n• LM Studio: (optional `LMSTUDIO_API_KEY`)\n\n**Override:** --api-key-env CUSTOM_KEY
     #[arg(long, global = true, default_value = crate::config::constants::defaults::DEFAULT_API_KEY_ENV)]
     pub api_key_env: String,
 

--- a/vtcode-core/src/cli/man_pages.rs
+++ b/vtcode-core/src/cli/man_pages.rs
@@ -50,7 +50,11 @@ impl ManPageGenerator {
             .text([roman("Specify the LLM model to use (default: gemini-2.5-flash-preview-05-20)")])
             .control("TP", [])
             .text([bold("-p"), roman(", "), bold("--provider"), roman(" "), italic("PROVIDER")])
-            .text([roman("Specify the LLM provider (gemini, openai, anthropic, deepseek, xai, zai, moonshot, openrouter, ollama)")])
+            .text([
+                roman(
+                    "Specify the LLM provider (gemini, openai, anthropic, deepseek, xai, zai, moonshot, openrouter, ollama, lmstudio)",
+                ),
+            ])
             .control("TP", [])
             .text([bold("--workspace"), roman(" "), italic("PATH")])
             .text([roman("Set the workspace root directory for file operations")])

--- a/vtcode-core/src/cli/models_commands.rs
+++ b/vtcode-core/src/cli/models_commands.rs
@@ -144,6 +144,12 @@ fn is_provider_configured(config: &DotConfig, provider: &str) -> bool {
             .as_ref()
             .map(|p| p.enabled)
             .unwrap_or(true),
+        "lmstudio" => config
+            .providers
+            .lmstudio
+            .as_ref()
+            .map(|p| p.enabled)
+            .unwrap_or(true),
         _ => false,
     }
 }
@@ -207,7 +213,8 @@ async fn handle_config_provider(
     let mut config = manager.load_config().await?;
 
     match provider {
-        "openai" | "anthropic" | "gemini" | "openrouter" | "deepseek" | "xai" | "ollama" => {
+        "openai" | "anthropic" | "gemini" | "openrouter" | "deepseek" | "xai" | "ollama"
+        | "lmstudio" => {
             configure_standard_provider(&mut config, provider, api_key, base_url, model)?;
         }
         _ => return Err(anyhow!("Unsupported provider: {}", provider)),
@@ -255,6 +262,10 @@ fn configure_standard_provider(
             .get_or_insert_with(Default::default),
         "xai" => config.providers.xai.get_or_insert_with(Default::default),
         "ollama" => config.providers.ollama.get_or_insert_with(Default::default),
+        "lmstudio" => config
+            .providers
+            .lmstudio
+            .get_or_insert_with(Default::default),
         _ => return Err(anyhow!("Unknown provider: {}", provider)),
     };
 
@@ -267,7 +278,7 @@ fn configure_standard_provider(
     if let Some(m) = model {
         provider_config.model = Some(m.to_string());
     }
-    provider_config.enabled = if provider == "ollama" {
+    provider_config.enabled = if provider == "ollama" || provider == "lmstudio" {
         true
     } else {
         api_key.is_some() || provider_config.api_key.is_some()
@@ -349,6 +360,7 @@ fn get_provider_credentials(
         "openrouter" => Ok(get_config(config.providers.openrouter.as_ref())),
         "xai" => Ok(get_config(config.providers.xai.as_ref())),
         "ollama" => Ok(get_config(config.providers.ollama.as_ref())),
+        "lmstudio" => Ok(get_config(config.providers.lmstudio.as_ref())),
         _ => Err(anyhow!("Unknown provider: {}", provider)),
     }
 }

--- a/vtcode-core/src/cli/update_commands.rs
+++ b/vtcode-core/src/cli/update_commands.rs
@@ -71,9 +71,7 @@ pub async fn handle_update_command(command: UpdateCommands) -> Result<()> {
             frequency,
             auto_download,
             auto_install,
-        } => {
-            handle_config_command(enabled, channel, frequency, auto_download, auto_install).await
-        }
+        } => handle_config_command(enabled, channel, frequency, auto_download, auto_install).await,
         UpdateCommands::Backups => handle_backups_command().await,
         UpdateCommands::Rollback { backup } => handle_rollback_command(backup).await,
         UpdateCommands::Cleanup => handle_cleanup_command().await,
@@ -137,7 +135,8 @@ async fn handle_install_command(yes: bool, force: bool) -> Result<()> {
     }
 
     if !yes {
-        println!("This will update vtcode from {} to {}.", 
+        println!(
+            "This will update vtcode from {} to {}.",
             status.current_version,
             status.latest_version.as_deref().unwrap_or("unknown")
         );
@@ -165,7 +164,10 @@ async fn handle_install_command(yes: bool, force: bool) -> Result<()> {
 
     if result.success {
         println!("\nUpdate installed successfully!");
-        println!("Updated from {} to {}", result.old_version, result.new_version);
+        println!(
+            "Updated from {} to {}",
+            result.old_version, result.new_version
+        );
 
         if let Some(backup) = result.backup_path {
             println!("Backup created at: {:?}", backup);
@@ -196,7 +198,10 @@ async fn handle_config_command(
     if let Some(val) = enabled {
         config.enabled = val;
         changed = true;
-        println!("Automatic updates: {}", if val { "enabled" } else { "disabled" });
+        println!(
+            "Automatic updates: {}",
+            if val { "enabled" } else { "disabled" }
+        );
     }
 
     if let Some(val) = channel {
@@ -204,7 +209,10 @@ async fn handle_config_command(
             "stable" => UpdateChannel::Stable,
             "beta" => UpdateChannel::Beta,
             "nightly" => UpdateChannel::Nightly,
-            _ => anyhow::bail!("Invalid channel: {}. Use 'stable', 'beta', or 'nightly'.", val),
+            _ => anyhow::bail!(
+                "Invalid channel: {}. Use 'stable', 'beta', or 'nightly'.",
+                val
+            ),
         };
         changed = true;
         println!("Update channel: {}", config.channel);
@@ -216,7 +224,10 @@ async fn handle_config_command(
             "daily" => UpdateFrequency::Daily,
             "weekly" => UpdateFrequency::Weekly,
             "never" => UpdateFrequency::Never,
-            _ => anyhow::bail!("Invalid frequency: {}. Use 'always', 'daily', 'weekly', or 'never'.", val),
+            _ => anyhow::bail!(
+                "Invalid frequency: {}. Use 'always', 'daily', 'weekly', or 'never'.",
+                val
+            ),
         };
         changed = true;
         println!("Update frequency: {:?}", config.frequency);
@@ -225,13 +236,19 @@ async fn handle_config_command(
     if let Some(val) = auto_download {
         config.auto_download = val;
         changed = true;
-        println!("Automatic downloads: {}", if val { "enabled" } else { "disabled" });
+        println!(
+            "Automatic downloads: {}",
+            if val { "enabled" } else { "disabled" }
+        );
     }
 
     if let Some(val) = auto_install {
         config.auto_install = val;
         changed = true;
-        println!("Automatic installation: {}", if val { "enabled" } else { "disabled" });
+        println!(
+            "Automatic installation: {}",
+            if val { "enabled" } else { "disabled" }
+        );
     }
 
     if !changed {

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -263,12 +263,18 @@ pub enum ModelId {
     OllamaGlm46Cloud,
 
     // LM Studio models
+    /// Meta Llama 3 8B Instruct served locally via LM Studio
+    LmStudioMetaLlama38BInstruct,
     /// Meta Llama 3.1 8B Instruct served locally via LM Studio
     LmStudioMetaLlama318BInstruct,
     /// Qwen2.5 7B Instruct served locally via LM Studio
     LmStudioQwen257BInstruct,
     /// Gemma 2 2B IT served locally via LM Studio
     LmStudioGemma22BIt,
+    /// Gemma 2 9B IT served locally via LM Studio
+    LmStudioGemma29BIt,
+    /// Phi-3.1 Mini 4K Instruct served locally via LM Studio
+    LmStudioPhi31Mini4kInstruct,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model powered by xAI Grok
@@ -447,9 +453,12 @@ impl ModelId {
             ModelId::OllamaKimiK21tCloud => models::ollama::KIMI_K2_1T_CLOUD,
             ModelId::OllamaQwen3Coder480bCloud => models::ollama::QWEN3_CODER_480B_CLOUD,
             ModelId::OllamaGlm46Cloud => models::ollama::GLM_46_CLOUD,
+            ModelId::LmStudioMetaLlama38BInstruct => models::lmstudio::META_LLAMA_3_8B_INSTRUCT,
             ModelId::LmStudioMetaLlama318BInstruct => models::lmstudio::META_LLAMA_31_8B_INSTRUCT,
             ModelId::LmStudioQwen257BInstruct => models::lmstudio::QWEN25_7B_INSTRUCT,
             ModelId::LmStudioGemma22BIt => models::lmstudio::GEMMA_2_2B_IT,
+            ModelId::LmStudioGemma29BIt => models::lmstudio::GEMMA_2_9B_IT,
+            ModelId::LmStudioPhi31Mini4kInstruct => models::lmstudio::PHI_31_MINI_4K_INSTRUCT,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -503,9 +512,12 @@ impl ModelId {
             | ModelId::OllamaKimiK21tCloud
             | ModelId::OllamaQwen3Coder480bCloud
             | ModelId::OllamaGlm46Cloud => Provider::Ollama,
-            ModelId::LmStudioMetaLlama318BInstruct
+            ModelId::LmStudioMetaLlama38BInstruct
+            | ModelId::LmStudioMetaLlama318BInstruct
             | ModelId::LmStudioQwen257BInstruct
-            | ModelId::LmStudioGemma22BIt => Provider::LmStudio,
+            | ModelId::LmStudioGemma22BIt
+            | ModelId::LmStudioGemma29BIt
+            | ModelId::LmStudioPhi31Mini4kInstruct => Provider::LmStudio,
             _ => unreachable!(),
         }
     }
@@ -634,9 +646,12 @@ impl ModelId {
             ModelId::OllamaKimiK21tCloud => "Kimi K2 1T (cloud)",
             ModelId::OllamaQwen3Coder480bCloud => "Qwen3 Coder 480B (cloud)",
             ModelId::OllamaGlm46Cloud => "GLM 4.6 (cloud)",
+            ModelId::LmStudioMetaLlama38BInstruct => "Meta Llama 3 8B (LM Studio)",
             ModelId::LmStudioMetaLlama318BInstruct => "Meta Llama 3.1 8B (LM Studio)",
             ModelId::LmStudioQwen257BInstruct => "Qwen2.5 7B (LM Studio)",
             ModelId::LmStudioGemma22BIt => "Gemma 2 2B (LM Studio)",
+            ModelId::LmStudioGemma29BIt => "Gemma 2 9B (LM Studio)",
+            ModelId::LmStudioPhi31Mini4kInstruct => "Phi-3.1 Mini 4K (LM Studio)",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -752,6 +767,9 @@ impl ModelId {
             ModelId::OllamaGlm46Cloud => {
                 "GLM 4.6 reasoning model offered by Ollama Cloud with extended context support"
             }
+            ModelId::LmStudioMetaLlama38BInstruct => {
+                "Meta Llama 3 8B running through LM Studio's local OpenAI-compatible server"
+            }
             ModelId::LmStudioMetaLlama318BInstruct => {
                 "Meta Llama 3.1 8B running through LM Studio's local OpenAI-compatible server"
             }
@@ -760,6 +778,12 @@ impl ModelId {
             }
             ModelId::LmStudioGemma22BIt => {
                 "Gemma 2 2B IT deployed via LM Studio for lightweight on-device assistance"
+            }
+            ModelId::LmStudioGemma29BIt => {
+                "Gemma 2 9B IT served locally via LM Studio when you need additional capacity"
+            }
+            ModelId::LmStudioPhi31Mini4kInstruct => {
+                "Phi-3.1 Mini 4K hosted in LM Studio for compact reasoning and experimentation"
             }
             _ => unreachable!(),
         }
@@ -823,9 +847,12 @@ impl ModelId {
             ModelId::OllamaQwen3Coder480bCloud,
             ModelId::OllamaGlm46Cloud,
             // LM Studio models
+            ModelId::LmStudioMetaLlama38BInstruct,
             ModelId::LmStudioMetaLlama318BInstruct,
             ModelId::LmStudioQwen257BInstruct,
             ModelId::LmStudioGemma22BIt,
+            ModelId::LmStudioGemma29BIt,
+            ModelId::LmStudioPhi31Mini4kInstruct,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -1061,9 +1088,12 @@ impl ModelId {
             ModelId::OllamaKimiK21tCloud => "kimi-k2",
             ModelId::OllamaQwen3Coder480bCloud => "qwen3",
             ModelId::OllamaGlm46Cloud => "glm-4.6",
+            ModelId::LmStudioMetaLlama38BInstruct => "meta-llama-3",
             ModelId::LmStudioMetaLlama318BInstruct => "meta-llama-3.1",
             ModelId::LmStudioQwen257BInstruct => "qwen2.5",
             ModelId::LmStudioGemma22BIt => "gemma-2",
+            ModelId::LmStudioGemma29BIt => "gemma-2",
+            ModelId::LmStudioPhi31Mini4kInstruct => "phi-3.1",
             _ => unreachable!(),
         }
     }
@@ -1141,11 +1171,18 @@ impl FromStr for ModelId {
                 Ok(ModelId::OllamaQwen3Coder480bCloud)
             }
             s if s == models::ollama::GLM_46_CLOUD => Ok(ModelId::OllamaGlm46Cloud),
+            s if s == models::lmstudio::META_LLAMA_3_8B_INSTRUCT => {
+                Ok(ModelId::LmStudioMetaLlama38BInstruct)
+            }
             s if s == models::lmstudio::META_LLAMA_31_8B_INSTRUCT => {
                 Ok(ModelId::LmStudioMetaLlama318BInstruct)
             }
             s if s == models::lmstudio::QWEN25_7B_INSTRUCT => Ok(ModelId::LmStudioQwen257BInstruct),
             s if s == models::lmstudio::GEMMA_2_2B_IT => Ok(ModelId::LmStudioGemma22BIt),
+            s if s == models::lmstudio::GEMMA_2_9B_IT => Ok(ModelId::LmStudioGemma29BIt),
+            s if s == models::lmstudio::PHI_31_MINI_4K_INSTRUCT => {
+                Ok(ModelId::LmStudioPhi31Mini4kInstruct)
+            }
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -1466,6 +1503,10 @@ mod tests {
         assert_eq!(ModelId::OllamaGptOss120bCloud.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaQwen317b.provider(), Provider::Ollama);
         assert_eq!(
+            ModelId::LmStudioMetaLlama38BInstruct.provider(),
+            Provider::LmStudio
+        );
+        assert_eq!(
             ModelId::LmStudioMetaLlama318BInstruct.provider(),
             Provider::LmStudio
         );
@@ -1474,6 +1515,11 @@ mod tests {
             Provider::LmStudio
         );
         assert_eq!(ModelId::LmStudioGemma22BIt.provider(), Provider::LmStudio);
+        assert_eq!(ModelId::LmStudioGemma29BIt.provider(), Provider::LmStudio);
+        assert_eq!(
+            ModelId::LmStudioPhi31Mini4kInstruct.provider(),
+            Provider::LmStudio
+        );
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -1714,11 +1760,17 @@ mod tests {
         assert_eq!(ModelId::OllamaQwen3Coder480bCloud.generation(), "qwen3");
         assert_eq!(ModelId::OllamaGlm46Cloud.generation(), "glm-4.6");
         assert_eq!(
+            ModelId::LmStudioMetaLlama38BInstruct.generation(),
+            "meta-llama-3"
+        );
+        assert_eq!(
             ModelId::LmStudioMetaLlama318BInstruct.generation(),
             "meta-llama-3.1"
         );
         assert_eq!(ModelId::LmStudioQwen257BInstruct.generation(), "qwen2.5");
         assert_eq!(ModelId::LmStudioGemma22BIt.generation(), "gemma-2");
+        assert_eq!(ModelId::LmStudioGemma29BIt.generation(), "gemma-2");
+        assert_eq!(ModelId::LmStudioPhi31Mini4kInstruct.generation(), "phi-3.1");
 
         for entry in openrouter_generated::ENTRIES {
             assert_eq!(entry.variant.generation(), entry.generation);
@@ -1788,10 +1840,13 @@ mod tests {
         assert_eq!(ollama_models.len(), 7);
 
         let lmstudio_models = ModelId::models_for_provider(Provider::LmStudio);
+        assert!(lmstudio_models.contains(&ModelId::LmStudioMetaLlama38BInstruct));
         assert!(lmstudio_models.contains(&ModelId::LmStudioMetaLlama318BInstruct));
         assert!(lmstudio_models.contains(&ModelId::LmStudioQwen257BInstruct));
         assert!(lmstudio_models.contains(&ModelId::LmStudioGemma22BIt));
-        assert_eq!(lmstudio_models.len(), 3);
+        assert!(lmstudio_models.contains(&ModelId::LmStudioGemma29BIt));
+        assert!(lmstudio_models.contains(&ModelId::LmStudioPhi31Mini4kInstruct));
+        assert_eq!(lmstudio_models.len(), 6);
     }
 
     #[test]

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -37,6 +37,8 @@ pub enum Provider {
     OpenRouter,
     /// Local Ollama models
     Ollama,
+    /// LM Studio local server (OpenAI-compatible)
+    LmStudio,
     /// Moonshot.ai models
     Moonshot,
     /// xAI Grok models
@@ -55,6 +57,7 @@ impl Provider {
             Provider::DeepSeek => "DEEPSEEK_API_KEY",
             Provider::OpenRouter => "OPENROUTER_API_KEY",
             Provider::Ollama => "OLLAMA_API_KEY",
+            Provider::LmStudio => "LMSTUDIO_API_KEY",
             Provider::Moonshot => "MOONSHOT_API_KEY",
             Provider::XAI => "XAI_API_KEY",
             Provider::ZAI => "ZAI_API_KEY",
@@ -70,6 +73,7 @@ impl Provider {
             Provider::DeepSeek,
             Provider::OpenRouter,
             Provider::Ollama,
+            Provider::LmStudio,
             Provider::Moonshot,
             Provider::XAI,
             Provider::ZAI,
@@ -85,6 +89,7 @@ impl Provider {
             Provider::DeepSeek => "DeepSeek",
             Provider::OpenRouter => "OpenRouter",
             Provider::Ollama => "Ollama",
+            Provider::LmStudio => "LM Studio",
             Provider::Moonshot => "Moonshot",
             Provider::XAI => "xAI",
             Provider::ZAI => "Z.AI",
@@ -107,6 +112,7 @@ impl Provider {
                 models::openrouter::REASONING_MODELS.contains(&model)
             }
             Provider::Ollama => models::ollama::REASONING_LEVEL_MODELS.contains(&model),
+            Provider::LmStudio => false,
             Provider::Moonshot => false,
             Provider::XAI => model == models::xai::GROK_4 || model == models::xai::GROK_4_CODE,
             Provider::ZAI => model == models::zai::GLM_4_6,
@@ -123,6 +129,7 @@ impl fmt::Display for Provider {
             Provider::DeepSeek => write!(f, "deepseek"),
             Provider::OpenRouter => write!(f, "openrouter"),
             Provider::Ollama => write!(f, "ollama"),
+            Provider::LmStudio => write!(f, "lmstudio"),
             Provider::Moonshot => write!(f, "moonshot"),
             Provider::XAI => write!(f, "xai"),
             Provider::ZAI => write!(f, "zai"),
@@ -141,6 +148,7 @@ impl FromStr for Provider {
             "deepseek" => Ok(Provider::DeepSeek),
             "openrouter" => Ok(Provider::OpenRouter),
             "ollama" => Ok(Provider::Ollama),
+            "lmstudio" => Ok(Provider::LmStudio),
             "moonshot" => Ok(Provider::Moonshot),
             "xai" => Ok(Provider::XAI),
             "zai" => Ok(Provider::ZAI),
@@ -253,6 +261,14 @@ pub enum ModelId {
     OllamaQwen3Coder480bCloud,
     /// GLM 4.6 Cloud - GLM 4.6 reasoning model via Ollama Cloud
     OllamaGlm46Cloud,
+
+    // LM Studio models
+    /// Meta Llama 3.1 8B Instruct served locally via LM Studio
+    LmStudioMetaLlama318BInstruct,
+    /// Qwen2.5 7B Instruct served locally via LM Studio
+    LmStudioQwen257BInstruct,
+    /// Gemma 2 2B IT served locally via LM Studio
+    LmStudioGemma22BIt,
 
     // OpenRouter models
     /// Grok Code Fast 1 - Fast OpenRouter coding model powered by xAI Grok
@@ -431,6 +447,9 @@ impl ModelId {
             ModelId::OllamaKimiK21tCloud => models::ollama::KIMI_K2_1T_CLOUD,
             ModelId::OllamaQwen3Coder480bCloud => models::ollama::QWEN3_CODER_480B_CLOUD,
             ModelId::OllamaGlm46Cloud => models::ollama::GLM_46_CLOUD,
+            ModelId::LmStudioMetaLlama318BInstruct => models::lmstudio::META_LLAMA_31_8B_INSTRUCT,
+            ModelId::LmStudioQwen257BInstruct => models::lmstudio::QWEN25_7B_INSTRUCT,
+            ModelId::LmStudioGemma22BIt => models::lmstudio::GEMMA_2_2B_IT,
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -484,6 +503,9 @@ impl ModelId {
             | ModelId::OllamaKimiK21tCloud
             | ModelId::OllamaQwen3Coder480bCloud
             | ModelId::OllamaGlm46Cloud => Provider::Ollama,
+            ModelId::LmStudioMetaLlama318BInstruct
+            | ModelId::LmStudioQwen257BInstruct
+            | ModelId::LmStudioGemma22BIt => Provider::LmStudio,
             _ => unreachable!(),
         }
     }
@@ -612,6 +634,9 @@ impl ModelId {
             ModelId::OllamaKimiK21tCloud => "Kimi K2 1T (cloud)",
             ModelId::OllamaQwen3Coder480bCloud => "Qwen3 Coder 480B (cloud)",
             ModelId::OllamaGlm46Cloud => "GLM 4.6 (cloud)",
+            ModelId::LmStudioMetaLlama318BInstruct => "Meta Llama 3.1 8B (LM Studio)",
+            ModelId::LmStudioQwen257BInstruct => "Qwen2.5 7B (LM Studio)",
+            ModelId::LmStudioGemma22BIt => "Gemma 2 2B (LM Studio)",
             // OpenRouter models
             _ => unreachable!(),
         }
@@ -727,6 +752,15 @@ impl ModelId {
             ModelId::OllamaGlm46Cloud => {
                 "GLM 4.6 reasoning model offered by Ollama Cloud with extended context support"
             }
+            ModelId::LmStudioMetaLlama318BInstruct => {
+                "Meta Llama 3.1 8B running through LM Studio's local OpenAI-compatible server"
+            }
+            ModelId::LmStudioQwen257BInstruct => {
+                "Qwen2.5 7B hosted in LM Studio for local experimentation and coding tasks"
+            }
+            ModelId::LmStudioGemma22BIt => {
+                "Gemma 2 2B IT deployed via LM Studio for lightweight on-device assistance"
+            }
             _ => unreachable!(),
         }
     }
@@ -788,6 +822,10 @@ impl ModelId {
             ModelId::OllamaKimiK21tCloud,
             ModelId::OllamaQwen3Coder480bCloud,
             ModelId::OllamaGlm46Cloud,
+            // LM Studio models
+            ModelId::LmStudioMetaLlama318BInstruct,
+            ModelId::LmStudioQwen257BInstruct,
+            ModelId::LmStudioGemma22BIt,
         ];
         models.extend(Self::openrouter_models());
         models
@@ -844,6 +882,7 @@ impl ModelId {
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::Ollama => ModelId::OllamaGptOss20b,
+            Provider::LmStudio => ModelId::LmStudioMetaLlama318BInstruct,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -859,6 +898,7 @@ impl ModelId {
             Provider::XAI => ModelId::XaiGrok4Code,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::Ollama => ModelId::OllamaQwen317b,
+            Provider::LmStudio => ModelId::LmStudioQwen257BInstruct,
             Provider::ZAI => ModelId::ZaiGlm45Flash,
         }
     }
@@ -874,6 +914,7 @@ impl ModelId {
             Provider::XAI => ModelId::XaiGrok4,
             Provider::OpenRouter => ModelId::OpenRouterGrokCodeFast1,
             Provider::Ollama => ModelId::OllamaGptOss20b,
+            Provider::LmStudio => ModelId::LmStudioMetaLlama318BInstruct,
             Provider::ZAI => ModelId::ZaiGlm46,
         }
     }
@@ -1020,6 +1061,9 @@ impl ModelId {
             ModelId::OllamaKimiK21tCloud => "kimi-k2",
             ModelId::OllamaQwen3Coder480bCloud => "qwen3",
             ModelId::OllamaGlm46Cloud => "glm-4.6",
+            ModelId::LmStudioMetaLlama318BInstruct => "meta-llama-3.1",
+            ModelId::LmStudioQwen257BInstruct => "qwen2.5",
+            ModelId::LmStudioGemma22BIt => "gemma-2",
             _ => unreachable!(),
         }
     }
@@ -1097,6 +1141,11 @@ impl FromStr for ModelId {
                 Ok(ModelId::OllamaQwen3Coder480bCloud)
             }
             s if s == models::ollama::GLM_46_CLOUD => Ok(ModelId::OllamaGlm46Cloud),
+            s if s == models::lmstudio::META_LLAMA_31_8B_INSTRUCT => {
+                Ok(ModelId::LmStudioMetaLlama318BInstruct)
+            }
+            s if s == models::lmstudio::QWEN25_7B_INSTRUCT => Ok(ModelId::LmStudioQwen257BInstruct),
+            s if s == models::lmstudio::GEMMA_2_2B_IT => Ok(ModelId::LmStudioGemma22BIt),
             _ => {
                 if let Some(model) = Self::parse_openrouter_model(s) {
                     Ok(model)
@@ -1394,6 +1443,7 @@ mod tests {
         assert_eq!("xai".parse::<Provider>().unwrap(), Provider::XAI);
         assert_eq!("zai".parse::<Provider>().unwrap(), Provider::ZAI);
         assert_eq!("moonshot".parse::<Provider>().unwrap(), Provider::Moonshot);
+        assert_eq!("lmstudio".parse::<Provider>().unwrap(), Provider::LmStudio);
         assert!("invalid-provider".parse::<Provider>().is_err());
     }
 
@@ -1415,6 +1465,15 @@ mod tests {
         assert_eq!(ModelId::OllamaGptOss20b.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaGptOss120bCloud.provider(), Provider::Ollama);
         assert_eq!(ModelId::OllamaQwen317b.provider(), Provider::Ollama);
+        assert_eq!(
+            ModelId::LmStudioMetaLlama318BInstruct.provider(),
+            Provider::LmStudio
+        );
+        assert_eq!(
+            ModelId::LmStudioQwen257BInstruct.provider(),
+            Provider::LmStudio
+        );
+        assert_eq!(ModelId::LmStudioGemma22BIt.provider(), Provider::LmStudio);
         assert_eq!(
             ModelId::OpenRouterGrokCodeFast1.provider(),
             Provider::OpenRouter
@@ -1460,6 +1519,10 @@ mod tests {
             ModelId::OllamaGptOss20b
         );
         assert_eq!(
+            ModelId::default_orchestrator_for_provider(Provider::LmStudio),
+            ModelId::LmStudioMetaLlama318BInstruct
+        );
+        assert_eq!(
             ModelId::default_orchestrator_for_provider(Provider::ZAI),
             ModelId::ZaiGlm46
         );
@@ -1497,6 +1560,10 @@ mod tests {
             ModelId::OllamaQwen317b
         );
         assert_eq!(
+            ModelId::default_subagent_for_provider(Provider::LmStudio),
+            ModelId::LmStudioQwen257BInstruct
+        );
+        assert_eq!(
             ModelId::default_subagent_for_provider(Provider::ZAI),
             ModelId::ZaiGlm45Flash
         );
@@ -1516,6 +1583,10 @@ mod tests {
         assert_eq!(
             ModelId::default_single_for_provider(Provider::Ollama),
             ModelId::OllamaGptOss20b
+        );
+        assert_eq!(
+            ModelId::default_single_for_provider(Provider::LmStudio),
+            ModelId::LmStudioMetaLlama318BInstruct
         );
     }
 
@@ -1642,6 +1713,12 @@ mod tests {
         assert_eq!(ModelId::OllamaKimiK21tCloud.generation(), "kimi-k2");
         assert_eq!(ModelId::OllamaQwen3Coder480bCloud.generation(), "qwen3");
         assert_eq!(ModelId::OllamaGlm46Cloud.generation(), "glm-4.6");
+        assert_eq!(
+            ModelId::LmStudioMetaLlama318BInstruct.generation(),
+            "meta-llama-3.1"
+        );
+        assert_eq!(ModelId::LmStudioQwen257BInstruct.generation(), "qwen2.5");
+        assert_eq!(ModelId::LmStudioGemma22BIt.generation(), "gemma-2");
 
         for entry in openrouter_generated::ENTRIES {
             assert_eq!(entry.variant.generation(), entry.generation);
@@ -1709,6 +1786,12 @@ mod tests {
         assert!(ollama_models.contains(&ModelId::OllamaQwen3Coder480bCloud));
         assert!(ollama_models.contains(&ModelId::OllamaGlm46Cloud));
         assert_eq!(ollama_models.len(), 7);
+
+        let lmstudio_models = ModelId::models_for_provider(Provider::LmStudio);
+        assert!(lmstudio_models.contains(&ModelId::LmStudioMetaLlama318BInstruct));
+        assert!(lmstudio_models.contains(&ModelId::LmStudioQwen257BInstruct));
+        assert!(lmstudio_models.contains(&ModelId::LmStudioGemma22BIt));
+        assert_eq!(lmstudio_models.len(), 3);
     }
 
     #[test]

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -192,14 +192,14 @@ pub use tool_policy::{ToolPolicy, ToolPolicyManager};
 pub use tools::advanced_search::{AdvancedSearchTool, SearchOptions};
 pub use tools::grep_file::GrepSearchManager;
 pub use tools::tree_sitter::TreeSitterAnalyzer;
-pub use update::{
-    UpdateChannel, UpdateConfig, UpdateFrequency, UpdateManager, UpdateResult, UpdateStatus,
-};
 pub use tools::{
     ToolRegistration, ToolRegistry, build_function_declarations,
     build_function_declarations_for_level, build_function_declarations_with_mode,
 };
 pub use ui::diff_renderer::DiffRenderer;
+pub use update::{
+    UpdateChannel, UpdateConfig, UpdateFrequency, UpdateManager, UpdateResult, UpdateStatus,
+};
 pub use utils::dot_config::{
     CacheConfig, DotConfig, DotManager, ProviderConfigs, UiConfig, UserPreferences,
     WorkspaceTrustRecord, WorkspaceTrustStore, initialize_dot_folder, load_user_config,

--- a/vtcode-core/src/llm/client.rs
+++ b/vtcode-core/src/llm/client.rs
@@ -1,7 +1,7 @@
 use super::provider::LLMError;
 use super::providers::{
-    AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OllamaProvider,
-    OpenAIProvider, OpenRouterProvider, XAIProvider, ZAIProvider,
+    AnthropicProvider, DeepSeekProvider, GeminiProvider, LmStudioProvider, MoonshotProvider,
+    OllamaProvider, OpenAIProvider, OpenRouterProvider, XAIProvider, ZAIProvider,
 };
 use super::types::{BackendKind, LLMResponse};
 use crate::config::models::{ModelId, Provider};
@@ -39,6 +39,10 @@ pub fn make_client(api_key: String, model: ModelId) -> AnyClient {
             model.as_str().to_string(),
         )),
         Provider::Ollama => Box::new(OllamaProvider::with_model(
+            api_key,
+            model.as_str().to_string(),
+        )),
+        Provider::LmStudio => Box::new(LmStudioProvider::with_model(
             api_key,
             model.as_str().to_string(),
         )),

--- a/vtcode-core/src/llm/error_display.rs
+++ b/vtcode-core/src/llm/error_display.rs
@@ -126,7 +126,14 @@ mod tests {
 
     #[test]
     fn test_style_provider_name() {
-        let providers = vec!["gemini", "openai", "anthropic", "ollama", "unknown"];
+        let providers = vec![
+            "gemini",
+            "openai",
+            "anthropic",
+            "ollama",
+            "lmstudio",
+            "unknown",
+        ];
         for provider in providers {
             let result = style_provider_name(provider);
             assert!(!result.is_empty());

--- a/vtcode-core/src/llm/error_display_test.rs
+++ b/vtcode-core/src/llm/error_display_test.rs
@@ -23,7 +23,14 @@ mod tests {
         assert!(styled_success.contains(success_msg));
 
         // Test provider name styling
-        let providers = vec!["gemini", "openai", "anthropic", "ollama", "unknown"];
+        let providers = vec![
+            "gemini",
+            "openai",
+            "anthropic",
+            "ollama",
+            "lmstudio",
+            "unknown",
+        ];
         for provider in providers {
             let styled_name = style_provider_name(provider);
             assert!(!styled_name.is_empty());

--- a/vtcode-core/src/llm/factory.rs
+++ b/vtcode-core/src/llm/factory.rs
@@ -1,6 +1,6 @@
 use super::providers::{
-    AnthropicProvider, DeepSeekProvider, GeminiProvider, MoonshotProvider, OllamaProvider,
-    OpenAIProvider, OpenRouterProvider, XAIProvider, ZAIProvider,
+    AnthropicProvider, DeepSeekProvider, GeminiProvider, LmStudioProvider, MoonshotProvider,
+    OllamaProvider, OpenAIProvider, OpenRouterProvider, XAIProvider, ZAIProvider,
 };
 use crate::config::core::PromptCachingConfig;
 use crate::config::models::{ModelId, Provider};
@@ -49,6 +49,7 @@ impl LLMFactory {
             "openrouter" => OpenRouterProvider,
             "moonshot" => MoonshotProvider,
             "ollama" => OllamaProvider,
+            "lmstudio" => LmStudioProvider,
             "xai" => XAIProvider,
             "zai" => ZAIProvider,
         );
@@ -116,6 +117,8 @@ impl LLMFactory {
             Some("xai".to_string())
         } else if m.starts_with("glm-") {
             Some("zai".to_string())
+        } else if m.starts_with("lmstudio-community/") {
+            Some("lmstudio".to_string())
         } else if m.starts_with("moonshot-") || m.starts_with("kimi-") {
             Some("moonshot".to_string())
         } else if m.contains('/') || m.contains('@') {
@@ -330,6 +333,24 @@ impl BuiltinProvider for OllamaProvider {
         } = config;
 
         Box::new(OllamaProvider::from_config(
+            api_key,
+            model,
+            base_url,
+            prompt_cache,
+        ))
+    }
+}
+
+impl BuiltinProvider for LmStudioProvider {
+    fn build_from_config(config: ProviderConfig) -> Box<dyn LLMProvider> {
+        let ProviderConfig {
+            api_key,
+            base_url,
+            model,
+            prompt_cache,
+        } = config;
+
+        Box::new(LmStudioProvider::from_config(
             api_key,
             model,
             base_url,

--- a/vtcode-core/src/llm/providers/lmstudio.rs
+++ b/vtcode-core/src/llm/providers/lmstudio.rs
@@ -1,0 +1,149 @@
+use super::common::resolve_model;
+use super::openai::OpenAIProvider;
+use crate::config::constants::{env_vars, models, urls};
+use crate::config::core::PromptCachingConfig;
+use crate::llm::client::LLMClient;
+use crate::llm::error_display;
+use crate::llm::provider::{LLMError, LLMProvider, LLMRequest, LLMResponse, LLMStream};
+use crate::llm::providers::common::override_base_url;
+use crate::llm::types as llm_types;
+use async_trait::async_trait;
+
+pub struct LmStudioProvider {
+    inner: OpenAIProvider,
+}
+
+impl LmStudioProvider {
+    fn resolve_base_url(base_url: Option<String>) -> String {
+        override_base_url(
+            urls::LMSTUDIO_API_BASE,
+            base_url,
+            Some(env_vars::LMSTUDIO_BASE_URL),
+        )
+    }
+
+    fn build_inner(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> OpenAIProvider {
+        let resolved_model = resolve_model(model, models::lmstudio::DEFAULT_MODEL);
+        let resolved_base = Self::resolve_base_url(base_url);
+        OpenAIProvider::from_config(
+            api_key,
+            Some(resolved_model),
+            Some(resolved_base),
+            prompt_cache,
+        )
+    }
+
+    pub fn new(api_key: String) -> Self {
+        Self::with_model(api_key, models::lmstudio::DEFAULT_MODEL.to_string())
+    }
+
+    pub fn with_model(api_key: String, model: String) -> Self {
+        Self::with_model_internal(Some(api_key), Some(model), None, None)
+    }
+
+    pub fn from_config(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        Self::with_model_internal(api_key, model, base_url, prompt_cache)
+    }
+
+    fn with_model_internal(
+        api_key: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        prompt_cache: Option<PromptCachingConfig>,
+    ) -> Self {
+        let inner = Self::build_inner(api_key, model, base_url, prompt_cache);
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for LmStudioProvider {
+    fn name(&self) -> &str {
+        "lmstudio"
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.inner.supports_streaming()
+    }
+
+    fn supports_reasoning(&self, model: &str) -> bool {
+        self.inner.supports_reasoning(model)
+    }
+
+    fn supports_reasoning_effort(&self, model: &str) -> bool {
+        self.inner.supports_reasoning_effort(model)
+    }
+
+    fn supports_tools(&self, model: &str) -> bool {
+        self.inner.supports_tools(model)
+    }
+
+    fn supports_parallel_tool_config(&self, model: &str) -> bool {
+        self.inner.supports_parallel_tool_config(model)
+    }
+
+    async fn generate(&self, request: LLMRequest) -> Result<LLMResponse, LLMError> {
+        self.inner.generate(request).await
+    }
+
+    async fn stream(&self, request: LLMRequest) -> Result<LLMStream, LLMError> {
+        self.inner.stream(request).await
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        models::lmstudio::SUPPORTED_MODELS
+            .iter()
+            .map(|model| model.to_string())
+            .collect()
+    }
+
+    fn validate_request(&self, request: &LLMRequest) -> Result<(), LLMError> {
+        if request.messages.is_empty() {
+            let formatted_error =
+                error_display::format_llm_error("LM Studio", "Messages cannot be empty");
+            return Err(LLMError::InvalidRequest(formatted_error));
+        }
+
+        if !models::lmstudio::SUPPORTED_MODELS.contains(&request.model.as_str()) {
+            let formatted_error = error_display::format_llm_error(
+                "LM Studio",
+                &format!("Unsupported model: {}", request.model),
+            );
+            return Err(LLMError::InvalidRequest(formatted_error));
+        }
+
+        for message in &request.messages {
+            if let Err(err) = message.validate_for_provider("openai") {
+                let formatted = error_display::format_llm_error("LM Studio", &err);
+                return Err(LLMError::InvalidRequest(formatted));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LLMClient for LmStudioProvider {
+    async fn generate(&mut self, prompt: &str) -> Result<llm_types::LLMResponse, LLMError> {
+        LLMClient::generate(&mut self.inner, prompt).await
+    }
+
+    fn backend_kind(&self) -> llm_types::BackendKind {
+        self.inner.backend_kind()
+    }
+
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+}

--- a/vtcode-core/src/llm/providers/mod.rs
+++ b/vtcode-core/src/llm/providers/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic;
 pub mod deepseek;
 pub mod gemini;
+pub mod lmstudio;
 pub mod moonshot;
 pub mod ollama;
 pub mod openai;
@@ -19,6 +20,7 @@ pub(crate) use reasoning::{ReasoningBuffer, extract_reasoning_trace, split_reaso
 pub use anthropic::AnthropicProvider;
 pub use deepseek::DeepSeekProvider;
 pub use gemini::GeminiProvider;
+pub use lmstudio::LmStudioProvider;
 pub use moonshot::MoonshotProvider;
 pub use ollama::OllamaProvider;
 pub use openai::OpenAIProvider;

--- a/vtcode-core/src/llm/providers/openai.rs
+++ b/vtcode-core/src/llm/providers/openai.rs
@@ -528,6 +528,14 @@ impl OpenAIProvider {
         }
     }
 
+    fn authorize(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if self.api_key.trim().is_empty() {
+            builder
+        } else {
+            builder.bearer_auth(&self.api_key)
+        }
+    }
+
     fn supports_temperature_parameter(model: &str) -> bool {
         // GPT-5 variants and GPT-5 Codex models don't support temperature parameter
         // All other OpenAI models generally support it
@@ -2097,9 +2105,7 @@ impl LLMProvider for OpenAIProvider {
         let url = format!("{}/responses", self.base_url);
 
         let response = self
-            .http_client
-            .post(&url)
-            .bearer_auth(&self.api_key)
+            .authorize(self.http_client.post(&url))
             .header("OpenAI-Beta", "responses=v1")
             .json(&openai_request)
             .send()
@@ -2366,9 +2372,7 @@ impl LLMProvider for OpenAIProvider {
             let url = format!("{}/responses", self.base_url);
 
             let response = self
-                .http_client
-                .post(&url)
-                .bearer_auth(&self.api_key)
+                .authorize(self.http_client.post(&url))
                 .header("OpenAI-Beta", "responses=v1")
                 .json(&openai_request)
                 .send()
@@ -2444,9 +2448,7 @@ impl LLMProvider for OpenAIProvider {
         let url = format!("{}/chat/completions", self.base_url);
 
         let response = self
-            .http_client
-            .post(&url)
-            .bearer_auth(&self.api_key)
+            .authorize(self.http_client.post(&url))
             .json(&openai_request)
             .send()
             .await

--- a/vtcode-core/src/llm/rig_adapter.rs
+++ b/vtcode-core/src/llm/rig_adapter.rs
@@ -46,6 +46,9 @@ pub fn verify_model_with_rig(
         Provider::Ollama => {
             // Rig does not provide an Ollama integration; validation is skipped.
         }
+        Provider::LmStudio => {
+            // LM Studio uses the OpenAI-compatible API; rig has no direct client.
+        }
         Provider::XAI => {
             let client = xai::Client::new(api_key);
             let _ = client.completion_model(model);
@@ -96,6 +99,7 @@ pub fn reasoning_parameters_for(provider: Provider, effort: ReasoningEffortLevel
                 .map(|value| json!({ "thinking_config": value }))
         }
         Provider::Ollama => None,
+        Provider::LmStudio => None,
         Provider::ZAI => None,
         _ => None,
     }

--- a/vtcode-core/src/ui/tui/types.rs
+++ b/vtcode-core/src/ui/tui/types.rs
@@ -118,6 +118,8 @@ pub struct InlineTheme {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InlineListSelection {
     Model(usize),
+    DynamicModel(usize),
+    RefreshDynamicModels,
     Reasoning(ReasoningEffortLevel),
     DisableReasoning,
     CustomModel,

--- a/vtcode-core/src/update/checker.rs
+++ b/vtcode-core/src/update/checker.rs
@@ -1,6 +1,8 @@
 //! Version checking and update detection
 
-use super::{config::UpdateConfig, UpdateStatus, CURRENT_VERSION, GITHUB_REPO_NAME, GITHUB_REPO_OWNER};
+use super::{
+    CURRENT_VERSION, GITHUB_REPO_NAME, GITHUB_REPO_OWNER, UpdateStatus, config::UpdateConfig,
+};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -109,10 +111,7 @@ impl UpdateChecker {
             .context("Failed to fetch release information")?;
 
         if !response.status().is_success() {
-            anyhow::bail!(
-                "GitHub API returned error: {}",
-                response.status()
-            );
+            anyhow::bail!("GitHub API returned error: {}", response.status());
         }
 
         let release: GitHubRelease = response

--- a/vtcode-core/src/update/downloader.rs
+++ b/vtcode-core/src/update/downloader.rs
@@ -26,10 +26,7 @@ impl UpdateDownloader {
         self.config.ensure_directories()?;
 
         // Extract filename from URL
-        let filename = url
-            .split('/')
-            .last()
-            .context("Invalid download URL")?;
+        let filename = url.split('/').last().context("Invalid download URL")?;
 
         let download_path = self.config.update_dir.join(filename);
 
@@ -73,7 +70,9 @@ impl UpdateDownloader {
             }
         }
 
-        file.flush().await.context("Failed to flush download file")?;
+        file.flush()
+            .await
+            .context("Failed to flush download file")?;
 
         tracing::info!("Download completed: {:?}", download_path);
 
@@ -98,10 +97,7 @@ impl UpdateDownloader {
 
     /// Download checksum file
     async fn download_checksum(&self, url: &str) -> Result<PathBuf> {
-        let filename = url
-            .split('/')
-            .last()
-            .context("Invalid checksum URL")?;
+        let filename = url.split('/').last().context("Invalid checksum URL")?;
 
         let checksum_path = self.config.update_dir.join(filename);
 
@@ -130,10 +126,7 @@ impl UpdateDownloader {
 
     /// Download signature file
     async fn download_signature(&self, url: &str) -> Result<PathBuf> {
-        let filename = url
-            .split('/')
-            .last()
-            .context("Invalid signature URL")?;
+        let filename = url.split('/').last().context("Invalid signature URL")?;
 
         let signature_path = self.config.update_dir.join(filename);
 

--- a/vtcode-core/src/update/installer.rs
+++ b/vtcode-core/src/update/installer.rs
@@ -19,7 +19,8 @@ impl UpdateInstaller {
         tracing::info!("Installing update from: {:?}", update_path);
 
         // Get the current executable path
-        let current_exe = std::env::current_exe().context("Failed to get current executable path")?;
+        let current_exe =
+            std::env::current_exe().context("Failed to get current executable path")?;
 
         tracing::info!("Current executable: {:?}", current_exe);
 
@@ -114,8 +115,7 @@ impl UpdateInstaller {
             {
                 use std::os::unix::fs::PermissionsExt;
                 if let Some(mode) = file.unix_mode() {
-                    std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode))
-                        .ok();
+                    std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode)).ok();
                 }
             }
         }

--- a/vtcode-core/src/update/mod.rs
+++ b/vtcode-core/src/update/mod.rs
@@ -93,9 +93,7 @@ impl UpdateManager {
             anyhow::bail!("No update available");
         }
 
-        let download_url = status
-            .download_url
-            .context("No download URL available")?;
+        let download_url = status.download_url.context("No download URL available")?;
         let new_version = status
             .latest_version
             .context("No version information available")?;

--- a/vtcode-core/src/update/rollback.rs
+++ b/vtcode-core/src/update/rollback.rs
@@ -81,12 +81,12 @@ impl RollbackManager {
     #[cfg(unix)]
     fn rollback_unix(&self, backup_path: &PathBuf, current_exe: &PathBuf) -> Result<()> {
         std::fs::copy(backup_path, current_exe).context("Failed to restore backup")?;
-        
+
         // Restore executable permissions
         let metadata = std::fs::metadata(backup_path)?;
         let permissions = metadata.permissions();
         std::fs::set_permissions(current_exe, permissions)?;
-        
+
         Ok(())
     }
 

--- a/vtcode-core/src/update/verifier.rs
+++ b/vtcode-core/src/update/verifier.rs
@@ -109,7 +109,9 @@ impl UpdateVerifier {
         // In a production implementation, you would use a proper signature verification library
         // such as `ed25519-dalek` or `rsa` to verify the signature against a public key
 
-        tracing::warn!("Signature verification not fully implemented - signature file exists but not verified");
+        tracing::warn!(
+            "Signature verification not fully implemented - signature file exists but not verified"
+        );
 
         Ok(())
     }

--- a/vtcode-core/src/utils/dot_config.rs
+++ b/vtcode-core/src/utils/dot_config.rs
@@ -40,6 +40,7 @@ pub struct ProviderConfigs {
     pub openrouter: Option<ProviderConfig>,
     pub xai: Option<ProviderConfig>,
     pub ollama: Option<ProviderConfig>,
+    pub lmstudio: Option<ProviderConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/vtcode-core/tests/execpolicy_security_tests.rs
+++ b/vtcode-core/tests/execpolicy_security_tests.rs
@@ -11,7 +11,7 @@ fn workspace_root() -> PathBuf {
 async fn test_ripgrep_pre_flag_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test --pre flag (preprocessor execution)
     let command = vec![
         "rg".to_string(),
@@ -20,7 +20,7 @@ async fn test_ripgrep_pre_flag_blocked() {
         "pattern".to_string(),
         ".".to_string(),
     ];
-    
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_err(), "ripgrep --pre flag should be blocked");
     assert!(
@@ -33,7 +33,7 @@ async fn test_ripgrep_pre_flag_blocked() {
 async fn test_ripgrep_pre_glob_flag_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test --pre-glob flag (preprocessor with glob pattern)
     let command = vec![
         "rg".to_string(),
@@ -44,7 +44,7 @@ async fn test_ripgrep_pre_glob_flag_blocked() {
         "pattern".to_string(),
         ".".to_string(),
     ];
-    
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_err(), "ripgrep --pre-glob flag should be blocked");
 }
@@ -53,7 +53,7 @@ async fn test_ripgrep_pre_glob_flag_blocked() {
 async fn test_ripgrep_safe_flags_allowed() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test safe ripgrep usage
     let command = vec![
         "rg".to_string(),
@@ -64,7 +64,7 @@ async fn test_ripgrep_safe_flags_allowed() {
         "pattern".to_string(),
         ".".to_string(),
     ];
-    
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_ok(), "safe ripgrep flags should be allowed");
 }
@@ -73,23 +73,23 @@ async fn test_ripgrep_safe_flags_allowed() {
 async fn test_sed_execution_flag_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Create a test file
     let test_file = root.join("test_sed.txt");
     std::fs::write(&test_file, "test content").expect("write test file");
-    
+
     // Test sed with execution flag
     let command = vec![
         "sed".to_string(),
         "s/test/malicious/e".to_string(),
         "test_sed.txt".to_string(),
     ];
-    
+
     let result = validate_command(&command, &root, &working_dir).await;
-    
+
     // Cleanup
     let _ = std::fs::remove_file(&test_file);
-    
+
     assert!(result.is_err(), "sed execution flag should be blocked");
     assert!(
         result.unwrap_err().to_string().contains("execution flags"),
@@ -101,13 +101,10 @@ async fn test_sed_execution_flag_blocked() {
 async fn test_path_traversal_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test path traversal attempt
-    let command = vec![
-        "cat".to_string(),
-        "../../../etc/passwd".to_string(),
-    ];
-    
+    let command = vec!["cat".to_string(), "../../../etc/passwd".to_string()];
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_err(), "path traversal should be blocked");
 }
@@ -116,28 +113,25 @@ async fn test_path_traversal_blocked() {
 async fn test_absolute_path_outside_workspace_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test absolute path outside workspace
-    let command = vec![
-        "cat".to_string(),
-        "/etc/passwd".to_string(),
-    ];
-    
+    let command = vec!["cat".to_string(), "/etc/passwd".to_string()];
+
     let result = validate_command(&command, &root, &working_dir).await;
-    assert!(result.is_err(), "absolute path outside workspace should be blocked");
+    assert!(
+        result.is_err(),
+        "absolute path outside workspace should be blocked"
+    );
 }
 
 #[tokio::test]
 async fn test_disallowed_command_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test command not in allowlist
-    let command = vec![
-        "curl".to_string(),
-        "https://evil.com".to_string(),
-    ];
-    
+    let command = vec!["curl".to_string(), "https://evil.com".to_string()];
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_err(), "disallowed command should be blocked");
     assert!(
@@ -150,13 +144,10 @@ async fn test_disallowed_command_blocked() {
 async fn test_git_diff_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test git diff (should be redirected to dedicated tool)
-    let command = vec![
-        "git".to_string(),
-        "diff".to_string(),
-    ];
-    
+    let command = vec!["git".to_string(), "diff".to_string()];
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_err(), "git diff should be blocked");
     assert!(
@@ -169,24 +160,27 @@ async fn test_git_diff_blocked() {
 async fn test_cp_without_recursive_flag_for_directory() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Create test directory
     let test_dir = root.join("test_cp_dir");
     std::fs::create_dir_all(&test_dir).expect("create test dir");
-    
+
     // Test copying directory without -r flag
     let command = vec![
         "cp".to_string(),
         "test_cp_dir".to_string(),
         "test_cp_dir_copy".to_string(),
     ];
-    
+
     let result = validate_command(&command, &root, &working_dir).await;
-    
+
     // Cleanup
     let _ = std::fs::remove_dir_all(&test_dir);
-    
-    assert!(result.is_err(), "copying directory without -r should be blocked");
+
+    assert!(
+        result.is_err(),
+        "copying directory without -r should be blocked"
+    );
     assert!(
         result.unwrap_err().to_string().contains("recursive"),
         "error should mention recursive flag"
@@ -197,7 +191,7 @@ async fn test_cp_without_recursive_flag_for_directory() {
 async fn test_ls_safe_usage() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test safe ls usage with separate flags
     let command = vec![
         "ls".to_string(),
@@ -205,22 +199,23 @@ async fn test_ls_safe_usage() {
         "-a".to_string(),
         ".".to_string(),
     ];
-    
+
     let result = validate_command(&command, &root, &working_dir).await;
-    assert!(result.is_ok(), "safe ls usage should be allowed: {:?}", result);
+    assert!(
+        result.is_ok(),
+        "safe ls usage should be allowed: {:?}",
+        result
+    );
 }
 
 #[tokio::test]
 async fn test_which_safe_usage() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test safe which usage
-    let command = vec![
-        "which".to_string(),
-        "cargo".to_string(),
-    ];
-    
+    let command = vec!["which".to_string(), "cargo".to_string()];
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_ok(), "safe which usage should be allowed");
 }
@@ -229,13 +224,10 @@ async fn test_which_safe_usage() {
 async fn test_which_path_injection_blocked() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test which with path injection attempt
-    let command = vec![
-        "which".to_string(),
-        "/bin/bash".to_string(),
-    ];
-    
+    let command = vec!["which".to_string(), "/bin/bash".to_string()];
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_err(), "which with path should be blocked");
 }
@@ -244,13 +236,10 @@ async fn test_which_path_injection_blocked() {
 async fn test_printenv_safe_usage() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Test safe printenv usage
-    let command = vec![
-        "printenv".to_string(),
-        "PATH".to_string(),
-    ];
-    
+    let command = vec!["printenv".to_string(), "PATH".to_string()];
+
     let result = validate_command(&command, &root, &working_dir).await;
     assert!(result.is_ok(), "safe printenv usage should be allowed");
 }
@@ -259,11 +248,11 @@ async fn test_printenv_safe_usage() {
 async fn test_head_with_line_count() {
     let root = workspace_root();
     let working_dir = root.clone();
-    
+
     // Create test file
     let test_file = root.join("test_head.txt");
     std::fs::write(&test_file, "line1\nline2\nline3\n").expect("write test file");
-    
+
     // Test head with line count
     let command = vec![
         "head".to_string(),
@@ -271,11 +260,11 @@ async fn test_head_with_line_count() {
         "2".to_string(),
         "test_head.txt".to_string(),
     ];
-    
+
     let result = validate_command(&command, &root, &working_dir).await;
-    
+
     // Cleanup
     let _ = std::fs::remove_file(&test_file);
-    
+
     assert!(result.is_ok(), "head with line count should be allowed");
 }


### PR DESCRIPTION
## Summary
- integrate the LM Studio provider throughout the configuration layer, CLI, and model factory so it can be selected like existing backends
- implement an LM Studio provider wrapper around the OpenAI client with local base URL overrides and request validation, plus extend provider tests
- document LM Studio usage in the docs and publish model metadata so it shows up in the catalog

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68fca889b250832390ebbec0f0f2cc62