### PR TITLE
Use assert_fs for filesystem-related tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
+name = "assert_fs"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1169,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "document-features"
@@ -1589,6 +1616,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.9.4",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -3025,6 +3063,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4451,6 +4516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +5406,7 @@ dependencies = [
  "anstyle-git",
  "anstyle-ls",
  "anyhow",
+ "assert_fs",
  "async-trait",
  "chrono",
  "clap",
@@ -5401,6 +5473,7 @@ dependencies = [
  "anstyle-query",
  "anstyle-syntect",
  "anyhow",
+ "assert_fs",
  "async-stream",
  "async-trait",
  "avt",
@@ -5481,6 +5554,7 @@ name = "vtcode-llm"
 version = "0.29.8"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "async-trait",
  "futures",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ name = "vtcode"
 path = "src/main.rs"
 
 [dev-dependencies]
+assert_fs = "1.1"
 criterion = "0.5"
 tempfile = "3.0"
 indexmap = { version = "2.2", features = ["serde"] }

--- a/benches/search_benchmark.rs
+++ b/benches/search_benchmark.rs
@@ -1,7 +1,7 @@
+use assert_fs::TempDir;
 use criterion::{Criterion, criterion_group, criterion_main};
 use serde_json::json;
 use std::env;
-use tempfile::TempDir;
 use vtcode_core::config::constants::tools;
 use vtcode_core::tools::ToolRegistry;
 

--- a/benches/system_benchmarks.rs
+++ b/benches/system_benchmarks.rs
@@ -1,8 +1,8 @@
 use std::env;
 
+use assert_fs::TempDir;
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use serde_json::json;
-use tempfile::TempDir;
 use vtcode::StartupContext;
 use vtcode_core::cli::args::Cli;
 use vtcode_core::config::constants::tools;

--- a/src/acp/zed.rs
+++ b/src/acp/zed.rs
@@ -1975,9 +1975,9 @@ impl acp::Agent for ZedAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use serde_json::{Value, json};
     use std::collections::BTreeMap;
-    use tempfile::tempdir;
     use tokio::fs;
     use vtcode_core::config::core::PromptCachingConfig;
     use vtcode_core::config::types::{
@@ -2031,7 +2031,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_list_files_defaults_to_workspace_root() {
-        let temp = tempdir().unwrap();
+        let temp = TempDir::new().unwrap();
         let file_path = temp.path().join("example.txt");
         fs::write(&file_path, "hello").await.unwrap();
 
@@ -2051,7 +2051,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_list_files_accepts_uri_argument() {
-        let temp = tempdir().unwrap();
+        let temp = TempDir::new().unwrap();
         let nested = temp.path().join("nested");
         fs::create_dir_all(&nested).await.unwrap();
         let inner = nested.join("inner.txt");

--- a/src/agent/runloop/model_picker.rs
+++ b/src/agent/runloop/model_picker.rs
@@ -1030,8 +1030,8 @@ fn title_case(value: &str) -> String {
 mod tests {
     use super::*;
     use anyhow::Result;
+    use assert_fs::TempDir;
     use std::fs;
-    use tempfile::tempdir;
 
     fn has_model(options: &[ModelOption], model: ModelId) -> bool {
         let id = model.as_str();
@@ -1087,7 +1087,7 @@ mod tests {
 
     #[test]
     fn read_workspace_env_returns_value_when_present() -> Result<()> {
-        let dir = tempdir()?;
+        let dir = TempDir::new()?;
         let env_path = dir.path().join(".env");
         fs::write(&env_path, "OPENAI_API_KEY=sk-test\n")?;
         let value = super::read_workspace_env(dir.path(), "OPENAI_API_KEY")?;
@@ -1097,7 +1097,7 @@ mod tests {
 
     #[test]
     fn read_workspace_env_returns_none_when_missing_file() -> Result<()> {
-        let dir = tempdir()?;
+        let dir = TempDir::new()?;
         let value = super::read_workspace_env(dir.path(), "OPENAI_API_KEY")?;
         assert_eq!(value, None);
         Ok(())
@@ -1105,7 +1105,7 @@ mod tests {
 
     #[test]
     fn read_workspace_env_returns_none_when_key_absent() -> Result<()> {
-        let dir = tempdir()?;
+        let dir = TempDir::new()?;
         let env_path = dir.path().join(".env");
         fs::write(&env_path, "OTHER_KEY=value\n")?;
         let value = super::read_workspace_env(dir.path(), "OPENAI_API_KEY")?;

--- a/src/agent/runloop/welcome.rs
+++ b/src/agent/runloop/welcome.rs
@@ -336,9 +336,9 @@ fn collect_non_empty_entries(items: &[String]) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use std::collections::BTreeMap;
     use std::fs;
-    use tempfile::tempdir;
     use vtcode_core::config::core::PromptCachingConfig;
     use vtcode_core::config::models::Provider;
     use vtcode_core::config::types::{
@@ -350,7 +350,7 @@ mod tests {
 
     #[test]
     fn test_prepare_session_bootstrap_builds_sections() {
-        let tmp = tempdir().unwrap();
+        let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join("Cargo.toml"),
             "[package]\nname = \"demo\"\nversion = \"0.1.0\"\ndescription = \"Demo project\"\n",
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_welcome_hides_optional_sections_by_default() {
-        let tmp = tempdir().unwrap();
+        let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join("Cargo.toml"),
             "[package]\nname = \"demo\"\nversion = \"0.1.0\"\ndescription = \"Demo project\"\n",
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn test_prepare_session_bootstrap_hides_placeholder_when_planning_disabled() {
-        let tmp = tempdir().unwrap();
+        let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join("Cargo.toml"),
             "[package]\nname = \"demo\"\nversion = \"0.1.0\"\ndescription = \"Demo\"\n",

--- a/src/startup/mod.rs
+++ b/src/startup/mod.rs
@@ -425,9 +425,9 @@ fn resolve_workspace_path(workspace_arg: Option<PathBuf>) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use std::env;
     use std::sync::{Mutex, OnceLock};
-    use tempfile::tempdir;
 
     fn workspace_guard() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -440,7 +440,7 @@ mod tests {
     fn resolves_current_dir_when_none() -> Result<()> {
         let _guard = workspace_guard();
         let original_cwd = env::current_dir()?;
-        let temp_dir = tempdir()?;
+        let temp_dir = TempDir::new()?;
         env::set_current_dir(temp_dir.path())?;
 
         let resolved = resolve_workspace_path(None)?;
@@ -454,7 +454,7 @@ mod tests {
     fn resolves_relative_workspace_path() -> Result<()> {
         let _guard = workspace_guard();
         let original_cwd = env::current_dir()?;
-        let temp_dir = tempdir()?;
+        let temp_dir = TempDir::new()?;
         let workspace_dir = temp_dir.path().join("project");
         std::fs::create_dir(&workspace_dir)?;
         env::set_current_dir(temp_dir.path())?;

--- a/tests/ansi_file_ops_test.rs
+++ b/tests/ansi_file_ops_test.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
+use assert_fs::TempDir;
 use serde_json::json;
-use tempfile::TempDir;
 use vtcode_core::{
     tools::ToolRegistry,
     utils::ansi::{AnsiRenderer, MessageStyle},

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,5 @@
+use assert_fs::TempDir;
 use serde_json::json;
-use tempfile::TempDir;
 use vtcode_core::config::constants::tools;
 use vtcode_core::config::loader::ConfigManager;
 use vtcode_core::tool_policy::ToolPolicy as RuntimeToolPolicy;

--- a/tests/manual_pty_test.rs
+++ b/tests/manual_pty_test.rs
@@ -1,8 +1,8 @@
 //! Manual test for PTY functionality
 
 use anyhow::Result;
+use assert_fs::TempDir;
 use serde_json::json;
-use tempfile::TempDir;
 use vtcode_core::tools::ToolRegistry;
 
 #[tokio::main]

--- a/tests/refactoring_engine_test.rs
+++ b/tests/refactoring_engine_test.rs
@@ -1,5 +1,5 @@
-use std::fs;
-use tempfile::tempdir;
+use assert_fs::TempDir;
+use assert_fs::prelude::*;
 use vtcode_core::tools::tree_sitter::analyzer::Position;
 use vtcode_core::tools::tree_sitter::refactoring::{
     CodeChange, RefactoringEngine, RefactoringKind, RefactoringOperation, TextRange,
@@ -22,17 +22,17 @@ fn make_range(offset: usize, len: usize) -> TextRange {
 
 #[test]
 fn rename_conflict_detected() {
-    let dir = tempdir().unwrap();
-    let file = dir.path().join("conflict.rs");
+    let dir = TempDir::new().unwrap();
+    let file = dir.child("conflict.rs");
     let content = "let x = 1;\nlet y = 2;\nprintln!(\"{}\", x);\n";
-    fs::write(&file, content).unwrap();
+    file.write_str(content).unwrap();
     let start = content.find("x = 1").unwrap();
     let range = make_range(start, 1);
     let op = RefactoringOperation {
         kind: RefactoringKind::Rename,
         description: "rename x to y".to_string(),
         changes: vec![CodeChange {
-            file_path: file.to_string_lossy().into(),
+            file_path: file.path().to_string_lossy().into(),
             old_range: range,
             new_text: "y".to_string(),
             description: String::new(),
@@ -47,17 +47,17 @@ fn rename_conflict_detected() {
 
 #[test]
 fn rename_applies_change() {
-    let dir = tempdir().unwrap();
-    let file = dir.path().join("rename.rs");
+    let dir = TempDir::new().unwrap();
+    let file = dir.child("rename.rs");
     let content = "let x = 1;\nprintln!(\"{}\", x);\n";
-    fs::write(&file, content).unwrap();
+    file.write_str(content).unwrap();
     let start = content.find("x = 1").unwrap();
     let range = make_range(start, 1);
     let op = RefactoringOperation {
         kind: RefactoringKind::Rename,
         description: "rename x to z".to_string(),
         changes: vec![CodeChange {
-            file_path: file.to_string_lossy().into(),
+            file_path: file.path().to_string_lossy().into(),
             old_range: range,
             new_text: "z".to_string(),
             description: String::new(),
@@ -67,6 +67,6 @@ fn rename_applies_change() {
     let mut engine = RefactoringEngine::new();
     let result = engine.apply_refactoring(&op).unwrap();
     assert!(result.success);
-    let updated = fs::read_to_string(&file).unwrap();
+    let updated = file.read_string().unwrap();
     assert!(updated.contains("let z = 1"));
 }

--- a/tests/snapshot_tests.rs.disabled
+++ b/tests/snapshot_tests.rs.disabled
@@ -7,8 +7,8 @@
 //! - Cleanup mechanisms
 //! - Error handling and edge cases
 
+use assert_fs::TempDir;
 use std::collections::HashMap;
-use tempfile::TempDir;
 use tokio::test;
 
 use vtcode_core::agent::snapshots::*;

--- a/tests/stats_command_test.rs
+++ b/tests/stats_command_test.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
+use assert_fs::TempDir;
 use std::collections::BTreeMap;
-use tempfile::TempDir;
 use tokio::time::{Duration, sleep};
 use vtcode_core::{
     Agent,

--- a/tests/test_tool_policy.rs
+++ b/tests/test_tool_policy.rs
@@ -7,11 +7,12 @@
 //! serde = { version = "1.0", features = ["derive"] }
 //! serde_json = "1.0"
 //! dirs = "5.0"
-//! tempfile = "3.0"
+//! assert_fs = "1.1"
 //! indexmap = { version = "2.2", features = ["serde"] }
 //! ```
 
 use anyhow::{Context, Result};
+use assert_fs::TempDir;
 use console::style;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -202,7 +203,7 @@ fn main() -> Result<()> {
     println!();
 
     // Create a temporary directory for testing
-    let temp_dir = tempfile::tempdir()?;
+    let temp_dir = TempDir::new()?;
     let config_path = temp_dir.path().join("tool-policy.json");
 
     // Create a new policy manager

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -129,6 +129,9 @@ indexmap = { version = "2.2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+[dev-dependencies]
+assert_fs = "1.1"
+
 [target.'cfg(unix)'.dependencies]
 
 [[example]]

--- a/vtcode-core/src/config/core/prompt_cache.rs
+++ b/vtcode-core/src/config/core/prompt_cache.rs
@@ -406,7 +406,7 @@ fn resolve_default_cache_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use assert_fs::TempDir;
 
     #[test]
     fn prompt_caching_defaults_align_with_constants() {
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn resolve_cache_dir_uses_workspace_when_relative() {
-        let temp = tempdir().unwrap();
+        let temp = TempDir::new().unwrap();
         let workspace = temp.path();
         let cfg = PromptCachingConfig {
             cache_dir: "relative/cache".to_string(),

--- a/vtcode-core/src/core/agent/bootstrap.rs
+++ b/vtcode-core/src/core/agent/bootstrap.rs
@@ -198,11 +198,12 @@ mod tests {
     use crate::core::agent::snapshots::{
         DEFAULT_CHECKPOINTS_ENABLED, DEFAULT_MAX_AGE_DAYS, DEFAULT_MAX_SNAPSHOTS,
     };
+    use assert_fs::TempDir;
     use std::collections::BTreeMap;
 
     #[test]
     fn builds_default_component_set() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let temp_dir = TempDir::new().expect("temp dir");
         let agent_config = AgentConfig {
             model: models::GEMINI_2_5_FLASH_PREVIEW.to_string(),
             api_key: "test-api-key".to_string(),
@@ -233,7 +234,7 @@ mod tests {
 
     #[test]
     fn allows_overriding_components() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let temp_dir = TempDir::new().expect("temp dir");
         let agent_config = AgentConfig {
             model: models::GEMINI_2_5_FLASH_PREVIEW.to_string(),
             api_key: "test-api-key".to_string(),

--- a/vtcode-core/src/core/agent/snapshots.rs
+++ b/vtcode-core/src/core/agent/snapshots.rs
@@ -521,7 +521,7 @@ pub struct CheckpointRestore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+    use assert_fs::TempDir;
 
     fn setup_manager() -> (TempDir, SnapshotManager) {
         let dir = TempDir::new().expect("tempdir");

--- a/vtcode-core/src/core/trajectory.rs
+++ b/vtcode-core/src/core/trajectory.rs
@@ -88,8 +88,8 @@ impl TrajectoryLogger {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use std::fs;
-    use tempfile::TempDir;
 
     #[test]
     fn test_trajectory_logger_log_route_integration() {

--- a/vtcode-core/src/instructions.rs
+++ b/vtcode-core/src/instructions.rs
@@ -312,16 +312,16 @@ fn canonicalize_dir(path: &Path) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use assert_fs::TempDir;
 
     #[test]
     fn collects_sources_with_precedence_and_patterns() -> Result<()> {
-        let workspace = tempdir()?;
+        let workspace = TempDir::new()?;
         let project_root = workspace.path();
         let nested = project_root.join("src");
         std::fs::create_dir_all(&nested)?;
 
-        let global_home = tempdir()?;
+        let global_home = TempDir::new()?;
         let global_rule = global_home.path().join(".vtcode").join(AGENTS_FILENAME);
         std::fs::create_dir_all(global_rule.parent().unwrap())?;
         std::fs::write(&global_rule, "# Global Rules\n- Global applies")?;
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn handles_missing_instructions_gracefully() -> Result<()> {
-        let workspace = tempdir()?;
+        let workspace = TempDir::new()?;
         let project_root = workspace.path();
         let nested = project_root.join("src");
         std::fs::create_dir_all(&nested)?;
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn enforces_byte_budget() -> Result<()> {
-        let workspace = tempdir()?;
+        let workspace = TempDir::new()?;
         let project_root = workspace.path();
         let root_rule = project_root.join(AGENTS_FILENAME);
         std::fs::write(&root_rule, "A".repeat(4096))?;
@@ -401,9 +401,9 @@ mod tests {
 
     #[test]
     fn expands_home_patterns() -> Result<()> {
-        let workspace = tempdir()?;
+        let workspace = TempDir::new()?;
         let project_root = workspace.path();
-        let home = tempdir()?;
+        let home = TempDir::new()?;
         let personal = home.path().join("notes.md");
         std::fs::write(&personal, "# Personal instructions")?;
 

--- a/vtcode-core/src/lib.rs
+++ b/vtcode-core/src/lib.rs
@@ -208,7 +208,7 @@ pub use utils::vtcodegitignore::initialize_vtcode_gitignore;
 mod tests {
     use super::*;
 
-    use tempfile::TempDir;
+    use assert_fs::TempDir;
 
     #[test]
     fn test_library_exports() {

--- a/vtcode-core/src/project_doc.rs
+++ b/vtcode-core/src/project_doc.rs
@@ -138,7 +138,7 @@ fn canonicalize_dir(path: &Path) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use assert_fs::TempDir;
 
     fn write_doc(dir: &Path, content: &str) {
         std::fs::write(dir.join("AGENTS.md"), content).unwrap();
@@ -146,14 +146,14 @@ mod tests {
 
     #[test]
     fn returns_none_when_no_docs_present() {
-        let tmp = tempdir().unwrap();
+        let tmp = TempDir::new().unwrap();
         let result = read_project_doc(tmp.path(), 4096).unwrap();
         assert!(result.is_none());
     }
 
     #[test]
     fn reads_doc_within_limit() {
-        let tmp = tempdir().unwrap();
+        let tmp = TempDir::new().unwrap();
         write_doc(tmp.path(), "hello world");
 
         let result = read_project_doc(tmp.path(), 4096).unwrap().unwrap();
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn truncates_when_limit_exceeded() {
-        let tmp = tempdir().unwrap();
+        let tmp = TempDir::new().unwrap();
         let content = "A".repeat(64);
         write_doc(tmp.path(), &content);
 
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn reads_docs_from_repo_root_downwards() {
-        let repo = tempdir().unwrap();
+        let repo = TempDir::new().unwrap();
         std::fs::write(repo.path().join(".git"), "gitdir: /tmp/git").unwrap();
         write_doc(repo.path(), "root doc");
 
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn includes_extra_instruction_files() {
-        let repo = tempdir().unwrap();
+        let repo = TempDir::new().unwrap();
         write_doc(repo.path(), "root doc");
         let docs = repo.path().join("docs");
         std::fs::create_dir_all(&docs).unwrap();

--- a/vtcode-core/src/prompts/custom.rs
+++ b/vtcode-core/src/prompts/custom.rs
@@ -562,7 +562,7 @@ fn is_identifier_continue(ch: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use assert_fs::TempDir;
 
     #[test]
     fn prompt_invocation_parses_named_and_positional_arguments() {
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn custom_prompt_expands_placeholders() {
-        let temp = tempdir().unwrap();
+        let temp = TempDir::new().unwrap();
         let path = temp.path().join("review.md");
         fs::write(
             &path,
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn custom_prompt_registry_loads_from_directory() {
-        let temp = tempdir().unwrap();
+        let temp = TempDir::new().unwrap();
         let prompts_dir = temp.path().join("prompts");
         fs::create_dir_all(&prompts_dir).unwrap();
         fs::write(prompts_dir.join("draft.md"), "Draft PR for $1").unwrap();
@@ -614,7 +614,7 @@ mod tests {
 
     #[test]
     fn builtin_prompt_available_without_files() {
-        let temp = tempdir().unwrap();
+        let temp = TempDir::new().unwrap();
         let registry = CustomPromptRegistry::load(None, temp.path()).expect("load registry");
         let prompt = registry.get("vtcode").expect("builtin prompt available");
 
@@ -625,7 +625,7 @@ mod tests {
 
     #[test]
     fn custom_prompt_overrides_builtin_version() {
-        let temp = tempdir().unwrap();
+        let temp = TempDir::new().unwrap();
         let prompts_dir = temp.path().join("prompts");
         fs::create_dir_all(&prompts_dir).unwrap();
         fs::write(prompts_dir.join("vtcode.md"), "Workspace-specific kickoff").unwrap();

--- a/vtcode-core/src/tool_policy.rs
+++ b/vtcode-core/src/tool_policy.rs
@@ -1123,7 +1123,7 @@ pub struct ToolConstraints {
 mod tests {
     use super::*;
     use crate::config::constants::tools;
-    use tempfile::tempdir;
+    use assert_fs::TempDir;
 
     #[test]
     fn test_tool_policy_config_serialization() {
@@ -1145,7 +1145,7 @@ mod tests {
 
     #[test]
     fn test_policy_updates() {
-        let dir = tempdir().unwrap();
+        let dir = TempDir::new().unwrap();
         let config_path = dir.path().join("tool-policy.json");
 
         let mut config = ToolPolicyConfig::default();

--- a/vtcode-core/src/tools/advanced_search.rs
+++ b/vtcode-core/src/tools/advanced_search.rs
@@ -513,8 +513,8 @@ impl Tool for AdvancedSearchTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use std::sync::Arc;
-    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_case_insensitive_search() {

--- a/vtcode-core/src/tools/apply_patch.rs
+++ b/vtcode-core/src/tools/apply_patch.rs
@@ -352,7 +352,7 @@ impl Patch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+    use assert_fs::TempDir;
 
     #[test]
     fn test_parse_simple_patch() {

--- a/vtcode-core/src/tools/cache_e2e_tests.rs
+++ b/vtcode-core/src/tools/cache_e2e_tests.rs
@@ -1,11 +1,11 @@
 //! End-to-end tests for file operations with quick-cache integration
 
+use assert_fs::TempDir;
+use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
-use tempfile::TempDir;
 use vtcode_core::tools::cache::FileCache;
 use vtcode_core::tools::registry::ToolRegistry;
-use serde_json::{Value, json};
 
 #[cfg(test)]
 mod e2e_tests {

--- a/vtcode-core/src/tools/file_search.rs
+++ b/vtcode-core/src/tools/file_search.rs
@@ -431,8 +431,8 @@ fn compile_fuzzy_pattern(pattern: &str) -> Option<FuzzyPattern> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use std::path::{Path, PathBuf};
-    use tempfile::TempDir;
 
     fn collect_relative_paths(results: &[FileSearchResult], root: &Path) -> Vec<PathBuf> {
         results

--- a/vtcode-core/src/tools/registry/mod.rs
+++ b/vtcode-core/src/tools/registry/mod.rs
@@ -711,9 +711,9 @@ fn normalize_mcp_tool_identifier(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use async_trait::async_trait;
     use serde_json::json;
-    use tempfile::TempDir;
 
     const CUSTOM_TOOL_NAME: &str = "custom_test_tool";
 

--- a/vtcode-core/src/utils/dot_config.rs
+++ b/vtcode-core/src/utils/dot_config.rs
@@ -507,7 +507,7 @@ pub fn update_model_preference(provider: &str, model: &str) -> Result<(), DotErr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+    use assert_fs::TempDir;
 
     #[test]
     fn test_dot_manager_initialization() {

--- a/vtcode-core/src/utils/vtcodegitignore.rs
+++ b/vtcode-core/src/utils/vtcodegitignore.rs
@@ -242,9 +242,9 @@ pub async fn reload_vtcode_gitignore() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use std::fs::File;
     use std::io::Write;
-    use tempfile::TempDir;
 
     /// Test the vtcodegitignore functionality in isolation
     #[tokio::test]

--- a/vtcode-core/tests/ast_grep_tool_test.rs
+++ b/vtcode-core/tests/ast_grep_tool_test.rs
@@ -6,10 +6,11 @@ use vtcode_core::tools::registry::ToolRegistry;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
 
     #[tokio::test]
     async fn test_ast_grep_tool_registration() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = TempDir::new().unwrap();
         let registry = ToolRegistry::new(temp_dir.path().to_path_buf());
 
         // Check if AST-grep tool is available (only if ast-grep is installed)
@@ -24,7 +25,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ast_grep_tool_execution() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = TempDir::new().unwrap();
         let mut registry = ToolRegistry::new(temp_dir.path().to_path_buf());
 
         // Create a simple test file

--- a/vtcode-core/tests/config_loader_test.rs
+++ b/vtcode-core/tests/config_loader_test.rs
@@ -1,7 +1,7 @@
 //! Test for configuration loading with home directory support
 
+use assert_fs::TempDir;
 use std::fs;
-use tempfile::TempDir;
 use vtcode_core::config::VTCodeConfig;
 
 #[test]

--- a/vtcode-core/tests/delete_file_tool.rs
+++ b/vtcode-core/tests/delete_file_tool.rs
@@ -1,9 +1,10 @@
+use assert_fs::TempDir;
 use serde_json::json;
 use vtcode_core::tools::ToolRegistry;
 
 #[tokio::test]
 async fn delete_file_tool_removes_file() {
-    let tmp = tempfile::TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
     let file_path = tmp.path().join("to_delete.txt");
     tokio::fs::write(&file_path, b"hello").await.unwrap();
 

--- a/vtcode-core/tests/mcp_integration_e2e.rs
+++ b/vtcode-core/tests/mcp_integration_e2e.rs
@@ -3,8 +3,8 @@
 //! These tests verify that MCP integration works correctly with real MCP servers.
 //! They test the complete flow from configuration loading to tool execution.
 
+use assert_fs::TempDir;
 use std::collections::HashMap;
-use tempfile::TempDir;
 use tokio::process::Command;
 use vtcode_core::config::loader::VTCodeConfig;
 use vtcode_core::config::mcp::{

--- a/vtcode-core/tests/project_test.rs
+++ b/vtcode-core/tests/project_test.rs
@@ -1,6 +1,6 @@
 //! Tests for simple project management and caching utilities
 
-use tempfile::TempDir;
+use assert_fs::TempDir;
 use vtcode_core::project::{SimpleCache, SimpleProjectManager};
 
 #[test]

--- a/vtcode-core/tests/pty_tests.rs
+++ b/vtcode-core/tests/pty_tests.rs
@@ -1,15 +1,15 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use assert_fs::TempDir;
 use portable_pty::PtySize;
-use tempfile::tempdir;
 
 use vtcode_core::config::PtyConfig;
 use vtcode_core::tools::{PtyCommandRequest, PtyManager};
 
 #[tokio::test]
 async fn run_pty_command_captures_output() -> Result<()> {
-    let temp_dir = tempdir()?;
+    let temp_dir = TempDir::new()?;
     let manager = PtyManager::new(temp_dir.path().to_path_buf(), PtyConfig::default());
 
     let working_dir = manager.resolve_working_dir(Some("."))?;
@@ -38,7 +38,7 @@ async fn run_pty_command_captures_output() -> Result<()> {
 
 #[test]
 fn create_list_and_close_session_preserves_screen_contents() -> Result<()> {
-    let temp_dir = tempdir()?;
+    let temp_dir = TempDir::new()?;
     let manager = PtyManager::new(temp_dir.path().to_path_buf(), PtyConfig::default());
 
     let working_dir = manager.resolve_working_dir(Some("."))?;
@@ -103,7 +103,7 @@ fn create_list_and_close_session_preserves_screen_contents() -> Result<()> {
 
 #[test]
 fn resolve_working_dir_rejects_missing_directory() {
-    let temp_dir = tempdir().unwrap();
+    let temp_dir = TempDir::new().unwrap();
     let manager = PtyManager::new(temp_dir.path().to_path_buf(), PtyConfig::default());
 
     let error = manager.resolve_working_dir(Some("missing"));
@@ -112,7 +112,7 @@ fn resolve_working_dir_rejects_missing_directory() {
 
 #[test]
 fn session_input_roundtrip_and_resize() -> Result<()> {
-    let temp_dir = tempdir()?;
+    let temp_dir = TempDir::new()?;
     let mut config = PtyConfig::default();
     config.scrollback_lines = 200;
     let manager = PtyManager::new(temp_dir.path().to_path_buf(), config);

--- a/vtcode-llm/Cargo.toml
+++ b/vtcode-llm/Cargo.toml
@@ -41,5 +41,6 @@ vtcode-commons = { path = "../vtcode-commons" }
 vtcode-core = { path = "../vtcode-core" }
 
 [dev-dependencies]
+assert_fs = "1.1"
 futures = "0.3"
 tempfile = "3"

--- a/vtcode-llm/src/config.rs
+++ b/vtcode-llm/src/config.rs
@@ -205,6 +205,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
     use std::borrow::Cow;
     use std::sync::{Arc, Mutex};
 
@@ -288,7 +289,7 @@ mod tests {
 
     #[test]
     fn applies_workspace_paths_to_prompt_cache() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path().join("workspace");
         let config = root.join("config");
         let cache = root.join("cache");
@@ -329,7 +330,7 @@ mod tests {
 
     #[test]
     fn reports_errors_when_telemetry_fails() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path().join("workspace");
         let config = root.join("config");
         let cache = root.join("cache");


### PR DESCRIPTION
## Summary
- add the assert_fs dev-dependency to crates that exercise filesystem-heavy tests and benches
- switch integration/unit tests and benches that touch the filesystem to use assert_fs::TempDir and helper APIs instead of tempfile::tempdir
- refresh ancillary test code paths to leverage assert_fs utilities for cleaner temporary workspace setup

## Testing
- cargo fmt
- cargo clippy
- cargo test (aborted due to long compile)

------
https://chatgpt.com/codex/tasks/task_e_68f651c1209c8323babee924135b25e8