### PR TITLE
Add libc as an optional dependency on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6523,6 +6523,7 @@ dependencies = [
  "itertools 0.14.0",
  "json5",
  "jsonschema",
+ "libc",
  "line-clipping",
  "lru 0.16.2",
  "lsp-types",

--- a/vtcode-core/Cargo.toml
+++ b/vtcode-core/Cargo.toml
@@ -168,7 +168,8 @@ tokio-stream = { version = "0.1", optional = true }
 [build-dependencies]
 vtcode-config = { path = "../vtcode-config", version = "0.60.5" }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
 
 [[example]]
 name = "anstyle_test"


### PR DESCRIPTION
# Pull Request

## Description

Fix the build on Linux, which is broken due to the optional dependency on libc

Fixes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include any relevant details for your test configuration.

- [X] Rust tests: `cargo test`
- [x] Build: `cargo build`

**Test Configuration**:
* Rust version:
* Operating system:
* Toolchain:

## Checklist:

- [X] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [X] I have performed a self-review of my code

## Additional Context

Add any other context or screenshots about the pull request here.