### PR TITLE
Fix/memory envelope

### DIFF
--- a/src/agent/runloop/unified/session_setup/types.rs
+++ b/src/agent/runloop/unified/session_setup/types.rs
@@ -22,7 +22,6 @@ use vtcode_core::tools::ApprovalRecorder;
 use vtcode_core::tools::{ToolRegistry, ToolResultCache};
 use vtcode_core::utils::ansi::AnsiRenderer;
 use vtcode_core::utils::session_archive::SessionArchive;
-use vtcode_core::utils::session_archive::session_workspace_path;
 use vtcode_ui::tui::app::{InlineHandle, InlineHeaderContext, InlineSession};
 
 use crate::updater::{StartupUpdateCheck, StartupUpdateNotice};
@@ -116,14 +115,84 @@ pub(crate) async fn build_conversation_history_from_resume(
         return Vec::new();
     };
 
-    let mut history = session.history().to_vec();
-    if let Some(workspace_root) = session_workspace_path(session.listing()) {
-        crate::agent::runloop::unified::turn::compaction::inject_latest_memory_envelope(
-            &workspace_root,
-            &session.identifier(),
-            &mut history,
-        );
-    }
+    session.history().to_vec()
+}
 
-    history
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+    use vtcode_core::core::threads::ArchivedSessionIntent;
+    use vtcode_core::llm::provider::MessageRole;
+    use vtcode_core::utils::session_archive::{
+        SessionArchiveMetadata, SessionListing, SessionMessage, SessionSnapshot,
+    };
+
+    #[tokio::test]
+    async fn plain_resume_with_full_history_does_not_inject_latest_memory_envelope() {
+        let temp = tempdir().expect("tempdir");
+        let history_dir = temp.path().join(".vtcode").join("history");
+        fs::create_dir_all(&history_dir).expect("history dir");
+        fs::write(
+            history_dir.join("resume-session.memory.json"),
+            serde_json::json!({
+                "session_id": "resume-session",
+                "schema_version": 2,
+                "summary": "Persisted summary that must not be prepended",
+                "task_summary": null,
+                "spec_summary": null,
+                "evaluation_summary": null,
+                "grounded_facts": [],
+                "touched_files": [],
+                "history_artifact_path": null,
+                "generated_at": "2026-03-14T00:00:00Z"
+            })
+            .to_string(),
+        )
+        .expect("write envelope");
+
+        let listing = SessionListing {
+            path: PathBuf::from("/tmp/resume-session.json"),
+            snapshot: SessionSnapshot {
+                metadata: SessionArchiveMetadata::new(
+                    "workspace",
+                    temp.path().to_string_lossy(),
+                    "model",
+                    "provider",
+                    "theme",
+                    "medium",
+                ),
+                started_at: Utc::now(),
+                ended_at: Utc::now(),
+                total_messages: 2,
+                distinct_tools: Vec::new(),
+                transcript: Vec::new(),
+                messages: vec![
+                    SessionMessage::new(MessageRole::User, "saved request"),
+                    SessionMessage::new(MessageRole::Assistant, "saved answer"),
+                ],
+                progress: None,
+                error_logs: Vec::new(),
+            },
+        };
+        let resume = ResumeSession::from_listing(&listing, ArchivedSessionIntent::ResumeInPlace);
+
+        let history = build_conversation_history_from_resume(Some(&resume)).await;
+
+        assert_eq!(history.as_slice(), resume.history());
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].role, MessageRole::User);
+        assert_eq!(history[0].content.as_text(), "saved request");
+        assert_eq!(history[1].role, MessageRole::Assistant);
+        assert_eq!(history[1].content.as_text(), "saved answer");
+        assert!(history.iter().all(|message| {
+            !message
+                .content
+                .as_text()
+                .contains("[Session Memory Envelope]")
+        }));
+    }
 }

