### PR TITLE
docs(atlascloud): document validated Atlas model pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,14 +150,14 @@ default_model = "gpt-5.4"
 ```toml
 [agent]
 provider = "atlascloud"
-default_model = "deepseek-ai/deepseek-v4-flash"
+default_model = "deepseek-ai/DeepSeek-V3-0324"
 
 [[custom_providers]]
 name = "atlascloud"
 display_name = "Atlas Cloud"
 base_url = "https://api.atlascloud.ai/v1"
 api_key_env = "ATLASCLOUD_API_KEY"
-model = "deepseek-ai/deepseek-v4-flash"
+model = "deepseek-ai/DeepSeek-V3-0324"
 ```
 
 <p align="center">
@@ -165,6 +165,20 @@ model = "deepseek-ai/deepseek-v4-flash"
 </p>
 
 Other custom OpenAI-compatible providers use the same `[[custom_providers]]` pattern.
+
+Recommended validated Atlas chat model pool examples for `default_model` or
+`vtcode ask --model <model-id>` include:
+
+- `deepseek-ai/DeepSeek-V3-0324`
+- `deepseek-ai/deepseek-r1-0528`
+- `moonshotai/Kimi-K2-Instruct`
+- `Qwen/Qwen3-Coder`
+- `google/gemini-2.5-flash`
+- `openai/gpt-5.2-chat`
+- `anthropic/claude-opus-4.5-20251101`
+- `zai-org/glm-4.7`
+- `minimaxai/minimax-m2.1`
+- `xai/grok-4-0709`
 
 Useful configuration docs:
 

--- a/docs/providers/atlascloud.md
+++ b/docs/providers/atlascloud.md
@@ -22,7 +22,7 @@ Add Atlas Cloud to your workspace `vtcode.toml`:
 ```toml
 [agent]
 provider = "atlascloud"
-default_model = "deepseek-ai/deepseek-v4-flash"
+default_model = "deepseek-ai/DeepSeek-V3-0324"
 reasoning_effort = "low"
 
 [[custom_providers]]
@@ -30,26 +30,20 @@ name = "atlascloud"
 display_name = "Atlas Cloud"
 base_url = "https://api.atlascloud.ai/v1"
 api_key_env = "ATLASCLOUD_API_KEY"
-model = "deepseek-ai/deepseek-v4-flash"
+model = "deepseek-ai/DeepSeek-V3-0324"
 
 # Optional: list available models for the model picker.
 # models = [
-#     "deepseek-ai/deepseek-v4-flash",
-#     "deepseek-ai/deepseek-v4-pro",
 #     "deepseek-ai/DeepSeek-V3-0324",
-#     "deepseek-ai/DeepSeek-V3.1",
 #     "deepseek-ai/deepseek-r1-0528",
-#     "qwen/qwen3.6-35b-a3b",
-#     "qwen/qwen3.6-plus",
-#     "qwen/qwen3.5-122b-a10b",
-#     "qwen/qwen3-coder-next",
-#     "moonshotai/kimi-k2.6",
-#     "moonshotai/kimi-k2.5",
-#     "zai-org/glm-5.1",
-#     "zai-org/glm-5-turbo",
-#     "minimaxai/minimax-m2.7",
-#     "minimaxai/minimax-m2.5",
-#     "kwaipilot/kat-coder-pro-v2",
+#     "moonshotai/Kimi-K2-Instruct",
+#     "Qwen/Qwen3-Coder",
+#     "google/gemini-2.5-flash",
+#     "openai/gpt-5.2-chat",
+#     "anthropic/claude-opus-4.5-20251101",
+#     "zai-org/glm-4.7",
+#     "minimaxai/minimax-m2.1",
+#     "xai/grok-4-0709",
 # ]
 ```
 
@@ -69,16 +63,32 @@ vtcode ask "Summarize this repository"
 ## Model Selection Notes
 
 - Atlas Cloud hosts 300+ models spanning LLM, image, video, audio, and 3D.
