### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: "CI Pipeline"
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+permissions:
+  contents: read
   push:
     branches:
       - main


### PR DESCRIPTION
Potential fix for [https://github.com/vinhnx/vtcode/security/code-scanning/20](https://github.com/vinhnx/vtcode/security/code-scanning/20)

To resolve this issue, add a `permissions:` block to the workflow file. The best approach is to set this at the workflow root (after `name` or `on`), so all jobs inherit the minimal permissions, unless individually overridden. As none of the shown jobs create issues or push commits, the read-only permissions to repository contents (`contents: read`) suffice. This maintains workflow functionality while reducing privilege. 

**File/lines to change:**  
- Edit `.github/workflows/ci.yml`, insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name:` and before `on:` or after `on:`. Conventionally, it's added after `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
