### PR TITLE
Add Moonshot Kimi K2 Thinking model metadata

### DIFF
--- a/docs/models.json
+++ b/docs/models.json
@@ -1548,6 +1548,23 @@
                     "output": 1e-5
                 }
             },
+            "kimi-k2-thinking": {
+                "id": "kimi-k2-thinking",
+                "name": "Kimi K2 Thinking",
+                "reasoning": true,
+                "tool_call": true,
+                "modalities": {
+                    "input": ["text"],
+                    "output": ["text"]
+                },
+                "context": 262144,
+                "max_output_tokens": 262144,
+                "cost": {
+                    "input_cache_hit": 1.5e-7,
+                    "input": 6e-7,
+                    "output": 2.5e-6
+                }
+            },
             "kimi-k2-0905-preview": {
                 "id": "kimi-k2-0905-preview",
                 "name": "Kimi K2 0905 Preview",

--- a/tests/llm_providers_test.rs
+++ b/tests/llm_providers_test.rs
@@ -297,6 +297,7 @@ fn test_provider_supported_models() {
     let moonshot = MoonshotProvider::new("test_key".to_string());
     let moonshot_models = moonshot.supported_models();
     assert!(moonshot_models.contains(&models::MOONSHOT_KIMI_K2_TURBO_PREVIEW.to_string()));
+    assert!(moonshot_models.contains(&models::MOONSHOT_KIMI_K2_THINKING.to_string()));
     assert!(moonshot_models.contains(&models::MOONSHOT_KIMI_K2_0905_PREVIEW.to_string()));
     assert!(moonshot_models.contains(&models::MOONSHOT_KIMI_LATEST_128K.to_string()));
     assert!(moonshot_models.len() >= 3);

--- a/vtcode-config/build_data/openrouter_models.json
+++ b/vtcode-config/build_data/openrouter_models.json
@@ -164,6 +164,38 @@
         "doc_comment": "Kimi K2 0905 - MoonshotAI Kimi K2 0905 MoE release optimised for coding agents"
       }
     },
