### PR TITLE
Potential fix for code scanning alert no. 15: Cleartext logging of sensitive information

### DIFF
--- a/vtcode-core/src/core/agent/core.rs
+++ b/vtcode-core/src/core/agent/core.rs
@@ -91,7 +91,7 @@ impl Agent {
             println!(
                 "  {} Session ID: {}",
                 style("(ID)").dim(),
-                self.session_info.session_id
+                "[redacted]"
             );
             println!();
         }


### PR DESCRIPTION
Potential fix for [https://github.com/vinhnx/vtcode/security/code-scanning/15](https://github.com/vinhnx/vtcode/security/code-scanning/15)

The best way to fix this problem is to avoid exposing the plaintext session ID in logs or user-visible output. Specifically, in the `println!` statement in question, instead of printing the sensitive `self.session_info.session_id`, either omit the output entirely or mask/obfuscate the session ID (for example, show only a hash or a few characters). The most privacy-preserving fix is to entirely omit logging the session ID, following the code example in the background material.

Edit file `vtcode-core/src/core/agent/core.rs`:
- Locate the `println!` statement on line 91 that logs the session ID.
- Change it to print a static string instead (e.g., "Session started" or "Session ID: [redacted]"), or simply remove the line.

No new imports, methods, or variable definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
