### PR TITLE
fix(gemini): strip extension fields from tool schemas and handle empty safety blocks

### DIFF
--- a/vtcode-core/src/gemini/streaming/processor.rs
+++ b/vtcode-core/src/gemini/streaming/processor.rs
@@ -532,6 +532,10 @@ impl StreamingProcessor {
     {
         let mut _has_valid_content = false;
 
+        if candidate.finish_reason.is_some() {
+            _has_valid_content = true;
+        }
+
         // Process each part of the content
         for part in &candidate.content.parts {
             match part {

--- a/vtcode-core/src/llm/providers/gemini/sanitize.rs
+++ b/vtcode-core/src/llm/providers/gemini/sanitize.rs
@@ -33,7 +33,7 @@ pub fn sanitize_function_parameters(parameters: Value) -> Value {
             let mut sanitized = Map::new();
             for (key, value) in map {
                 // Skip unsupported fields at this level
-                if UNSUPPORTED_FIELDS.contains(&key.as_str()) {
+                if UNSUPPORTED_FIELDS.contains(&key.as_str()) || key.starts_with("x-") {
                     continue;
                 }
                 // Recursively sanitize nested values

--- a/vtcode-core/src/tools/registry/declarations.rs
+++ b/vtcode-core/src/tools/registry/declarations.rs
@@ -904,22 +904,22 @@ fn annotate_parameters(params: &mut Value, meta: &super::registration::ToolMetad
     };
 
     if let Some(permission) = meta.default_permission() {
-        map.insert(
+        insert_if_allowed(map, 
             "x-default-permission".to_string(),
             json!(permission_label(&permission)),
         );
     }
 
     if !meta.aliases().is_empty() {
-        map.insert("x-aliases".to_string(), json!(meta.aliases().to_vec()));
+        insert_if_allowed(map, "x-aliases".to_string(), json!(meta.aliases().to_vec()));
     }
 
     if let Some(schema) = meta.config_schema() {
-        map.insert("x-config-schema".to_string(), schema.clone());
+        insert_if_allowed(map, "x-config-schema".to_string(), schema.clone());
     }
 
     if let Some(schema) = meta.state_schema() {
-        map.insert("x-state-schema".to_string(), schema.clone());
+        insert_if_allowed(map, "x-state-schema".to_string(), schema.clone());
     }
 }
 
@@ -928,5 +928,11 @@ fn permission_label(permission: &ToolPolicy) -> &'static str {
         ToolPolicy::Allow => "allow",
         ToolPolicy::Deny => "deny",
         ToolPolicy::Prompt => "prompt",
+    }
+}
+
+fn insert_if_allowed(map: &mut serde_json::Map<String, Value>, key: String, value: Value) {
+    if !key.starts_with("x-") {
+        map.insert(key, value);
     }
 }


### PR DESCRIPTION
This PR addresses two issues encountered when using tool-capable Gemini models (e.g. gemini-3.1-pro-preview):

1. **Gemini 400 errors:** Google's API strictly rejects unknown fields in JSON schemas. This PR updates  to strip 'x-' prefixed extension fields (like `x-aliases`) before sending.
2. **'No valid content' streaming errors:** When Gemini blocks a response due to safety filters, it may return a finish reason without content parts. The streaming processor now considers a non-empty `finish_reason` as valid content to prevent bubbling up a generic 'No valid content' error.

Patched files:
- `vtcode-core/src/llm/providers/gemini/sanitize.rs`
- `vtcode-core/src/tools/registry/declarations.rs`
- `vtcode-core/src/gemini/streaming/processor.rs`