### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tool-nextest-tools.yml
+++ b/.github/workflows/tool-nextest-tools.yml
@@ -1,4 +1,6 @@
 name: tool-nextest-tools
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vinhnx/vtcode/security/code-scanning/26](https://github.com/vinhnx/vtcode/security/code-scanning/26)

To fix the problem, add an explicit `permissions` block to restrict the GitHub Actions token permissions to the minimum necessary. In this workflow, the steps only read repository contents and do not require any write capabilities. Therefore, set `permissions: contents: read` at the top-level of the workflow, just after the `name` field (to apply to all jobs). Edit `.github/workflows/tool-nextest-tools.yml` to insert the permissions block after the workflow name.

No additional methods, imports, or definitions are required; this change is strictly to the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