--- a/src/agent/runloop/unified/turn/compaction/memory_envelope.rs
+++ b/src/agent/runloop/unified/turn/compaction/memory_envelope.rs
@@ -311,7 +311,7 @@ pub(crate) fn refresh_session_memory_envelope(
     workspace_root: &Path,
     session_id: &str,
     vt_cfg: Option<&VTCodeConfig>,
-    history: &mut Vec<Message>,
+    history: &[Message],
     session_stats: &SessionStats,
     envelope_update: Option<&SessionMemoryEnvelopeUpdate>,
 ) -> Result<Option<SessionMemoryEnvelope>> {

--- a/src/agent/runloop/unified/turn/compaction/memory_envelope.rs
+++ b/src/agent/runloop/unified/turn/compaction/memory_envelope.rs
@@ -346,6 +346,5 @@ pub(crate) fn refresh_session_memory_envelope(
     let path = latest_memory_envelope_path_for_session(workspace_root, session_id)
         .unwrap_or_else(|| default_memory_envelope_path_for_session(workspace_root, session_id));
     write_memory_envelope_to_path(&path, &envelope)?;
-    apply_memory_envelope(history, &envelope, MemoryEnvelopePlacement::Start);
     Ok(Some(envelope))
 }

--- a/src/agent/runloop/unified/turn/compaction/tests.rs
+++ b/src/agent/runloop/unified/turn/compaction/tests.rs
@@ -1114,7 +1114,7 @@ fn refresh_session_memory_envelope_merges_existing_continuity_fields() {
     )
     .expect("write envelope");
 
-    let mut history = vec![
+    let history = vec![
         Message::user("Continue the compaction work.".to_string()),
         Message::assistant("I will update the local compaction path.".to_string()),
     ];
@@ -1138,7 +1138,7 @@ fn refresh_session_memory_envelope_merges_existing_continuity_fields() {
         temp.path(),
         "session-alpha",
         Some(&VTCodeConfig::default()),
-        &mut history,
+        &history,
         &session_stats,
         Some(&update),
     )
@@ -1220,7 +1220,7 @@ fn refresh_session_memory_envelope_prefers_structured_verify_metadata() {
     )
     .expect("write task");
 
-    let mut history = vec![Message::user("Continue the compaction work.".to_string())];
+    let history = vec![Message::user("Continue the compaction work.".to_string())];
     let original_history = history.clone();
     let session_stats = SessionStats::default();
 
@@ -1228,7 +1228,7 @@ fn refresh_session_memory_envelope_prefers_structured_verify_metadata() {
         temp.path(),
         "session-alpha",
         Some(&VTCodeConfig::default()),
-        &mut history,
+        &history,
         &session_stats,
         None,
     )
@@ -1305,7 +1305,7 @@ fn refresh_session_memory_envelope_is_throttled_when_nothing_changes() {
     )
     .expect("write envelope");
 
-    let mut history = vec![Message::user("Continue the compaction work.".to_string())];
+    let history = vec![Message::user("Continue the compaction work.".to_string())];
     let original_history = history.clone();
     let session_stats = SessionStats::default();
 
@@ -1316,7 +1316,7 @@ fn refresh_session_memory_envelope_is_throttled_when_nothing_changes() {
         temp.path(),
         "session-alpha",
         Some(&VTCodeConfig::default()),
-        &mut history,
+        &history,
         &session_stats,
         None,
     )
@@ -1332,7 +1332,7 @@ fn refresh_session_memory_envelope_is_throttled_when_nothing_changes() {
         temp.path(),
         "session-alpha",
         Some(&VTCodeConfig::default()),
-        &mut history,
+        &history,
         &session_stats,
         None,
     )
@@ -1367,7 +1367,7 @@ fn refresh_session_memory_envelope_summary_is_concise() {
     )
     .expect("write task");
 
-    let mut history = vec![
+    let history = vec![
         Message::user("Check the log and reduce repeated duplicated work.".to_string()),
         Message::assistant("I will audit the agent loop.".to_string()),
         Message::tool_response(
@@ -1382,7 +1382,7 @@ fn refresh_session_memory_envelope_summary_is_concise() {
         temp.path(),
         "session-alpha",
         Some(&VTCodeConfig::default()),
-        &mut history,
+        &history,
         &session_stats,
         None,
     )

--- a/src/agent/runloop/unified/turn/compaction/tests.rs
+++ b/src/agent/runloop/unified/turn/compaction/tests.rs
@@ -1118,6 +1118,7 @@ fn refresh_session_memory_envelope_merges_existing_continuity_fields() {
         Message::user("Continue the compaction work.".to_string()),
         Message::assistant("I will update the local compaction path.".to_string()),
     ];
+    let original_history = history.clone();
     let mut session_stats = SessionStats::default();
     session_stats.record_touched_files(["src/new.rs".to_string()]);
 
@@ -1191,13 +1192,17 @@ fn refresh_session_memory_envelope_merges_existing_continuity_fields() {
     );
     assert!(envelope.touched_files.contains(&"src/new.rs".to_string()));
     assert!(envelope.touched_files.contains(&"src/child.rs".to_string()));
-    assert!(
-        history[0]
-            .content
-            .as_text()
-            .contains("[Session Memory Envelope]")
+    assert_eq!(
+        history, original_history,
+        "ordinary refresh should not mutate live history"
     );
-    assert!(history[0].content.as_text().contains("Verification Status"));
+
+    let persisted_path = latest_memory_envelope_path_for_session(temp.path(), "session-alpha")
+        .expect("persisted envelope path");
+    let persisted: SessionMemoryEnvelope =
+        serde_json::from_str(&fs::read_to_string(persisted_path).expect("read persisted envelope"))
+            .expect("deserialize persisted envelope");
+    assert_eq!(persisted, envelope);
 }
 
 #[test]
@@ -1216,6 +1221,7 @@ fn refresh_session_memory_envelope_prefers_structured_verify_metadata() {
     .expect("write task");
 
     let mut history = vec![Message::user("Continue the compaction work.".to_string())];
+    let original_history = history.clone();
     let session_stats = SessionStats::default();
 
     let envelope = super::refresh_session_memory_envelope(
@@ -1235,17 +1241,29 @@ fn refresh_session_memory_envelope_prefers_structured_verify_metadata() {
             "- cargo check -p vtcode\n- cargo test -p vtcode --bin vtcode agent::runloop::unified::turn::compaction::tests::refresh_session_memory_envelope_prefers_structured_verify_metadata -- --exact"
         )
     );
-    assert!(history[0].content.as_text().contains("Verification Status"));
-    assert!(
-        history[0]
-            .content
-            .as_text()
-            .contains("- cargo check -p vtcode")
+    assert_eq!(
+        history, original_history,
+        "ordinary refresh should not mutate live history"
     );
-    assert!(history[0]
-        .content
-        .as_text()
-        .contains("- cargo test -p vtcode --bin vtcode agent::runloop::unified::turn::compaction::tests::refresh_session_memory_envelope_prefers_structured_verify_metadata -- --exact"));
+    let persisted_path = latest_memory_envelope_path_for_session(temp.path(), "session-alpha")
+        .expect("persisted envelope path");
+    let persisted: SessionMemoryEnvelope =
+        serde_json::from_str(&fs::read_to_string(persisted_path).expect("read persisted envelope"))
+            .expect("deserialize persisted envelope");
+    assert_eq!(persisted, envelope);
+    assert!(
+        persisted
+            .verification_summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains("- cargo check -p vtcode"))
+    );
+    let focused_regression = "- cargo test -p vtcode --bin vtcode agent::runloop::unified::turn::compaction::tests::refresh_session_memory_envelope_prefers_structured_verify_metadata -- --exact";
+    assert!(
+        persisted
+            .verification_summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains(focused_regression))
+    );
 }
 
 #[test]
@@ -1288,6 +1306,7 @@ fn refresh_session_memory_envelope_is_throttled_when_nothing_changes() {
     .expect("write envelope");
 
     let mut history = vec![Message::user("Continue the compaction work.".to_string())];
+    let original_history = history.clone();
     let session_stats = SessionStats::default();
 
     // First refresh with matching state should still write once because the
@@ -1303,6 +1322,10 @@ fn refresh_session_memory_envelope_is_throttled_when_nothing_changes() {
     )
     .expect("refresh succeeds");
     assert!(first.is_some(), "first refresh should produce an envelope");
+    assert_eq!(
+        history, original_history,
+        "ordinary refresh should not mutate live history"
+    );
     let history_len_after_first = history.len();
 
     let second = super::refresh_session_memory_envelope(
@@ -1322,6 +1345,10 @@ fn refresh_session_memory_envelope_is_throttled_when_nothing_changes() {
         history.len(),
         history_len_after_first,
         "history should not grow when refresh is throttled"
+    );
+    assert_eq!(
+        history, original_history,
+        "throttled refresh should leave live history unchanged"
     );
 }
 
@@ -1348,6 +1375,7 @@ fn refresh_session_memory_envelope_summary_is_concise() {
             json!({"error": "some tool error"}).to_string(),
         ),
     ];
+    let original_history = history.clone();
     let session_stats = SessionStats::default();
 
     let envelope = super::refresh_session_memory_envelope(
@@ -1373,6 +1401,10 @@ fn refresh_session_memory_envelope_summary_is_concise() {
     assert!(
         envelope.summary.contains("Audit agent loop"),
         "summary should reference the objective"
+    );
+    assert_eq!(
+        history, original_history,
+        "ordinary refresh should not mutate live history"
     );
 }
 

--- a/src/agent/runloop/unified/turn/session_loop_runner/mod.rs
+++ b/src/agent/runloop/unified/turn/session_loop_runner/mod.rs
@@ -1014,7 +1014,7 @@ pub(super) async fn run_single_agent_loop_unified_impl(
                         config.workspace.as_path(),
                         &harness_snapshot.session_id,
                         vt_cfg.as_ref(),
-                        &mut runtime.state.messages,
+                        &runtime.state.messages,
                         &session_stats,
                         None,
                     )

--- a/src/agent/runloop/unified/turn/session_loop_runner/mod.rs
+++ b/src/agent/runloop/unified/turn/session_loop_runner/mod.rs
@@ -1047,6 +1047,12 @@ pub(super) async fn run_single_agent_loop_unified_impl(
                     .await;
                 tool_result_cache.write().await.check_pressure_and_evict();
                 if let Some(archive) = session_archive.as_ref() {
+                    let messages: Vec<SessionMessage> = runtime
+                        .state
+                        .messages
+                        .iter()
+                        .map(SessionMessage::from)
+                        .collect();
                     let mut recent_messages: Vec<SessionMessage> = runtime
                         .state
                         .messages
@@ -1066,6 +1072,7 @@ pub(super) async fn run_single_agent_loop_unified_impl(
                         .persist_progress_async(SessionProgressArgs {
                             total_messages: runtime.state.messages.len(),
                             distinct_tools: distinct_tools.clone(),
+                            messages,
                             recent_messages,
                             turn_number: progress_turn,
                             token_usage: None,

--- a/src/agent/runloop/unified/turn/session_loop_runner/support.rs
+++ b/src/agent/runloop/unified/turn/session_loop_runner/support.rs
@@ -274,12 +274,14 @@ pub(super) async fn checkpoint_session_archive_start(
     thread_handle: &vtcode_core::core::threads::ThreadRuntimeHandle,
 ) -> Result<()> {
     let snapshot = thread_handle.snapshot();
-    let recent_messages = snapshot.messages.iter().map(SessionMessage::from).collect();
+    let messages: Vec<SessionMessage> =
+        snapshot.messages.iter().map(SessionMessage::from).collect();
     archive
         .persist_progress_async(SessionProgressArgs {
             total_messages: snapshot.messages.len(),
             distinct_tools: Vec::new(),
-            recent_messages,
+            messages: messages.clone(),
+            recent_messages: messages,
             turn_number: 1,
             token_usage: None,
             max_context_tokens: None,

--- a/src/agent/runloop/unified/turn/tool_outcomes/subagent_memory.rs
+++ b/src/agent/runloop/unified/turn/tool_outcomes/subagent_memory.rs
@@ -256,7 +256,7 @@ pub(super) fn merge_subagent_completion_into_memory(
         ctx.config.workspace.as_path(),
         &session_id,
         ctx.vt_cfg,
-        ctx.working_history,
+        ctx.working_history.as_slice(),
         ctx.session_stats,
         Some(&update),
     )?;

--- a/src/cli/exec/run.rs
+++ b/src/cli/exec/run.rs
@@ -94,12 +94,13 @@ async fn checkpoint_exec_archive(
     archive: &vtcode_core::utils::session_archive::SessionArchive,
     session_messages: &[vtcode_core::llm::provider::Message],
 ) -> Result<()> {
-    let recent_messages = session_messages.iter().map(SessionMessage::from).collect();
+    let messages: Vec<SessionMessage> = session_messages.iter().map(SessionMessage::from).collect();
     archive
         .persist_progress_async(SessionProgressArgs {
             total_messages: session_messages.len(),
             distinct_tools: Vec::new(),
-            recent_messages,
+            messages: messages.clone(),
+            recent_messages: messages,
             turn_number: 1,
             token_usage: None,
             max_context_tokens: None,

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -503,7 +503,7 @@ mod tests {
     };
 
     #[test]
-    fn convert_listing_prefers_progress_messages() {
+    fn convert_listing_prefers_full_messages_over_progress_tail() {
         let progress_msg = SessionMessage::new(MessageRole::Assistant, "progress");
         let snapshot = SessionSnapshot {
             metadata: SessionArchiveMetadata::new(
@@ -515,6 +515,41 @@ mod tests {
             distinct_tools: vec!["tool_a".to_string()],
             transcript: Vec::new(),
             messages: vec![SessionMessage::new(MessageRole::User, "full")],
+            progress: Some(Box::new(SessionProgress {
+                turn_number: 2,
+                recent_messages: vec![progress_msg.clone()],
+                tool_summaries: vec!["tool_a".to_string()],
+                token_usage: None,
+                max_context_tokens: Some(128),
+                loaded_skills: Vec::new(),
+            })),
+            error_logs: Vec::new(),
+        };
+
+        let listing = SessionListing {
+            path: PathBuf::new(),
+            snapshot,
+        };
+
+        let resume = convert_listing(&listing, ArchivedSessionIntent::ResumeInPlace);
+        assert_eq!(resume.history().len(), 1);
+        assert_eq!(resume.history()[0].content.as_text(), "full");
+        assert!(!resume.is_fork());
+    }
+
+    #[test]
+    fn convert_listing_falls_back_to_progress_messages_for_legacy_archives() {
+        let progress_msg = SessionMessage::new(MessageRole::Assistant, "progress");
+        let snapshot = SessionSnapshot {
+            metadata: SessionArchiveMetadata::new(
+                "ws", "/tmp/ws", "model", "provider", "theme", "medium",
+            ),
+            started_at: Utc::now(),
+            ended_at: Utc::now(),
+            total_messages: 2,
+            distinct_tools: vec!["tool_a".to_string()],
+            transcript: Vec::new(),
+            messages: Vec::new(),
             progress: Some(Box::new(SessionProgress {
                 turn_number: 2,
                 recent_messages: vec![progress_msg.clone()],

--- a/src/codex_app_server/runtime.rs
+++ b/src/codex_app_server/runtime.rs
@@ -956,6 +956,7 @@ fn persist_archive_progress(
         .persist_progress(SessionProgressArgs {
             total_messages: messages.len(),
             distinct_tools: Vec::new(),
+            messages: messages.to_vec(),
             recent_messages: messages.to_vec(),
             turn_number,
             token_usage: None,

--- a/vtcode-core/src/core/threads.rs
+++ b/vtcode-core/src/core/threads.rs
@@ -443,17 +443,17 @@ fn preserve_prompt_cache_lineage_if_compatible(
 }
 
 pub fn messages_from_session_listing(listing: &SessionListing) -> Vec<Message> {
-    if let Some(progress) = &listing.snapshot.progress
-        && !progress.recent_messages.is_empty()
-    {
-        progress.recent_messages.iter().map(Message::from).collect()
-    } else if !listing.snapshot.messages.is_empty() {
+    if !listing.snapshot.messages.is_empty() {
         listing
             .snapshot
             .messages
             .iter()
             .map(Message::from)
             .collect()
+    } else if let Some(progress) = &listing.snapshot.progress
+        && !progress.recent_messages.is_empty()
+    {
+        progress.recent_messages.iter().map(Message::from).collect()
     } else {
         Vec::new()
     }
@@ -679,7 +679,7 @@ mod tests {
 
         assert_eq!(prepared.thread_id, listing.identifier());
         assert_eq!(prepared.archive.path(), listing.path.as_path());
-        assert_eq!(prepared.bootstrap.messages[0].content.as_text(), "recent");
+        assert_eq!(prepared.bootstrap.messages[0].content.as_text(), "hello");
         assert_eq!(
             prepared.bootstrap.loaded_skills,
             vec!["skill_a".to_string()]

--- a/vtcode-core/src/subagents/mod.rs
+++ b/vtcode-core/src/subagents/mod.rs
@@ -1875,7 +1875,7 @@ async fn checkpoint_subagent_archive_start(
     messages: &[Message],
 ) -> Result<()> {
     use crate::utils::session_archive::SessionMessage;
-    let recent_messages = messages
+    let recent_messages: Vec<SessionMessage> = messages
         .iter()
         .map(SessionMessage::from)
         .collect::<Vec<_>>();
@@ -1883,6 +1883,7 @@ async fn checkpoint_subagent_archive_start(
         .persist_progress_async(crate::utils::session_archive::SessionProgressArgs {
             total_messages: recent_messages.len(),
             distinct_tools: Vec::new(),
+            messages: recent_messages.clone(),
             recent_messages,
             turn_number: 1,
             token_usage: None,

--- a/vtcode-core/src/utils/session_archive.rs
+++ b/vtcode-core/src/utils/session_archive.rs
@@ -549,6 +549,7 @@ pub struct SessionListing {
 pub struct SessionProgressArgs {
     pub total_messages: usize,
     pub distinct_tools: Vec<String>,
+    pub messages: Vec<SessionMessage>,
     pub recent_messages: Vec<SessionMessage>,
     pub turn_number: usize,
     pub token_usage: Option<String>,
@@ -1159,6 +1160,7 @@ impl SessionArchive {
         let SessionProgressArgs {
             total_messages,
             distinct_tools,
+            messages,
             recent_messages,
             turn_number,
             token_usage,
@@ -1169,7 +1171,6 @@ impl SessionArchive {
         let transcript = progress_transcript_from_recent_messages(&recent_messages);
         let distinct_tools = normalize_distinct_tools_for_summary(&distinct_tools);
         let tool_summaries = distinct_tools.clone();
-        let messages = recent_messages.clone();
 
         self.build_snapshot(
             total_messages,

--- a/vtcode-core/src/utils/session_archive_tests.rs
+++ b/vtcode-core/src/utils/session_archive_tests.rs
@@ -302,11 +302,17 @@ async fn session_progress_persists_budget_and_recent_messages() -> Result<()> {
         "medium",
     );
     let archive = SessionArchive::new(metadata, None).await?;
+    let full = vec![
+        SessionMessage::new(MessageRole::User, "first"),
+        SessionMessage::new(MessageRole::Assistant, "middle"),
+        SessionMessage::new(MessageRole::User, "latest"),
+    ];
     let recent = vec![SessionMessage::new(MessageRole::Assistant, "recent")];
 
     let path = archive.persist_progress(SessionProgressArgs {
-        total_messages: 1,
+        total_messages: full.len(),
         distinct_tools: vec!["tool_a".to_owned()],
+        messages: full.clone(),
         recent_messages: recent.clone(),
         turn_number: 2,
         token_usage: Some("10 tokens".to_string()),
@@ -319,6 +325,7 @@ async fn session_progress_persists_budget_and_recent_messages() -> Result<()> {
     let snapshot: SessionSnapshot =
         serde_json::from_str(&stored).context("failed to deserialize stored snapshot")?;
 
+    assert_eq!(snapshot.messages, full);
     let progress = snapshot.progress.expect("progress should exist");
     assert_eq!(progress.turn_number, 2);
     assert_eq!(progress.recent_messages, recent);
@@ -358,6 +365,7 @@ async fn session_progress_transcript_skips_tool_noise_and_duplicates() -> Result
     let path = archive.persist_progress(SessionProgressArgs {
         total_messages: recent.len(),
         distinct_tools: vec!["unified_exec".to_owned()],
+        messages: recent.clone(),
         recent_messages: recent,
         turn_number: 2,
         token_usage: Some("10 tokens".to_string()),
@@ -489,6 +497,7 @@ async fn session_progress_normalizes_exec_tool_aliases_in_summaries() -> Result<
             "exec".to_string(),
             "container.exec".to_string(),
         ],
+        messages: recent.clone(),
         recent_messages: recent,
         turn_number: 2,
         token_usage: Some("10 tokens".to_string()),


### PR DESCRIPTION
# Pull Request

## Description

Fixes #682

This PR stops the session memory envelope from being injected into normal live conversation history and plain full-history resume paths.

Previously, ordinary turn finalisation and resume could prepend a synthetic `[Session Memory Envelope]` system message into the active history. That could disrupt follow-up behaviour and harm prompt-cache locality, even when the full conversation history was still available.

This change keeps the useful persistence behaviour, but limits in-history envelope injection to explicit compaction/recovery/summarised-history paths.

Changes included:

- Make ordinary `refresh_session_memory_envelope` persist the envelope without mutating live history.
- Change the refresh API to accept immutable `&[Message]`, preventing accidental live-history insertion at post-turn and subagent-memory call sites.
- Preserve subagent memory envelope updates via `Some(&update)` while keeping `ctx.working_history` immutable.
- Stop plain full-history resume from injecting the latest memory envelope.
- Preserve explicit envelope insertion for compaction, recovery, summarised fork, and targeted compaction flows.
- Add focused regression coverage for refresh, resume, and explicit insertion behaviour.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Rust tests: `cargo test`
- [ ] Linting: `cargo clippy`
- [x] Formatting: `cargo fmt`
- [x] Build: `cargo build`

Tested with:

```bash
cargo test -p vtcode --bin vtcode refresh_session_memory_envelope -- --nocapture
cargo test -p vtcode --bin vtcode inject_latest_memory_envelope -- --nocapture
cargo test -p vtcode --bin vtcode targeted_compaction_preserves_prefix_and_replaces_suffix -- --nocapture
cargo test -p vtcode --bin vtcode compaction -- --nocapture
cargo test -p vtcode --bin vtcode plain_resume_with_full_history_does_not_inject_latest_memory_envelope -- --nocapture
```

Also run:

```bash
git diff --check origin/main..HEAD
```

**Test Configuration**:
* Rust version: `rustc 1.96.0 (ac68faa20 2026-05-25)`
* Operating system: Linux `7.0.12-artix1-1` x86_64
* Toolchain: system Rust; `rustup` not installed

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`cargo test`)
- [ ] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the `CHANGELOG.md` if this change affects the user-facing behaviour
- [x] I have checked my code and corrected any misspellings

## Additional Context

The memory envelope is still used where history is intentionally compacted or reconstructed. It is no longer injected into ordinary live turns or plain full-history resume, so normal follow-ups should continue from the real saved conversation history without a synthetic system message being prepended.