### PR TITLE
Add sandbox runtime selection and filesystem allowlist controls

### DIFF
--- a/src/agent/runloop/slash_commands.rs
+++ b/src/agent/runloop/slash_commands.rs
@@ -94,6 +94,9 @@ pub enum SandboxAction {
     Status,
     AllowDomain(String),
     RemoveDomain(String),
+    AllowPath(String),
+    RemovePath(String),
+    ListPaths,
     Help,
 }
 
@@ -502,10 +505,8 @@ pub async fn handle_slash_command(
                     "install" => UpdateAction::Install,
                     "status" => UpdateAction::Status,
                     _ => {
-                        renderer.line(
-                            MessageStyle::Error,
-                            "Usage: /update [check|install|status]",
-                        )?;
+                        renderer
+                            .line(MessageStyle::Error, "Usage: /update [check|install|status]")?;
                         return Ok(SlashCommandOutcome::Handled);
                     }
                 }
@@ -687,6 +688,21 @@ fn parse_sandbox_action(args: &str) -> std::result::Result<SandboxAction, String
                 Ok(SandboxAction::RemoveDomain(remainder.to_string()))
             }
         }
+        "allow-path" | "allow-dir" | "allow-paths" => {
+            if remainder.is_empty() {
+                Err("Usage: /sandbox allow-path <path>".to_string())
+            } else {
+                Ok(SandboxAction::AllowPath(remainder.to_string()))
+            }
+        }
+        "remove-path" | "deny-path" | "revoke-path" => {
+            if remainder.is_empty() {
+                Err("Usage: /sandbox remove-path <path>".to_string())
+            } else {
+                Ok(SandboxAction::RemovePath(remainder.to_string()))
+            }
+        }
+        "list-paths" | "paths" => Ok(SandboxAction::ListPaths),
         _ => Err(format!(
             "Unknown sandbox subcommand '{}'. Type /sandbox help for usage.",
             keyword

--- a/vtcode-core/src/tools/bash_tool.rs
+++ b/vtcode-core/src/tools/bash_tool.rs
@@ -268,6 +268,16 @@ impl BashTool {
             "sandbox": {
                 "binary": profile.binary().display().to_string(),
                 "settings_path": profile.settings().display().to_string(),
+                "runtime": profile.runtime_kind().as_str(),
+                "persistent_storage": profile
+                    .persistent_storage()
+                    .display()
+                    .to_string(),
+                "allowed_paths": profile
+                    .allowed_paths()
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>(),
                 "command_string": command_string,
             },
         }))


### PR DESCRIPTION
## Summary
- extend the sandbox coordinator with runtime selection, persistent storage, filesystem allowlisting, and event logging
- expose new `/sandbox allow-path`, `/sandbox remove-path`, and `/sandbox list-paths` commands while surfacing sandbox metadata in Bash tool output and PTY environments
- document the expanded sandbox workflow, including Firecracker microVM support, persistent storage, and the sandbox event log

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68fcd781fae483238e4918693369801e