### PR TITLE
Fix/671 chatgpt OpenAI requests

### DIFF
--- a/src/agent/runloop/unified/turn/context/continuation.rs
+++ b/src/agent/runloop/unified/turn/context/continuation.rs
@@ -131,8 +131,9 @@ fn last_clause_contains_conclusive_marker(lower: &str) -> bool {
         "all set",
     ];
     let last_clause = lower
-        .rfind(|ch| ['.', '!', '\n', '—', '…'].contains(&ch))
-        .map(|idx| lower[idx + 1..].trim_start())
+        .char_indices()
+        .rfind(|(_, ch)| ['.', '!', '\n', '—', '…'].contains(ch))
+        .map(|(idx, ch)| lower[idx + ch.len_utf8()..].trim_start())
         .unwrap_or(lower);
     conclusive_markers
         .iter()

--- a/src/agent/runloop/unified/turn/context/tests.rs
+++ b/src/agent/runloop/unified/turn/context/tests.rs
@@ -102,3 +102,14 @@ fn push_assistant_message_keeps_different_phases_separate() {
     assert_eq!(history[0].phase, Some(uni::AssistantPhase::Commentary));
     assert_eq!(history[1].phase, Some(uni::AssistantPhase::FinalAnswer));
 }
+
+#[test]
+fn interim_continuation_handles_multibyte_clause_boundaries() {
+    let text =
+        "hello! what are we ducking through today—debugging, design, scope clarification, or planning a change?";
+
+    let decision = evaluate_interim_text_continuation(false, false, &[], text);
+
+    assert!(!decision.should_continue);
+    assert_eq!(decision.reason, "non_interim_text");
+}

