### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete string escaping or encoding

### DIFF
--- a/vscode-extension/src/vtcodeConfig.ts
+++ b/vscode-extension/src/vtcodeConfig.ts
@@ -221,7 +221,7 @@ export async function appendMcpProvider(
     ];
 
     if (provider.args.length > 0) {
-        const serializedArgs = provider.args.map((arg) => `"${arg.replace(/"/g, '\\"')}"`).join(', ');
+        const serializedArgs = provider.args.map((arg) => `"${arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(', ');
         snippetLines.push(`args = [${serializedArgs}]`);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/vinhnx/vtcode/security/code-scanning/13](https://github.com/vinhnx/vtcode/security/code-scanning/13)

To fix this issue, we must ensure that both backslashes and quotes are properly escaped within string literals before embedding them in TOML. The best way is to replace each backslash (`\`) with a double-backslash (`\\`), *then* replace every quote (`"`) with an escaped quote (`\"`). This ordering is critical: if you escape quotes first, a single backslash before a quote may be interpreted as escaping the quote. Alternatively, we could use a TOML serialization library, but since the code generates its own TOML snippets, the minimal change is to fix the escaping logic.

Update line 224 in the shown code so that, for each `arg`, first all backslashes are replaced by double-backslashes, then all double quotes are replaced by escaped quotes. Explicitly:
```ts
const serializedArgs = provider.args.map((arg) => `"${arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(', ');
```
This change should be applied specifically to line 224 in file `vscode-extension/src/vtcodeConfig.ts`.

No extra imports or definitions are required. TOML string escaping rules are minimal: backslash and double quote should be escaped within a double-quoted string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