+    "moonshotai/kimi-k2-thinking": {
+      "id": "moonshotai/kimi-k2-thinking",
+      "name": "MoonshotAI: Kimi K2 Thinking",
+      "reasoning": true,
+      "tool_call": true,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "context": 262144,
+      "max_output_tokens": 262144,
+      "cost": {
+        "input_cache_hit": 1.5E-7,
+        "input": 6E-7,
+        "output": 0.0000025
+      },
+      "vtcode": {
+        "variant": "OpenRouterMoonshotaiKimiK2Thinking",
+        "constant": "MOONSHOTAI_KIMI_K2_THINKING",
+        "vendor": "moonshotai",
+        "display": "Kimi K2 Thinking",
+        "description": "MoonshotAI reasoning-tier Kimi K2 release optimized for long-horizon agents",
+        "efficient": false,
+        "top_tier": true,
+        "generation": "K2-Thinking",
+        "doc_comment": "Kimi K2 Thinking - MoonshotAI reasoning-tier Kimi K2 release optimized for long-horizon agents"
+      }
+    },
     "moonshotai/kimi-k2:free": {
       "id": "moonshotai/kimi-k2:free",
       "name": "MoonshotAI: Kimi K2 (free)",

--- a/vtcode-config/src/constants.rs
+++ b/vtcode-config/src/constants.rs
@@ -88,6 +88,7 @@ pub mod models {
         pub const DEFAULT_MODEL: &str = "kimi-k2-turbo-preview";
         pub const SUPPORTED_MODELS: &[&str] = &[
             "kimi-k2-turbo-preview",
+            "kimi-k2-thinking",
             "kimi-k2-0905-preview",
             "kimi-k2-0711-preview",
             "kimi-latest",
@@ -97,6 +98,7 @@ pub mod models {
         ];
 
         pub const KIMI_K2_TURBO_PREVIEW: &str = "kimi-k2-turbo-preview";
+        pub const KIMI_K2_THINKING: &str = "kimi-k2-thinking";
         pub const KIMI_K2_0905_PREVIEW: &str = "kimi-k2-0905-preview";
         pub const KIMI_K2_0711_PREVIEW: &str = "kimi-k2-0711-preview";
         pub const KIMI_LATEST: &str = "kimi-latest";
@@ -270,6 +272,7 @@ pub mod models {
     pub const CLAUDE_SONNET_4_20250514: &str = anthropic::CLAUDE_SONNET_4_20250514;
     pub const MINIMAX_M2: &str = minimax::MINIMAX_M2;
     pub const MOONSHOT_KIMI_K2_TURBO_PREVIEW: &str = moonshot::KIMI_K2_TURBO_PREVIEW;
+    pub const MOONSHOT_KIMI_K2_THINKING: &str = moonshot::KIMI_K2_THINKING;
     pub const MOONSHOT_KIMI_K2_0905_PREVIEW: &str = moonshot::KIMI_K2_0905_PREVIEW;
     pub const MOONSHOT_KIMI_K2_0711_PREVIEW: &str = moonshot::KIMI_K2_0711_PREVIEW;
     pub const MOONSHOT_KIMI_LATEST: &str = moonshot::KIMI_LATEST;

--- a/vtcode-config/src/models.rs
+++ b/vtcode-config/src/models.rs
@@ -236,6 +236,8 @@ pub enum ModelId {
     // Moonshot.ai models
     /// Kimi K2 Turbo Preview - Recommended high-speed K2 deployment
     MoonshotKimiK2TurboPreview,
+    /// Kimi K2 Thinking - Moonshot reasoning-tier K2 release for long-horizon agentic tasks
+    MoonshotKimiK2Thinking,
     /// Kimi K2 0905 Preview - Flagship 256K K2 release with enhanced coding agents
     MoonshotKimiK20905Preview,
     /// Kimi K2 0711 Preview - Long-context K2 release tuned for balanced workloads
@@ -509,6 +511,7 @@ impl ModelId {
             ModelId::ZaiGlm432b0414128k => models::zai::GLM_4_32B_0414_128K,
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview => models::MOONSHOT_KIMI_K2_TURBO_PREVIEW,
+            ModelId::MoonshotKimiK2Thinking => models::MOONSHOT_KIMI_K2_THINKING,
             ModelId::MoonshotKimiK20905Preview => models::MOONSHOT_KIMI_K2_0905_PREVIEW,
             ModelId::MoonshotKimiK20711Preview => models::MOONSHOT_KIMI_K2_0711_PREVIEW,
             ModelId::MoonshotKimiLatest => models::MOONSHOT_KIMI_LATEST,
@@ -572,6 +575,7 @@ impl ModelId {
             | ModelId::ZaiGlm45Flash
             | ModelId::ZaiGlm432b0414128k => Provider::ZAI,
             ModelId::MoonshotKimiK2TurboPreview
+            | ModelId::MoonshotKimiK2Thinking
             | ModelId::MoonshotKimiK20905Preview
             | ModelId::MoonshotKimiK20711Preview
             | ModelId::MoonshotKimiLatest
@@ -643,6 +647,7 @@ impl ModelId {
             ModelId::ZaiGlm432b0414128k => "GLM 4 32B 0414 128K",
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview => "Kimi K2 Turbo Preview",
+            ModelId::MoonshotKimiK2Thinking => "Kimi K2 Thinking",
             ModelId::MoonshotKimiK20905Preview => "Kimi K2 0905 Preview",
             ModelId::MoonshotKimiK20711Preview => "Kimi K2 0711 Preview",
             ModelId::MoonshotKimiLatest => "Kimi Latest (auto-tier)",
@@ -740,6 +745,9 @@ impl ModelId {
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview => {
                 "Recommended high-speed Kimi K2 turbo variant with 256K context and 60+ tok/s output"
+            }
+            ModelId::MoonshotKimiK2Thinking => {
+                "Moonshot reasoning-tier Kimi K2 release optimized for deliberate, multi-step agentic reasoning"
             }
             ModelId::MoonshotKimiK20905Preview => {
                 "Latest Kimi K2 0905 flagship with enhanced agentic coding, 256K context, and richer tool support"
@@ -851,6 +859,7 @@ impl ModelId {
             ModelId::ZaiGlm432b0414128k,
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview,
+            ModelId::MoonshotKimiK2Thinking,
             ModelId::MoonshotKimiK20905Preview,
             ModelId::MoonshotKimiK20711Preview,
             ModelId::MoonshotKimiLatest,
@@ -986,6 +995,7 @@ impl ModelId {
                 | ModelId::DeepSeekReasoner
                 | ModelId::XaiGrok4
                 | ModelId::ZaiGlm46
+                | ModelId::MoonshotKimiK2Thinking
                 | ModelId::MoonshotKimiK20905Preview
                 | ModelId::MoonshotKimiLatest128k
         )
@@ -1031,6 +1041,7 @@ impl ModelId {
                 | ModelId::XaiGrok4
                 | ModelId::XaiGrok4CodeLatest
                 | ModelId::ZaiGlm46
+                | ModelId::MoonshotKimiK2Thinking
                 | ModelId::MoonshotKimiK20905Preview
                 | ModelId::MoonshotKimiLatest128k
         )
@@ -1038,6 +1049,9 @@ impl ModelId {
 
     /// Determine whether the model is a reasoning-capable variant
     pub fn is_reasoning_variant(&self) -> bool {
+        if matches!(self, ModelId::MoonshotKimiK2Thinking) {
+            return true;
+        }
         if let Some(meta) = self.openrouter_metadata() {
             return meta.reasoning;
         }
@@ -1093,6 +1107,7 @@ impl ModelId {
             ModelId::MoonshotKimiK2TurboPreview
             | ModelId::MoonshotKimiK20905Preview
             | ModelId::MoonshotKimiK20711Preview => "k2",
+            ModelId::MoonshotKimiK2Thinking => "k2-thinking",
             ModelId::MoonshotKimiLatest
             | ModelId::MoonshotKimiLatest8k
             | ModelId::MoonshotKimiLatest32k
@@ -1168,6 +1183,7 @@ impl FromStr for ModelId {
             s if s == models::MOONSHOT_KIMI_K2_TURBO_PREVIEW => {
                 Ok(ModelId::MoonshotKimiK2TurboPreview)
             }
+            s if s == models::MOONSHOT_KIMI_K2_THINKING => Ok(ModelId::MoonshotKimiK2Thinking),
             s if s == models::MOONSHOT_KIMI_K2_0905_PREVIEW => {
                 Ok(ModelId::MoonshotKimiK20905Preview)
             }
@@ -1446,6 +1462,12 @@ mod tests {
                 .parse::<ModelId>()
                 .unwrap(),
             ModelId::MoonshotKimiK2TurboPreview
+        );
+        assert_eq!(
+            models::MOONSHOT_KIMI_K2_THINKING
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiK2Thinking
         );
         assert_eq!(
             models::MOONSHOT_KIMI_K2_0905_PREVIEW
@@ -1831,13 +1853,14 @@ mod tests {
 
         let moonshot_models = ModelId::models_for_provider(Provider::Moonshot);
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiK2TurboPreview));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK2Thinking));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20905Preview));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20711Preview));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest8k));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest32k));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest128k));
-        assert_eq!(moonshot_models.len(), 7);
+        assert_eq!(moonshot_models.len(), 8);
 
         let ollama_models = ModelId::models_for_provider(Provider::Ollama);
         assert!(ollama_models.contains(&ModelId::OllamaGptOss20b));

--- a/vtcode-core/src/config/models.rs
+++ b/vtcode-core/src/config/models.rs
@@ -241,6 +241,8 @@ pub enum ModelId {
     // Moonshot.ai models
     /// Kimi K2 Turbo Preview - Recommended high-speed K2 deployment
     MoonshotKimiK2TurboPreview,
+    /// Kimi K2 Thinking - Moonshot reasoning-tier K2 release for long-horizon agentic tasks
+    MoonshotKimiK2Thinking,
     /// Kimi K2 0905 Preview - Flagship 256K K2 release with enhanced coding agents
     MoonshotKimiK20905Preview,
     /// Kimi K2 0711 Preview - Long-context K2 release tuned for balanced workloads
@@ -453,6 +455,7 @@ impl ModelId {
             ModelId::ZaiGlm432b0414128k => models::zai::GLM_4_32B_0414_128K,
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview => models::MOONSHOT_KIMI_K2_TURBO_PREVIEW,
+            ModelId::MoonshotKimiK2Thinking => models::MOONSHOT_KIMI_K2_THINKING,
             ModelId::MoonshotKimiK20905Preview => models::MOONSHOT_KIMI_K2_0905_PREVIEW,
             ModelId::MoonshotKimiK20711Preview => models::MOONSHOT_KIMI_K2_0711_PREVIEW,
             ModelId::MoonshotKimiLatest => models::MOONSHOT_KIMI_LATEST,
@@ -515,6 +518,7 @@ impl ModelId {
             | ModelId::ZaiGlm45Flash
             | ModelId::ZaiGlm432b0414128k => Provider::ZAI,
             ModelId::MoonshotKimiK2TurboPreview
+            | ModelId::MoonshotKimiK2Thinking
             | ModelId::MoonshotKimiK20905Preview
             | ModelId::MoonshotKimiK20711Preview
             | ModelId::MoonshotKimiLatest
@@ -649,6 +653,7 @@ impl ModelId {
             ModelId::ZaiGlm432b0414128k => "GLM 4 32B 0414 128K",
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview => "Kimi K2 Turbo Preview",
+            ModelId::MoonshotKimiK2Thinking => "Kimi K2 Thinking",
             ModelId::MoonshotKimiK20905Preview => "Kimi K2 0905 Preview",
             ModelId::MoonshotKimiK20711Preview => "Kimi K2 0711 Preview",
             ModelId::MoonshotKimiLatest => "Kimi Latest (auto-tier)",
@@ -746,6 +751,9 @@ impl ModelId {
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview => {
                 "Recommended high-speed Kimi K2 turbo variant with 256K context and 60+ tok/s output"
+            }
+            ModelId::MoonshotKimiK2Thinking => {
+                "Moonshot reasoning-tier Kimi K2 release optimized for deliberate, multi-step agentic reasoning"
             }
             ModelId::MoonshotKimiK20905Preview => {
                 "Latest Kimi K2 0905 flagship with enhanced agentic coding, 256K context, and richer tool support"
@@ -856,6 +864,7 @@ impl ModelId {
             ModelId::ZaiGlm432b0414128k,
             // Moonshot models
             ModelId::MoonshotKimiK2TurboPreview,
+            ModelId::MoonshotKimiK2Thinking,
             ModelId::MoonshotKimiK20905Preview,
             ModelId::MoonshotKimiK20711Preview,
             ModelId::MoonshotKimiLatest,
@@ -999,6 +1008,7 @@ impl ModelId {
                 | ModelId::DeepSeekReasoner
                 | ModelId::XaiGrok4
                 | ModelId::ZaiGlm46
+                | ModelId::MoonshotKimiK2Thinking
                 | ModelId::MoonshotKimiK20905Preview
                 | ModelId::MoonshotKimiLatest128k
         )
@@ -1044,6 +1054,7 @@ impl ModelId {
                 | ModelId::XaiGrok4
                 | ModelId::XaiGrok4CodeLatest
                 | ModelId::ZaiGlm46
+                | ModelId::MoonshotKimiK2Thinking
                 | ModelId::MoonshotKimiK20905Preview
                 | ModelId::MoonshotKimiLatest128k
         )
@@ -1051,6 +1062,9 @@ impl ModelId {
 
     /// Determine whether the model is a reasoning-capable variant
     pub fn is_reasoning_variant(&self) -> bool {
+        if matches!(self, ModelId::MoonshotKimiK2Thinking) {
+            return true;
+        }
         if let Some(meta) = self.openrouter_metadata() {
             return meta.reasoning;
         }
@@ -1106,6 +1120,7 @@ impl ModelId {
             ModelId::MoonshotKimiK2TurboPreview
             | ModelId::MoonshotKimiK20905Preview
             | ModelId::MoonshotKimiK20711Preview => "k2",
+            ModelId::MoonshotKimiK2Thinking => "k2-thinking",
             ModelId::MoonshotKimiLatest
             | ModelId::MoonshotKimiLatest8k
             | ModelId::MoonshotKimiLatest32k
@@ -1181,6 +1196,7 @@ impl FromStr for ModelId {
             s if s == models::MOONSHOT_KIMI_K2_TURBO_PREVIEW => {
                 Ok(ModelId::MoonshotKimiK2TurboPreview)
             }
+            s if s == models::MOONSHOT_KIMI_K2_THINKING => Ok(ModelId::MoonshotKimiK2Thinking),
             s if s == models::MOONSHOT_KIMI_K2_0905_PREVIEW => {
                 Ok(ModelId::MoonshotKimiK20905Preview)
             }
@@ -1459,6 +1475,12 @@ mod tests {
                 .parse::<ModelId>()
                 .unwrap(),
             ModelId::MoonshotKimiK2TurboPreview
+        );
+        assert_eq!(
+            models::MOONSHOT_KIMI_K2_THINKING
+                .parse::<ModelId>()
+                .unwrap(),
+            ModelId::MoonshotKimiK2Thinking
         );
         assert_eq!(
             models::MOONSHOT_KIMI_K2_0905_PREVIEW
@@ -1854,13 +1876,14 @@ mod tests {
 
         let moonshot_models = ModelId::models_for_provider(Provider::Moonshot);
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiK2TurboPreview));
+        assert!(moonshot_models.contains(&ModelId::MoonshotKimiK2Thinking));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20905Preview));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiK20711Preview));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest8k));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest32k));
         assert!(moonshot_models.contains(&ModelId::MoonshotKimiLatest128k));
-        assert_eq!(moonshot_models.len(), 7);
+        assert_eq!(moonshot_models.len(), 8);
 
         let ollama_models = ModelId::models_for_provider(Provider::Ollama);
         assert!(ollama_models.contains(&ModelId::OllamaGptOss20b));

--- a/vtcode-core/src/llm/providers/moonshot.rs
+++ b/vtcode-core/src/llm/providers/moonshot.rs
@@ -70,8 +70,14 @@ impl LLMProvider for MoonshotProvider {
         "moonshot"
     }
 
-    fn supports_reasoning(&self, _model: &str) -> bool {
-        false
+    fn supports_reasoning(&self, model: &str) -> bool {
+        let requested = if model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            model
+        };
+
+        requested == models::moonshot::KIMI_K2_THINKING
     }
 
     fn supports_reasoning_effort(&self, _model: &str) -> bool {


### PR DESCRIPTION
## Summary
- add the kimi-k2-thinking reasoning model to the Moonshot provider catalog
- register kimi-k2-thinking in the OpenRouter metadata with vtcode constants and pricing details

## Testing
- cargo fmt
- cargo clippy


------
https://chatgpt.com/codex/tasks/task_e_690d2e0f40b883239608e0efd7538774