### PR TITLE
fix(install.sh): correct asset filename format in get_download_url

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -218,7 +218,7 @@ get_download_url() {
 
     # Strip 'v' prefix from tag for filename only
     local version_tag="${release_tag#v}"
-    local filename="vtcode-${platform}-v${version_tag}.${file_ext}"
+    local filename="vtcode-${version_tag}-${platform}.${file_ext}"
     echo "${GITHUB_RELEASES}/${release_tag}/${filename}"
 }
 


### PR DESCRIPTION
## Description

The `get_download_url` function in `install.sh` constructed asset filenames in the wrong order, causing the installer to always fail with "No releases with compatible binaries found" even when binaries exist for the platform.

The script was generating:
```
vtcode-{platform}-v{version}.tar.gz
# e.g. vtcode-aarch64-apple-darwin-v0.117.0.tar.gz
```

But actual GitHub release assets follow the format:
```
vtcode-{version}-{platform}.tar.gz
# e.g. vtcode-0.117.0-aarch64-apple-darwin.tar.gz
```

This mismatch caused `check_version_available` to always receive a 404, so every candidate platform was rejected. The fix reverses the order and removes the stray `v` prefix (the script already strips it via `version_tag="${release_tag#v}"`).

Note: `install.ps1` already uses the correct format and is unaffected.

Fixes # (issue number)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually ran the updated `install.sh` on macOS (aarch64-apple-darwin) and confirmed the installer correctly finds, downloads, verifies, and installs the binary.

- [ ] Rust tests: `cargo test`
- [ ] Linting: `cargo clippy`
- [ ] Formatting: `cargo fmt`
- [ ] Build: `cargo build`

**Test Configuration**:
* Operating system: macOS (Apple Silicon, aarch64-apple-darwin)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Additional Context

The one-line fix in `get_download_url`:

```bash
# Before
local filename="vtcode-${platform}-v${version_tag}.${file_ext}"

# After
local filename="vtcode-${version_tag}-${platform}.${file_ext}"
```