--- a/vtcode-core/src/llm/providers/openai/provider.rs
+++ b/vtcode-core/src/llm/providers/openai/provider.rs
@@ -830,6 +830,7 @@ impl OpenAIProvider {
             default_response_store: self.responses_store,
             default_responses_include: (!self.responses_include.is_empty())
                 .then_some(self.responses_include.as_slice()),
+            include_encrypted_reasoning: is_chatgpt_backend,
             hosted_shell: self.hosted_shell_for_model(&request.model),
             include_structured_history_in_input: !is_chatgpt_backend,
             preserve_structured_history_on_replay: is_chatgpt_backend,

--- a/vtcode-core/src/llm/providers/openai/provider/tests.rs
+++ b/vtcode-core/src/llm/providers/openai/provider/tests.rs
@@ -460,6 +460,87 @@ async fn chatgpt_backend_uses_oauth_access_token_and_account_header() {
 }
 
 #[tokio::test]
+async fn chatgpt_responses_stream_accepts_empty_final_output_after_text_delta() {
+    let Some(server) = start_mock_server_or_skip().await else {
+        return;
+    };
+    let captured = Arc::new(Mutex::new(None::<Value>));
+    let captured_for_mock = Arc::clone(&captured);
+    let stream_body = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello from stream\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_chatgpt_stream\",\"output\":[],\"usage\":{\"input_tokens\":13,\"output_tokens\":4,\"total_tokens\":17}}}\n\n",
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(move |req: &wiremock::Request| {
+            *captured_for_mock.lock().expect("not poisoned") =
+                Some(serde_json::from_slice(&req.body).expect("valid json"));
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(stream_body)
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = OpenAIProvider::new_with_client(
+        String::new(),
+        Some(sample_chatgpt_auth_handle()),
+        models::openai::GPT_5_5.to_string(),
+        reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("test client"),
+        chatgpt_mock_base_url(&server),
+        TimeoutsConfig::default(),
+    );
+
+    let mut stream = provider
+        .stream(provider::LLMRequest {
+            messages: vec![provider::Message::user("Hello".to_string())],
+            model: models::openai::GPT_5_5.to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("stream should start");
+    let mut text = String::new();
+    let mut completed = None;
+    while let Some(event) = stream.next().await {
+        match event.expect("stream event should parse") {
+            provider::LLMStreamEvent::Token { delta } => text.push_str(&delta),
+            provider::LLMStreamEvent::Completed { response } => {
+                completed = Some(*response);
+                break;
+            }
+            provider::LLMStreamEvent::Reasoning { .. }
+            | provider::LLMStreamEvent::ReasoningSignature { .. }
+            | provider::LLMStreamEvent::ReasoningStage { .. } => {}
+        }
+    }
+
+    let response = completed.expect("completion event should be emitted");
+    assert_eq!(text, "hello from stream");
+    assert_eq!(response.content.as_deref(), Some("hello from stream"));
+    assert_eq!(response.request_id.as_deref(), Some("resp_chatgpt_stream"));
+    let usage = response.usage.expect("final usage should be preserved");
+    assert_eq!(usage.prompt_tokens, 13);
+    assert_eq!(usage.completion_tokens, 4);
+    assert_eq!(usage.total_tokens, 17);
+
+    let payload = captured
+        .lock()
+        .expect("not poisoned")
+        .clone()
+        .expect("payload captured");
+    assert_eq!(payload.get("store").and_then(Value::as_bool), Some(false));
+    assert_eq!(
+        payload.get("include").and_then(Value::as_array),
+        Some(&vec![json!("reasoning.encrypted_content")])
+    );
+}
+
+#[tokio::test]
 async fn external_chatgpt_auth_retries_with_refreshed_tokens_after_401() {
     let Some(server) = start_mock_server_or_skip().await else {
         return;
@@ -2191,6 +2272,42 @@ fn chatgpt_backend_forces_store_false_and_omits_output_sampling_cache() {
         .convert_to_openai_responses_format(&request)
         .expect("should succeed");
     assert_absent(&payload2, "sampling_parameters");
+}
+
+#[test]
+fn chatgpt_backend_includes_encrypted_reasoning_and_preserves_configured_includes() {
+    let provider = chatgpt_backend_provider(models::openai::GPT_5_5);
+    let payload = responses_payload_for(models::openai::GPT_5_5, &provider);
+    assert_eq!(
+        payload.get("include").and_then(Value::as_array),
+        Some(&vec![json!("reasoning.encrypted_content")])
+    );
+
+    let provider = OpenAIProvider::from_config(
+        Some(String::new()),
+        Some(sample_chatgpt_auth_handle()),
+        Some(models::openai::GPT_5_5.to_string()),
+        None,
+        None,
+        None,
+        None,
+        Some(OpenAIConfig {
+            responses_include: vec![
+                "output_text.annotations".to_string(),
+                " reasoning.encrypted_content ".to_string(),
+            ],
+            ..Default::default()
+        }),
+        None,
+    );
+    let payload = responses_payload_for(models::openai::GPT_5_5, &provider);
+    assert_eq!(
+        payload.get("include").and_then(Value::as_array),
+        Some(&vec![
+            json!("output_text.annotations"),
+            json!("reasoning.encrypted_content"),
+        ])
+    );
 }
 
 #[test]

--- a/vtcode-core/src/llm/providers/openai/request_builder.rs
+++ b/vtcode-core/src/llm/providers/openai/request_builder.rs
@@ -86,6 +86,7 @@ pub(crate) struct ResponsesRequestContext<'a> {
     pub default_service_tier: Option<&'a str>,
     pub default_response_store: Option<bool>,
     pub default_responses_include: Option<&'a [String]>,
+    pub include_encrypted_reasoning: bool,
     pub hosted_shell: Option<&'a OpenAIHostedShellConfig>,
     pub include_structured_history_in_input: bool,
     pub preserve_structured_history_on_replay: bool,
@@ -144,6 +145,15 @@ fn default_reasoning_effort_for_model(model: &str) -> Option<ReasoningEffortLeve
 
 fn supports_text_verbosity(model: &str) -> bool {
     TEXT_VERBOSITY_MODELS.contains(&model)
+}
+
+fn push_unique_include(include_values: &mut Vec<String>, field: &str) {
+    let field = field.trim();
+    if field.is_empty() || include_values.iter().any(|value| value == field) {
+        return;
+    }
+
+    include_values.push(field.to_string());
 }
 
 fn default_text_verbosity_for_model(model: &str) -> Option<VerbosityLevel> {
@@ -436,20 +446,21 @@ pub(crate) fn build_responses_request(
         openai_request["store"] = json!(store);
     }
 
+    let mut include_values = Vec::new();
     if let Some(include_fields) = request
         .responses_include
         .as_deref()
         .or(ctx.default_responses_include)
     {
-        let include_values: Vec<String> = include_fields
-            .iter()
-            .map(|field| field.trim())
-            .filter(|field| !field.is_empty())
-            .map(ToOwned::to_owned)
-            .collect();
-        if !include_values.is_empty() {
-            openai_request["include"] = json!(include_values);
+        for field in include_fields {
+            push_unique_include(&mut include_values, field);
         }
+    }
+    if ctx.include_encrypted_reasoning {
+        push_unique_include(&mut include_values, "reasoning.encrypted_content");
+    }
+    if !include_values.is_empty() {
+        openai_request["include"] = json!(include_values);
     }
 
     if let Some(context_management) = &request.context_management {

--- a/vtcode-core/src/llm/providers/openai/stream_decoder.rs
+++ b/vtcode-core/src/llm/providers/openai/stream_decoder.rs
@@ -25,6 +25,83 @@ fn strip_reasoning_for_model(
     response
 }
 
+fn streamed_response_is_usable(response: &provider::LLMResponse) -> bool {
+    response
+        .content
+        .as_deref()
+        .is_some_and(|content| !content.is_empty())
+        || response
+            .tool_calls
+            .as_ref()
+            .is_some_and(|tool_calls| !tool_calls.is_empty())
+        || response
+            .reasoning
+            .as_deref()
+            .is_some_and(|reasoning| !reasoning.is_empty())
+        || response
+            .reasoning_details
+            .as_ref()
+            .is_some_and(|details| !details.is_empty())
+}
+
+fn final_response_output_is_empty(final_response: &Value) -> bool {
+    final_response
+        .get("output")
+        .and_then(Value::as_array)
+        .is_some_and(Vec::is_empty)
+}
+
+fn merge_final_response_metadata(
+    response: &mut provider::LLMResponse,
+    final_response: &Value,
+    include_cached_prompt_metrics: bool,
+) {
+    if let Some(usage_value) = final_response.get("usage") {
+        let cached_prompt_tokens = if include_cached_prompt_metrics {
+            usage_value
+                .get("prompt_tokens_details")
+                .and_then(|details| details.get("cached_tokens"))
+                .or_else(|| usage_value.get("prompt_cache_hit_tokens"))
+                .and_then(Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+        } else {
+            None
+        };
+
+        response.usage = Some(provider::Usage {
+            prompt_tokens: usage_value
+                .get("input_tokens")
+                .or_else(|| usage_value.get("prompt_tokens"))
+                .and_then(Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+                .unwrap_or(0),
+            completion_tokens: usage_value
+                .get("output_tokens")
+                .or_else(|| usage_value.get("completion_tokens"))
+                .and_then(Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+                .unwrap_or(0),
+            total_tokens: usage_value
+                .get("total_tokens")
+                .and_then(Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+                .unwrap_or(0),
+            cached_prompt_tokens,
+            cache_creation_tokens: None,
+            cache_read_tokens: None,
+            iterations: None,
+        });
+    }
+
+    if let Some(request_id) = final_response
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| final_response.get("request_id").and_then(Value::as_str))
+    {
+        response.request_id = Some(request_id.to_string());
+    }
+}
+
 pub(crate) fn create_chat_stream(
     response: reqwest::Response,
     model: String,
@@ -255,9 +332,19 @@ pub(crate) fn create_responses_stream(
             }
         };
 
-        let mut response = parse_responses_payload(response_value, model.clone(), include_metrics)?;
-
         let final_aggregator_response = aggregator.finalize();
+        let mut response = match parse_responses_payload(response_value.clone(), model.clone(), include_metrics) {
+            Ok(response) => response,
+            Err(_)
+                if final_response_output_is_empty(&response_value)
+                    && streamed_response_is_usable(&final_aggregator_response) =>
+            {
+                let mut response = final_aggregator_response.clone();
+                merge_final_response_metadata(&mut response, &response_value, include_metrics);
+                response
+            }
+            Err(err) => Err(err)?,
+        };
 
         if response.content.is_none() {
             response.content = final_aggregator_response.content;

--- a/vtcode-core/src/llm/providers/shared/responses_stream.rs
+++ b/vtcode-core/src/llm/providers/shared/responses_stream.rs
@@ -171,7 +171,18 @@ where
     fn finish(self) -> Result<Vec<NormalizedStreamEvent>, LLMError> {
         let streamed = self.aggregator.finalize();
         let mut response = if let Some(final_response) = self.final_response {
-            (self.parse_final_response)(final_response)?
+            match (self.parse_final_response)(final_response.clone()) {
+                Ok(response) => response,
+                Err(_)
+                    if final_response_output_is_empty(&final_response)
+                        && streamed_response_is_usable(&streamed) =>
+                {
+                    let mut response = streamed.clone();
+                    merge_final_response_metadata(&mut response, &final_response);
+                    response
+                }
+                Err(err) => return Err(err),
+            }
         } else {
             streamed.clone()
         };
@@ -313,6 +324,32 @@ where
     Box::pin(stream)
 }
 
+fn streamed_response_is_usable(response: &LLMResponse) -> bool {
+    response
+        .content
+        .as_deref()
+        .is_some_and(|content| !content.is_empty())
+        || response
+            .tool_calls
+            .as_ref()
+            .is_some_and(|tool_calls| !tool_calls.is_empty())
+        || response
+            .reasoning
+            .as_deref()
+            .is_some_and(|reasoning| !reasoning.is_empty())
+        || response
+            .reasoning_details
+            .as_ref()
+            .is_some_and(|details| !details.is_empty())
+}
+
+fn final_response_output_is_empty(final_response: &Value) -> bool {
+    final_response
+        .get("output")
+        .and_then(Value::as_array)
+        .is_some_and(Vec::is_empty)
+}
+
 fn merge_streamed_response(response: &mut LLMResponse, streamed: LLMResponse) {
     if response.content.as_deref().unwrap_or_default().is_empty() {
         response.content = streamed.content;
@@ -351,6 +388,47 @@ fn merge_streamed_response(response: &mut LLMResponse, streamed: LLMResponse) {
     if response.organization_id.is_none() {
         response.organization_id = streamed.organization_id;
     }
+}
+
+fn merge_final_response_metadata(response: &mut LLMResponse, final_response: &Value) {
+    if let Some(usage) = parse_responses_usage(final_response) {
+        response.usage = Some(usage);
+    }
+
+    if let Some(request_id) = final_response
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| final_response.get("request_id").and_then(Value::as_str))
+    {
+        response.request_id = Some(request_id.to_string());
+    }
+}
+
+fn parse_responses_usage(final_response: &Value) -> Option<crate::llm::provider::Usage> {
+    let usage_value = final_response.get("usage")?;
+    Some(crate::llm::provider::Usage {
+        prompt_tokens: usage_value
+            .get("input_tokens")
+            .or_else(|| usage_value.get("prompt_tokens"))
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0),
+        completion_tokens: usage_value
+            .get("output_tokens")
+            .or_else(|| usage_value.get("completion_tokens"))
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0),
+        total_tokens: usage_value
+            .get("total_tokens")
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0),
+        cached_prompt_tokens: None,
+        cache_creation_tokens: None,
+        cache_read_tokens: None,
+        iterations: None,
+    })
 }
 
 fn extract_error_message(payload: &Value) -> Option<String> {
@@ -447,6 +525,55 @@ mod tests {
             [NormalizedStreamEvent::Done { response }]
                 if response.content.as_deref() == Some("hello")
         ));
+    }
+
+    #[test]
+    fn empty_final_response_uses_streamed_text_and_preserves_metadata() {
+        let mut processor = ResponsesNormalizedStreamProcessor::new(options(), |value| {
+            let output = value
+                .get("output")
+                .and_then(Value::as_array)
+                .ok_or_else(|| provider_error("TestProvider", "missing output"))?;
+            if output.is_empty() {
+                return Err(provider_error("TestProvider", "No output in response"));
+            }
+            parse_response(value)
+        });
+
+        processor
+            .handle_payload(json!({
+                "type": "response.output_text.delta",
+                "delta": "streamed answer"
+            }))
+            .expect("text delta should parse");
+        processor
+            .handle_payload(json!({
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_streamed",
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 11,
+                        "output_tokens": 7,
+                        "total_tokens": 18
+                    }
+                }
+            }))
+            .expect("completed event should parse");
+
+        let finished = processor.finish().expect("finish should succeed");
+        let [
+            NormalizedStreamEvent::Usage { usage },
+            NormalizedStreamEvent::Done { response },
+        ] = finished.as_slice()
+        else {
+            panic!("expected usage then done");
+        };
+        assert_eq!(usage.prompt_tokens, 11);
+        assert_eq!(usage.completion_tokens, 7);
+        assert_eq!(usage.total_tokens, 18);
+        assert_eq!(response.content.as_deref(), Some("streamed answer"));
+        assert_eq!(response.request_id.as_deref(), Some("resp_streamed"));
     }
 
     #[test]

--- a/vtcode-core/src/tools/file_ops/tool.rs
+++ b/vtcode-core/src/tools/file_ops/tool.rs
@@ -97,6 +97,13 @@ impl FileOpsTool {
 impl Tool for FileOpsTool {
     async fn execute(&self, args: Value) -> Result<Value> {
         let mut input: ListInput = deserialize_tool_args(&args, "list_files")?;
+        if input
+            .mode
+            .as_deref()
+            .is_some_and(|mode| mode.trim().is_empty())
+        {
+            input.mode = None;
+        }
 
         // Standard path extraction from args (handles aliases)
         let path_args: PathArgs = serde_json::from_value(args).unwrap_or(PathArgs {
@@ -127,7 +134,13 @@ impl Tool for FileOpsTool {
             input.mode = Some("recursive".to_string());
         }
 
-        let raw_mode = input.mode.as_deref().unwrap_or("list").trim().to_string();
+        let raw_mode = input
+            .mode
+            .as_deref()
+            .map(str::trim)
+            .filter(|mode| !mode.is_empty())
+            .unwrap_or("list")
+            .to_string();
         let mode = Self::normalize_list_mode(&raw_mode).unwrap_or(raw_mode.as_str());
         input.mode = Some(mode.to_string());
 
@@ -296,5 +309,54 @@ mod tests {
         let items = result["items"].as_array().expect("items array");
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["path"], json!("src/lib.rs"));
+    }
+
+    #[tokio::test]
+    async fn blank_mode_defaults_to_basic_list() {
+        let temp_dir = TempDir::new().expect("workspace tempdir");
+        fs::create_dir_all(temp_dir.path().join("src")).expect("create src");
+        fs::write(temp_dir.path().join("src/lib.rs"), "pub fn lib() {}\n").expect("write lib");
+
+        let grep_manager = Arc::new(GrepSearchManager::new(temp_dir.path().to_path_buf()));
+        let file_ops = FileOpsTool::new(temp_dir.path().to_path_buf(), grep_manager);
+
+        let result = file_ops
+            .execute(json!({
+                "path": "src",
+                "mode": "",
+                "pattern": "*.rs"
+            }))
+            .await
+            .expect("blank mode should behave like missing mode");
+
+        assert_eq!(result["mode"], json!("list"));
+        let items = result["items"].as_array().expect("items array");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["path"], json!("src/lib.rs"));
+    }
+
+    #[tokio::test]
+    async fn blank_mode_allows_recursive_glob_promotion() {
+        let temp_dir = TempDir::new().expect("workspace tempdir");
+        fs::create_dir_all(temp_dir.path().join("src/nested")).expect("create nested src");
+        fs::write(temp_dir.path().join("src/nested/lib.rs"), "pub fn lib() {}\n")
+            .expect("write lib");
+
+        let grep_manager = Arc::new(GrepSearchManager::new(temp_dir.path().to_path_buf()));
+        let file_ops = FileOpsTool::new(temp_dir.path().to_path_buf(), grep_manager);
+
+        let result = file_ops
+            .execute(json!({
+                "path": "src",
+                "mode": "",
+                "pattern": "**/*.rs"
+            }))
+            .await
+            .expect("blank mode should still allow recursive glob promotion");
+
+        assert_eq!(result["mode"], json!("recursive"));
+        let items = result["items"].as_array().expect("items array");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["path"], json!("src/nested/lib.rs"));
     }
 }

--- a/vtcode-core/tests/unified_search_preflight_aliases.rs
+++ b/vtcode-core/tests/unified_search_preflight_aliases.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde_json::json;
+use std::fs;
 use tempfile::TempDir;
 use vtcode_core::config::constants::tools;
 use vtcode_core::tools::ToolRegistry;
@@ -109,5 +110,35 @@ async fn preflight_accepts_unified_search_with_case_variant_keys() -> Result<()>
     )?;
 
     assert_eq!(outcome.normalized_tool_name, tools::UNIFIED_SEARCH);
+    Ok(())
+}
+
+#[tokio::test]
+async fn unified_search_list_with_blank_mode_executes_default_list() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    fs::create_dir_all(temp_dir.path().join("src"))?;
+    fs::write(temp_dir.path().join("src/lib.rs"), "pub fn lib() {}\n")?;
+    fs::write(temp_dir.path().join("src/readme.md"), "# readme\n")?;
+    let registry = ToolRegistry::new(temp_dir.path().to_path_buf()).await;
+
+    let args = json!({
+        "action": "list",
+        "mode": "",
+        "path": "src",
+        "pattern": "*.rs"
+    });
+
+    let outcome = registry.preflight_validate_call(tools::UNIFIED_SEARCH, &args)?;
+    assert_eq!(outcome.normalized_tool_name, tools::UNIFIED_SEARCH);
+
+    let result = registry
+        .execute_tool_ref(tools::UNIFIED_SEARCH, &args)
+        .await?;
+    assert_eq!(result["mode"], json!("list"));
+    assert_eq!(result["pattern"], json!("*.rs"));
+
+    let items = result["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["path"], json!("src/lib.rs"));
     Ok(())
 }


### PR DESCRIPTION
# Pull Request

## Description

Fixes ChatGPT-backed OpenAI Responses streaming when the final `response.completed` payload contains an empty `output` array even though usable text/tool/reasoning deltas were already streamed.

This PR also fixes two issues exposed while testing that path locally:
- A runloop panic when continuation detection sliced after multibyte delimiters such as `—`.
- `unified_search action=list` failing when OpenAI emitted optional schema fields with `mode=""`.

Fixes #671

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Rust tests: targeted `cargo test` commands
- [ ] Linting: `cargo clippy`
- [ ] Formatting: targeted rustfmt / `git diff --check`
- [x] Build: `cargo build --locked`

Tested with:

```bash
cargo build --locked
cargo test -p vtcode-core --locked empty_final_response_uses_streamed_text_and_preserves_metadata
cargo test -p vtcode-core --locked chatgpt_backend_includes_encrypted_reasoning_and_preserves_configured_includes
cargo test -p vtcode-core --locked chatgpt_responses_stream_accepts_empty_final_output_after_text_delta
cargo test -p vtcode-core --locked blank_mode_defaults_to_basic_list
cargo test -p vtcode-core --locked blank_mode_allows_recursive_glob_promotion
cargo test -p vtcode-core --test unified_search_preflight_aliases unified_search_list_with_blank_mode_executes_default_list --locked
cargo test --test cache_e2e_tests test_directory_caching --locked
git diff --check
```

Also smoke-tested locally with ChatGPT auth using `gpt-5.5`.

**Test Configuration**:
* Rust version: `rustc 1.95.0`
* Operating system: Artix Linux, kernel `7.0.10-artix1-1`, x86_64
* Toolchain: system Rust toolchain, `x86_64-unknown-linux-gnu`

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`cargo test`)
- [ ] I have run `cargo clippy` and addressed any issues
- [ ] I have run `cargo fmt` to ensure proper formatting
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the `CHANGELOG.md` if this change affects the user-facing behavior
- [x] I have checked my code and corrected any misspellings

## Additional Context

This was tested against the ChatGPT subscription auth path, not just the OpenAI API-key path. The core issue was that streamed deltas could produce a usable assistant response, while the final Responses API payload still had an empty `output` array. The streaming path now falls back to the accumulated streamed response in that case while preserving final metadata such as response id and usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text processing to correctly handle multi-byte characters (em dashes, ellipsis) in clause boundaries.
  * Improved streaming response handling to use previously received content when final responses have empty output.

* **New Features**
  * Added encrypted reasoning support for ChatGPT responses.

* **Tests**
  * Added test coverage for multi-byte character boundaries in text processing.
  * Added integration tests for ChatGPT response streaming behavior.
  * Added tests for file operation mode parameter handling with blank values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->