### PR TITLE
Expose additional authentication methods in VTCode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ walkdir = "2.5"
 itertools = "0.14.0"
 memchr = "2.7"
 url = "2.5"
-agent-client-protocol = "0.10.4"
+agent-client-protocol = { version = "0.10.4", features = ["unstable_auth_methods"] }
 uuid = "1.23.0"
 ignore = "0.4"
 ring = "0.17"

--- a/vtcode-acp/src/zed/agent/handlers.rs
+++ b/vtcode-acp/src/zed/agent/handlers.rs
@@ -40,9 +40,70 @@ impl acp::Agent for ZedAgent {
         capabilities.mcp_capabilities.sse = false;
         capabilities.load_session = true;
 
+        let auth_methods = vec![
+            // Agent Auth (OAuth)
+            acp::AuthMethod::Agent(
+                acp::AuthMethodAgent::new("oauth-openai", "OpenAI OAuth")
+                    .description("Authenticate with OpenAI via OAuth 2.0 with PKCE"),
+            ),
+            acp::AuthMethod::Agent(
+                acp::AuthMethodAgent::new("oauth-openrouter", "OpenRouter OAuth")
+                    .description("Authenticate with OpenRouter via OAuth 2.0 with PKCE"),
+            ),
+            // Terminal Auth (Interactive Login)
+            acp::AuthMethod::Terminal(
+                acp::AuthMethodTerminal::new("terminal-login", "Terminal Login")
+                    .description("Interactive terminal-based authentication via vtcode login command")
+                    .args(vec!["login".to_string()]),
+            ),
+            // Env Var Auth (API Keys)
+            acp::AuthMethod::EnvVar(acp::AuthMethodEnvVar::new(
+                "env-api-keys",
+                "API Key",
+                vec![
+                    acp::AuthEnvVar::new("OPENAI_API_KEY").label("OpenAI"),
+                    acp::AuthEnvVar::new("ANTHROPIC_API_KEY").label("Anthropic"),
+                    acp::AuthEnvVar::new("GEMINI_API_KEY").label("Google Gemini"),
+                    acp::AuthEnvVar::new("OPENROUTER_API_KEY").label("OpenRouter"),
+                    acp::AuthEnvVar::new("DEEPSEEK_API_KEY").label("DeepSeek"),
+                    acp::AuthEnvVar::new("ZAI_API_KEY").label("Z.AI"),
+                    acp::AuthEnvVar::new("MOONSHOT_API_KEY").label("Moonshot"),
+                    acp::AuthEnvVar::new("MINIMAX_API_KEY").label("MiniMax"),
+                    acp::AuthEnvVar::new("GROQ_API_KEY").label("Groq"),
+                    acp::AuthEnvVar::new("XAI_API_KEY").label("xAI"),
+                    acp::AuthEnvVar::new("COHERE_API_KEY").label("Cohere"),
+                    acp::AuthEnvVar::new("HF_TOKEN").label("Hugging Face"),
+                    acp::AuthEnvVar::new("MISTRAL_API_KEY").label("Mistral"),
+                    acp::AuthEnvVar::new("GOOGLE_API_KEY").label("Google (alt)").optional(true),
+                    acp::AuthEnvVar::new("OLLAMA_API_KEY").label("Ollama").optional(true),
+                    acp::AuthEnvVar::new("LMSTUDIO_API_KEY").label("LM Studio").optional(true),
+                ],
+            )),
+            // Env Var Auth (Base URLs)
+            acp::AuthMethod::EnvVar(acp::AuthMethodEnvVar::new(
+                "env-base-urls",
+                "API Base URL",
+                vec![
+                    acp::AuthEnvVar::new("OPENAI_BASE_URL").label("OpenAI").optional(true),
+                    acp::AuthEnvVar::new("ANTHROPIC_BASE_URL").label("Anthropic").optional(true),
+                    acp::AuthEnvVar::new("GEMINI_BASE_URL").label("Gemini").optional(true),
+                    acp::AuthEnvVar::new("OPENROUTER_BASE_URL").label("OpenRouter").optional(true),
+                    acp::AuthEnvVar::new("DEEPSEEK_BASE_URL").label("DeepSeek").optional(true),
+                    acp::AuthEnvVar::new("ZAI_BASE_URL").label("Z.AI").optional(true),
+                    acp::AuthEnvVar::new("MOONSHOT_BASE_URL").label("Moonshot").optional(true),
+                    acp::AuthEnvVar::new("MINIMAX_BASE_URL").label("MiniMax").optional(true),
+                    acp::AuthEnvVar::new("XAI_BASE_URL").label("xAI").optional(true),
+                    acp::AuthEnvVar::new("HUGGINGFACE_BASE_URL").label("Hugging Face").optional(true),
+                    acp::AuthEnvVar::new("OLLAMA_BASE_URL").label("Ollama").optional(true),
+                    acp::AuthEnvVar::new("LMSTUDIO_BASE_URL").label("LM Studio").optional(true),
+                ],
+            )),
+        ];
+
         Ok(acp::InitializeResponse::new(acp::ProtocolVersion::V1)
             .agent_capabilities(capabilities)
-            .agent_info(agent_implementation_info(self.title.clone())))
+            .agent_info(agent_implementation_info(self.title.clone()))
+            .auth_methods(auth_methods))
     }
 
     async fn authenticate(


### PR DESCRIPTION
# Pull Request

## Description

Implements ACP (Agent Communication Protocol) authentication methods for the Zed agent integration. This exposes authentication capabilities to the ACP host (Zed), allowing users to authenticate via OAuth, interactive terminal login, or API keys/base URLs through environment variables.

**Changes:**
- `vtcode-acp/src/zed/agent/handlers.rs`: Adds `auth_methods` to the `InitializeResponse` in the `initialize` handler, declaring support for:
  - **OAuth (Agent Auth)**: OpenAI and OpenRouter via OAuth 2.0 with PKCE
  - **Terminal Login**: Interactive auth via `vtcode login` command
  - **API Keys (Env Vars)**: 13 providers (OpenAI, Anthropic, Gemini, OpenRouter, DeepSeek, Z.AI, Moonshot, MiniMax, Groq, xAI, Cohere, Hugging Face, Mistral)
  - **Base URLs (Env Vars)**: Optional custom endpoints for 12 providers
- `Cargo.toml`: Enables the `unstable_auth_methods` feature on `agent-client-protocol` to unlock the auth method APIs

This would be needed to make some progress on #621 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include any relevant details for your test configuration.

- [x] Rust tests: `cargo test`
- [x] Linting: `cargo clippy` 
- [x] Formatting: `cargo fmt`
- [x] Build: `cargo build`

**Test Configuration**:
* Rust version: `rustc 1.94.1 (e408947bf 2026-03-25)`
* Operating system: Artix Linux (x86_64)
* Toolchain: `stable-x86_64-unknown-linux-gnu`

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (`cargo test`)
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [x] I have checked my code and corrected any misspellings

## Additional Context

Uses the `unstable_auth_methods` feature flag from `agent-client-protocol` — this API may change in future versions of the crate. However this was necessary to broadcast the supported auth methods via ACP.