### PR TITLE
Add inline !cmd shell execution support

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -79,6 +79,7 @@ VT Code provides several quick actions directly in the chat input for faster wor
 - **File Picker (`@`)** — Type `@` anywhere in your input to open the file picker and select files to reference in your message. This allows you to quickly mention files without typing full paths.
 - **Custom Prompt Shortcut (`#`)** — Type `#` at the start of input to quickly access and run custom prompts. This is a shorthand for accessing your saved prompts directly from the input bar.
 - **Slash Commands (`/`)** — Type `/` at the start of input to access all available slash commands including `/prompts`, `/files`, `/stats`, and many more.
+- **Shell Command Shortcut (`!cmd`)** — Type `!cmd` followed by a command to run it immediately via the sandboxed runner. The input is parsed locally, validated against the shell allow list, and cancelled if it exceeds the configured timeout.
 
 ## stats (session metrics)
 

--- a/docs/user-guide/interactive-mode.md
+++ b/docs/user-guide/interactive-mode.md
@@ -39,7 +39,7 @@ The VT Code terminal UI includes an interactive mode that combines keyboard-firs
 | :-- | :-- | :-- |
 | `#` at start of input | Access custom prompts. | Opens quick picker to select and run custom prompts directly from input bar. |
 | `/` at start of input | Issue a slash command. | Run `/help` or `/slash-commands` in a session to list everything available. |
-| `!` at start of input | Enter Bash mode. | Runs shell commands directly and streams their output. |
+| `!cmd` at start of input | Run a sandboxed shell command. | Commands are parsed locally, validated against the allow list, and time-limited. |
 | `@` within input | Open file picker. | Triggers file path autocomplete and picker to quickly reference files in your message. |
 
 ## Vim Editor Mode
@@ -119,17 +119,23 @@ Common backgrounded commands include:
 * Test runners (jest, pytest)
 * Development servers and other long-running processes
 
-### Bash Mode with `!`
+### Shell Commands with `!cmd`
 
-Prefix input with `!` to run commands directly without agent interpretation:
+Prefix input with `!cmd` to run an inline shell command without routing through the model:
 
 ```bash
-! npm test
-! git status
-! ls -la
+!cmd npm test
+!cmd git status
+!cmd ls -la
 ```
 
-Bash mode streams the command and its output into the chat, supports backgrounding via `Ctrl+B`, and is ideal for quick shell operations while keeping a shared context with the agent.
+Commands are executed by the same sandboxed runner that powers the agent’s `run_terminal_cmd` tool:
+
+* Arguments are parsed locally with POSIX rules so the agent never sees the raw command line.
+* Each invocation passes through the workspace execution policy allow list; unsupported binaries or flags are rejected with a clear error.
+* Processes inherit the sandbox profile (when enabled via `/sandbox`) and are cancelled automatically if they exceed the configured timeout.
+
+The output is streamed directly into the conversation, and you can still background the task with `Ctrl+B` if it runs long. Use `/bash` or `/sandbox` for multi-line scripts or to adjust sandbox permissions.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary
- add inline `!cmd` handling in the unified turn loop to execute sandboxed shell commands with progress reporting and command output rendering
- document the new inline shell syntax and security constraints in the interactive mode and command reference guides

## Testing
- cargo fmt
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_690c300237e483239b58bbf9b9f6f187