### PR TITLE
Potential fix for code scanning alert no. 14: Incomplete string escaping or encoding

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1385,7 +1385,7 @@ function ensureAgentTerminal(
     // Instead of immediate execution, use a slight delay to allow any auto-activation to complete
     setTimeout(() => {
         const quotedCommandPath = /\s/.test(commandPath)
-            ? `"${commandPath.replace(/"/g, '\\"')}"`
+            ? `"${commandPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
             : commandPath;
         const configArgs = getConfigArguments();
         const terminalArgs = ["chat", ...configArgs];


### PR DESCRIPTION
Potential fix for [https://github.com/vinhnx/vtcode/security/code-scanning/14](https://github.com/vinhnx/vtcode/security/code-scanning/14)

To fix the problem, the `quotedCommandPath` must escape both double quotes and backslashes in `commandPath` before wrapping it in double quotes. The best way is to replace each backslash (`\`) with two backslashes (`\\`), and each double quote (`"`) with an escaped double quote (`\"`). This should be done using a global regular expression so that *all* occurrences are correctly handled. The change should occur in the block constructing `quotedCommandPath` on line 1387-1388 within vscode-extension/src/extension.ts. No new methods are required, but regular expressions with the global flag should be used. No new imports are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
