### PR TITLE
fix(installer): handle missing release assets and API metadata fallback

### DIFF
--- a/docs/installation/NATIVE_INSTALLERS.md
+++ b/docs/installation/NATIVE_INSTALLERS.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.
 
 ### How It Works
 
-1. Detects OS (macOS/Linux) and architecture (x86_64/aarch64)
+1. Detects OS (macOS/Linux) and architecture
 2. Fetches latest version from GitHub API (or uses specified version)
 3. Downloads release tarball from GitHub Releases
 4. Extracts and installs to `$VTCode_INSTALL_DIR/vtcode`
@@ -38,8 +38,10 @@ This differs from the optional search tools flow:
 ### Supported Platforms
 
 - macOS 10.15+ (Intel & Apple Silicon)
-- Linux x86_64, aarch64
+- Linux x86_64
 - WSL (use install.ps1 for native Windows)
+
+Linux `aarch64` hosts are detected by the installer, but native `aarch64` release artifacts are not published by default in current release workflow.
 
 ---
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = "Stop"
 # Configuration
 $Repo = "vinhnx/vtcode"
 $BinName = "vtcode.exe"
-$GitHubAPI = "https://api.github.com/repos/$Repo/releases/latest"
+$GitHubAPI = "https://api.github.com/repos/$Repo/releases?per_page=10"
 $GitHubReleases = "https://github.com/$Repo/releases/download"
 
 # Logging functions
@@ -50,9 +50,9 @@ if (-not (Test-Path $InstallDir)) {
     New-Item -ItemType Directory -Path $InstallDir -Force > $null
 }
 
-# Fetch latest release from GitHub API
-function Get-LatestRelease {
-    Write-Info "Fetching latest VT Code release from GitHub..."
+# Fetch recent releases from GitHub API
+function Get-RecentReleases {
+    Write-Info "Fetching recent VT Code releases from GitHub..."
     
     try {
         $response = Invoke-RestMethod -Uri $GitHubAPI -ErrorAction Stop
@@ -65,23 +65,53 @@ function Get-LatestRelease {
     }
 }
 
-# Get platform-specific download URL
-function Get-DownloadUrl {
-    param([object]$Release)
-    
-    $ReleaseTag = $Release.tag_name
-    Write-Info "Latest version: $ReleaseTag"
-    
-    # Windows always uses x86_64-pc-windows-msvc
-    $Platform = "x86_64-pc-windows-msvc"
-    $Filename = "vtcode-$ReleaseTag-$Platform.zip"
-    $DownloadUrl = "$GitHubReleases/$ReleaseTag/$Filename"
-    
-    return @{
-        Url = $DownloadUrl
-        Tag = $ReleaseTag
-        Filename = $Filename
+function Get-DownloadFilename {
+    param([string]$ReleaseTag)
+
+    $VersionTag = $ReleaseTag
+    if ($VersionTag.StartsWith("v")) {
+        $VersionTag = $VersionTag.Substring(1)
     }
+    return "vtcode-$VersionTag-x86_64-pc-windows-msvc.zip"
+}
+
+function Test-AssetAvailable {
+    param([string]$Url)
+
+    try {
+        Invoke-WebRequest -Uri $Url -Method Head -ErrorAction Stop > $null
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+# Select latest release that actually has Windows asset
+function Get-DownloadUrl {
+    param([array]$Releases)
+
+    foreach ($Release in $Releases) {
+        $ReleaseTag = $Release.tag_name
+        if ([string]::IsNullOrEmpty($ReleaseTag)) {
+            continue
+        }
+
+        $Filename = Get-DownloadFilename -ReleaseTag $ReleaseTag
+        $DownloadUrl = "$GitHubReleases/$ReleaseTag/$Filename"
+        if (Test-AssetAvailable -Url $DownloadUrl) {
+            Write-Info "Found compatible version: $ReleaseTag"
+            return @{
+                Url = $DownloadUrl
+                Tag = $ReleaseTag
+                Filename = $Filename
+            }
+        }
+    }
+
+    Write-Error "No recent releases include a Windows native binary asset"
+    Write-Info "Use cargo fallback: cargo install vtcode"
+    exit 1
 }
 
 # Download binary with progress
@@ -296,11 +326,11 @@ function Main {
     $TempDir = New-Item -ItemType Directory -Path "$env:TEMP\vtcode-install-$(Get-Random)" -Force
     
     try {
-        # Fetch latest release
-        $Release = Get-LatestRelease
+        # Fetch recent releases
+        $Releases = Get-RecentReleases
         
-        # Get download URL
-        $DownloadInfo = Get-DownloadUrl $Release
+        # Get latest compatible download URL
+        $DownloadInfo = Get-DownloadUrl $Releases
         
         # Download binary
         $ArchivePath = Join-Path $TempDir "vtcode-binary.zip"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -174,13 +174,32 @@ fetch_recent_releases() {
     response=$(cat "$response_file")
     rm -f "$response_file"
 
-    if [[ -z "$response" || "$response" == "[]" ]]; then
-        log_error "Failed to fetch releases info from GitHub API or no releases found"
-        log_info "Ensure you have internet connection and GitHub is accessible"
-        exit 1
+    if [[ -n "$response" && "$response" != "[]" ]]; then
+        echo "$response"
+        return 0
     fi
 
-    echo "$response"
+    return 1
+}
+
+fetch_latest_release_tag_fallback() {
+    local location
+    location=$(curl -fsSIL --connect-timeout 10 "https://github.com/$REPO/releases/latest" \
+        | tr -d '\r' \
+        | awk '/^location:/ {print $2}' \
+        | tail -n1)
+
+    if [[ -z "$location" ]]; then
+        return 1
+    fi
+
+    local tag
+    tag=$(echo "$location" | sed -nE 's|.*/tag/([^/]+)$|\1|p')
+    if [[ -z "$tag" ]]; then
+        return 1
+    fi
+
+    echo "$tag"
 }
 
 # Extract download URL for the detected platform
@@ -467,7 +486,20 @@ main() {
 
     # Fetch recent releases
     local all_releases
-    all_releases=$(fetch_recent_releases)
+    if all_releases=$(fetch_recent_releases); then
+        log_info "Fetched release metadata from GitHub API"
+    else
+        log_warning "Failed to fetch release metadata from GitHub API"
+        log_info "Falling back to the latest release redirect endpoint"
+        local fallback_tag=""
+        fallback_tag=$(fetch_latest_release_tag_fallback || true)
+        if [[ -z "$fallback_tag" ]]; then
+            log_error "Could not resolve a release tag from GitHub"
+            log_info "Ensure github.com is reachable, or install via: cargo install vtcode"
+            exit 1
+        fi
+        all_releases="[{\"tag_name\":\"$fallback_tag\"}]"
+    fi
 
     # Find the most recent release with assets for this platform
     local release_tag=""


### PR DESCRIPTION
## Summary
- make Windows installer select the latest release that actually has the  asset
- make shell installer fall back to GitHub  redirect when Releases API metadata fetch fails
- align native installer docs with currently published default Linux artifacts ()

## Why
Fixes #644 where:
- Windows installer could 404 on latest tag
- WSL/Linux x86_64 install could fail early at metadata fetch despite existing assets
- docs/platform claims were ahead of published assets

## Validation

Note: Tests were not run. Add --test to include them.
For full release quality gate, run: ./scripts/check.sh