-  The complete LLM catalog includes DeepSeek, Qwen, Kimi, GLM, MiniMax,
-  and many more.
-- The recommended default is `deepseek-ai/deepseek-v4-flash` — DeepSeek's
-  latest flash model with a 1M context window and competitive pricing
-  ($0.14/M input tokens).
+  The validated chat pool used in our rollout contains 50 cross-provider model
+  IDs that have already been smoke-tested through Atlas Cloud's OpenAI-compatible
+  route.
+- The recommended default is `deepseek-ai/DeepSeek-V3-0324`, because it is a
+  stable model slug that is already verified across multiple Atlas integrations.
 - Use the `models` field in `[[custom_providers]]` to populate the model picker
   with the exact slugs you have access to. Run `GET /v1/models` against your
   API key to see your full catalog.
 - If your account enables different models, update both `agent.default_model`
   and `[[custom_providers]].model` to the slug returned by Atlas Cloud.
+
+## Validated 50-model pool
+
+The following examples mirror the validated Atlas chat pool used across recent
+Atlas provider rollouts:
+
+- `deepseek-ai/DeepSeek-V3-0324`, `deepseek-ai/deepseek-r1-0528`, `moonshotai/Kimi-K2-Instruct`, `Qwen/Qwen3-Coder`, `Qwen/Qwen3-235B-A22B-Instruct-2507`
+- `deepseek-ai/DeepSeek-V3.1`, `moonshotai/Kimi-K2-Instruct-0905`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-Next-80B-A3B-Thinking`, `Qwen/Qwen3-30B-A3B-Instruct-2507`
+- `deepseek-ai/DeepSeek-V3.1-Terminus`, `deepseek-ai/DeepSeek-V3.2-Exp`, `zai-org/GLM-4.6`, `MiniMaxAI/MiniMax-M2`, `Qwen/Qwen3-VL-235B-A22B-Instruct`
+- `moonshotai/Kimi-K2-Thinking`, `google/gemini-2.5-flash`, `google/gemini-2.5-flash-lite`, `openai/gpt-5.1`, `openai/gpt-5.1-chat`
+- `openai/gpt-4o`, `openai/gpt-4o-mini`, `openai/gpt-4.1`, `openai/gpt-4.1-mini`, `openai/gpt-4.1-nano`
+- `openai/o1`, `openai/o3`, `openai/o3-mini`, `openai/o4-mini`, `anthropic/claude-sonnet-4.5-20250929`
+- `deepseek-ai/deepseek-v3.2`, `openai/gpt-5`, `openai/gpt-5-chat`, `openai/gpt-5-mini`, `openai/gpt-5-nano`
+- `openai/gpt-5.2`, `openai/gpt-5.2-chat`, `google/gemini-2.5-pro`, `anthropic/claude-opus-4.5-20251101`, `google/gemini-3-flash-preview`
+- `zai-org/glm-4.7`, `minimaxai/minimax-m2.1`, `google/gemini-2.0-flash`, `qwen/qwen3-8b`, `qwen/qwen3-235b-a22b-thinking-2507`
+- `qwen/qwen3-vl-235b-a22b-thinking`, `qwen/qwen3-30b-a3b`, `qwen/qwen3-30b-a3b-thinking-2507`, `deepseek-ai/deepseek-ocr`, `xai/grok-4-0709`
 
 ## CLI Examples
 


### PR DESCRIPTION
## Summary
- refresh the Atlas Cloud setup docs to use the validated default model `deepseek-ai/DeepSeek-V3-0324`
- add a validated Atlas chat model pool section so users can see the broader supported model IDs immediately
- keep the existing custom provider workflow unchanged while making the follow-up Atlas rollout explicit

## Why This PR
The original Atlas Cloud PR established the provider path. This follow-up PR makes the scope of supported Atlas chat models visible to users and maintainers without changing runtime behavior.

## Validation
- VS Code diagnostics clean for the touched files
