### PR TITLE
Fix/keyboard input & image pasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1087,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -1866,6 +1896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,6 +2355,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3890,6 +3936,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3898,6 +3956,19 @@ dependencies = [
  "bitflags 2.13.0",
  "dispatch2",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3926,6 +3997,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -4081,6 +4163,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,6 +4318,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -6857,6 +6960,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7698,6 +7812,8 @@ dependencies = [
  "anstyle-git",
  "anstyle-ls",
  "anyhow",
+ "arboard",
+ "base64",
  "better-panic",
  "catppuccin",
  "chrono",
@@ -7708,6 +7824,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "human-panic",
  "humantime",
+ "image",
  "line-clipping",
  "nucleo-matcher",
  "once_cell",
@@ -7885,6 +8002,76 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -8513,10 +8700,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ workspace = true
 
 # Override sections to consolidate duplicate dependencies
 [workspace.dependencies]
+arboard = { version = "3.6.1", features = ["wayland-data-control"] }
 base64 = "0.22.1"
 crossterm = "0.29"
 schemars = "1.2"
@@ -53,6 +54,7 @@ rand = "0.10"
 semver = "1.0"
 fs2 = "0.4"
 hashbrown = { version = "0.17", features = ["serde"] }
+image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 rustc-hash = "2.1"
 keyring-core = "1"
 libloading = "0.9"

--- a/docs/guides/macos-alt-shortcut-troubleshooting.md
+++ b/docs/guides/macos-alt-shortcut-troubleshooting.md
@@ -231,6 +231,7 @@ Once Alt keys are working, these shortcuts should be available:
 | Alt+a | Alternative action |
 | Alt+j | Jump/navigation down |
 | Alt+k | Jump/navigation up |
+| Alt+v | Paste clipboard image through VT Code (image-enabled sessions only) |
 | Alt+↑ | Scroll up (if applicable) |
 | Alt+↓ | Scroll down (if applicable) |
 | Ctrl+c | Interrupt/cancel (always works) |

--- a/docs/guides/terminal-optimization.md
+++ b/docs/guides/terminal-optimization.md
@@ -6,6 +6,7 @@ This guide covers the terminal-specific settings that matter most when using VT 
 
 - [Theme and Appearance](#theme-and-appearance)
 - [Line Break Options](#line-break-options)
+- [Paste Handling](#paste-handling)
 - [Notification Setup](#notification-setup)
 - [Handling Large Inputs](#handling-large-inputs)
 
@@ -65,6 +66,13 @@ VT Code supports several multiline input paths:
 - Use `/vim`, `/vim on`, or `/vim off` to change Vim mode for the current session only.
 - VT Code currently supports a focused subset with `INSERT` and `NORMAL` modes only.
 - VT Code-specific controls such as `Enter`, `Tab`, `Ctrl+Enter`, `/`, `@`, and `!` still keep their existing behavior.
+
+## Paste Handling
+
+- Text paste stays on the terminal's bracketed paste path, so use the terminal paste shortcut, commonly `Ctrl+Shift+V`.
+- `Ctrl+V` and `Alt+V` are VT Code app-level shortcuts for pasting clipboard images. They work only in image-enabled sessions.
+- Models without image input reject pasted images and submitted image attachments with a warning.
+- On WSL, VT Code attempts a Windows clipboard image fallback through PowerShell when direct Linux clipboard access cannot read an image.
 
 ## Notification Setup
 

--- a/docs/models.json
+++ b/docs/models.json
@@ -530,10 +530,10 @@
         },
         "context": 131072
       },
-      "gpt-5.5-2026-04-23": {
-        "id": "gpt-5.5-2026-04-23",
+      "gpt-5.5": {
+        "id": "gpt-5.5",
         "name": "GPT-5.5",
-        "description": "Next-gen OpenAI model with frontier reasoning and long context (2026-04-23 dated release).",
+        "description": "Next-gen OpenAI model with frontier reasoning and long context.",
         "reasoning": true,
         "tool_call": true,
         "modalities": {

--- a/docs/user-guide/interactive-mode.md
+++ b/docs/user-guide/interactive-mode.md
@@ -25,7 +25,7 @@ The VT Code terminal UI includes an interactive mode that combines keyboard-firs
 | `Ctrl+K`                                    | Delete from cursor to line end.                                                 | UNIX/readline-style editing.                                                                                                              |
 | `Alt+Left/Right`                            | Move cursor by word.                                                            | UNIX/readline-style navigation.                                                                                                           |
 | `Ctrl+R`                                    | Reverse search the command history.                                             | Matches previous prompts and bash commands.                                                                                               |
-| `Ctrl+V` (macOS/Linux) or `Alt+V` (Windows) | Paste an image from the clipboard.                                              | Works with image-enabled sessions.                                                                                                        |
+| `Ctrl+V` or `Alt+V`                         | Paste a clipboard image through VT Code.                                        | App-level shortcut; works only in image-enabled sessions. Use your terminal's paste shortcut for text.                                     |
 | `Ctrl+Z` (Unix)                             | Suspend VT Code to the shell; run `fg` to resume.                               | Job-control support for terminal workflows.                                                                                               |
 | `Up/Down arrows`                            | Navigate through command history.                                               | Recall previous prompts or commands.                                                                                                      |
 | `Esc` + `Esc`                               | Open the rewind picker for checkpoint restore or summarize actions.             | Idle context only (while no task/PTY is running).                                                                                         |
@@ -45,6 +45,13 @@ The VT Code terminal UI includes an interactive mode that combines keyboard-firs
 | Paste mode           | Paste directly | Ideal for code blocks or long transcripts.                                                        |
 
 > Tip: `Shift+Enter` works natively in `Ghostty`, `Kitty`, `WezTerm`, `iTerm2`, and `Warp`. Run `/terminal-setup` in supported terminals such as `VS Code`, `Alacritty`, or `Zed` when you want VT Code's guided setup flow.
+
+### Clipboard Paste
+
+- `Ctrl+V` and `Alt+V` are VT Code shortcuts for image paste. They read a clipboard image and attach it to the current draft when the selected session supports image input.
+- Text paste still uses the terminal bracketed paste path. In many terminals this is `Ctrl+Shift+V`; use the paste shortcut configured by your terminal.
+- If the selected model does not support image input, VT Code rejects both image paste and image submission, then shows a warning.
+- On WSL, VT Code first tries direct Linux clipboard access. If that cannot read an image, it tries a Windows clipboard image fallback through PowerShell.
 
 ### Quick Commands
 

--- a/src/agent/runloop/slash_commands/rendering.rs
+++ b/src/agent/runloop/slash_commands/rendering.rs
@@ -204,7 +204,10 @@ pub(super) async fn render_help(
             MessageStyle::Info,
             "  /history – Open command history picker",
         )?;
-        renderer.line(MessageStyle::Info, "  Ctrl+V – Paste image from clipboard")?;
+        renderer.line(
+            MessageStyle::Info,
+            "  Ctrl+V or Alt+V: App-level image paste (image-enabled sessions only; no text fallback)",
+        )?;
         renderer.line(
             MessageStyle::Info,
             "  Up/Down arrows – Navigate command history",

--- a/src/agent/runloop/unified/inline_events/action.rs
+++ b/src/agent/runloop/unified/inline_events/action.rs
@@ -1,8 +1,9 @@
 use vtcode_core::hooks::SessionEndReason;
+use vtcode_ui::tui::app::SubmittedInput;
 
 pub(crate) enum InlineLoopAction {
     Continue,
-    Submit(String),
+    Submit(SubmittedInput),
     SubmitQueued(super::queue::QueuedInput),
     CyclePrimaryAgent,
     CyclePrimaryAgentPrevious,

--- a/src/agent/runloop/unified/inline_events/context.rs
+++ b/src/agent/runloop/unified/inline_events/context.rs
@@ -5,7 +5,7 @@ use tokio::sync::Notify;
 use vtcode_core::config::loader::VTCodeConfig;
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::llm::provider::{self as uni};
-use vtcode_core::utils::ansi::AnsiRenderer;
+use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
 use vtcode_ui::tui::app::{
     InlineEvent, InlineHandle, InlineHeaderContext, TransientEvent, TransientHotkeyAction,
     TransientSelectionChange, TransientSubmission,
@@ -90,7 +90,20 @@ impl<'a> InlineEventContext<'a> {
                 queue.prefer_latest_next();
                 InlineLoopAction::Continue
             }
-            InlineEvent::Steer(_) | InlineEvent::Pause | InlineEvent::Resume => {
+            InlineEvent::Steer(input) => {
+                if input.has_attachments() {
+                    self.state.reset_interrupt_state();
+                    self.state.renderer().line(
+                        MessageStyle::Warning,
+                        "Live steering supports text only. Remove image attachments before steering.",
+                    )?;
+                    self.modal.restore_input_draft(input);
+                    InlineLoopAction::Continue
+                } else {
+                    self.input_processor().passive()
+                }
+            }
+            InlineEvent::Pause | InlineEvent::Resume => {
                 self.state.reset_interrupt_state();
                 self.input_processor().passive()
             }
@@ -139,7 +152,7 @@ impl<'a> InlineEventContext<'a> {
                     self.state.reset_interrupt_state();
                     match action {
                         TransientHotkeyAction::LaunchEditor => {
-                            self.input_processor().submit("/edit".to_string())
+                            self.input_processor().submit("/edit".into())
                         }
                         TransientHotkeyAction::ReloadSubagentInspector
                         | TransientHotkeyAction::GracefulStopSubagent
@@ -163,12 +176,12 @@ impl<'a> InlineEventContext<'a> {
             }
             InlineEvent::Exit => self.control_processor().exit()?,
             InlineEvent::Interrupt => self.handle_interrupt(),
-            InlineEvent::BackgroundOperation => self
-                .input_processor()
-                .submit("/subprocesses toggle".to_string()),
+            InlineEvent::BackgroundOperation => {
+                self.input_processor().submit("/subprocesses toggle".into())
+            }
             InlineEvent::LaunchEditor { draft } => {
                 if draft.is_empty() {
-                    self.input_processor().submit("/edit".to_string())
+                    self.input_processor().submit("/edit".into())
                 } else {
                     InlineLoopAction::LaunchEditorWithDraft { draft }
                 }
@@ -197,9 +210,9 @@ impl<'a> InlineEventContext<'a> {
                 self.state.reset_interrupt_state();
                 InlineLoopAction::OpenTranscriptReviewScrollback(text)
             }
-            InlineEvent::OpenFileInEditor(path) => {
-                self.input_processor().submit(format!("/edit {path}"))
-            }
+            InlineEvent::OpenFileInEditor(path) => self
+                .input_processor()
+                .submit(format!("/edit {path}").into()),
             InlineEvent::OpenUrl(url) => {
                 self.state.reset_interrupt_state();
                 self.modal.request_url_guard(self.state.renderer(), url)?

--- a/src/agent/runloop/unified/inline_events/driver.rs
+++ b/src/agent/runloop/unified/inline_events/driver.rs
@@ -198,7 +198,7 @@ impl<'a> InlineEventLoop<'a> {
 
     fn take_queued_submission(&mut self) -> Option<InlineLoopAction> {
         self.queue.take_next_submission().map(|queued| {
-            if queued.text.is_empty() {
+            if queued.input.is_empty() {
                 InlineLoopAction::Continue
             } else {
                 InlineLoopAction::SubmitQueued(queued)

--- a/src/agent/runloop/unified/inline_events/input.rs
+++ b/src/agent/runloop/unified/inline_events/input.rs
@@ -1,6 +1,7 @@
 use super::action::InlineLoopAction;
 use super::queue::InlineQueueState;
 use super::state::InlineEventState;
+use vtcode_ui::tui::app::SubmittedInput;
 
 pub(crate) struct InlineInputProcessor<'a, 'state> {
     state: &'a mut InlineEventState<'state>,
@@ -11,24 +12,24 @@ impl<'a, 'state> InlineInputProcessor<'a, 'state> {
         Self { state }
     }
 
-    pub(crate) fn submit(self, text: String) -> InlineLoopAction {
+    pub(crate) fn submit(self, input: SubmittedInput) -> InlineLoopAction {
         self.state.reset_interrupt_state();
-        InlineLoopAction::Submit(text.trim().to_string())
+        InlineLoopAction::Submit(input.trim_text())
     }
 
     pub(crate) fn queue_submit(
         self,
-        text: String,
+        input: SubmittedInput,
         queue: &mut InlineQueueState<'_>,
         primary_agent: Option<String>,
     ) -> InlineLoopAction {
         self.state.reset_interrupt_state();
-        let trimmed = text.trim().to_string();
-        if trimmed.is_empty() {
+        let input = input.trim_text();
+        if input.is_empty() {
             return InlineLoopAction::Continue;
         }
 
-        queue.push(trimmed, primary_agent);
+        queue.push(input, primary_agent);
         InlineLoopAction::Continue
     }
 

--- a/src/agent/runloop/unified/inline_events/modal.rs
+++ b/src/agent/runloop/unified/inline_events/modal.rs
@@ -8,7 +8,7 @@ use vtcode_core::config::loader::VTCodeConfig;
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
 use vtcode_core::llm::provider::{self as uni};
 use vtcode_core::utils::ansi::{AnsiRenderer, MessageStyle};
-use vtcode_ui::tui::app::{InlineHandle, InlineHeaderContext, InlineListSelection};
+use vtcode_ui::tui::app::{InlineHandle, InlineHeaderContext, InlineListSelection, SubmittedInput};
 
 use crate::agent::runloop::model_picker::{
     ModelPickerProgress, ModelPickerStart, ModelPickerState,
@@ -81,6 +81,10 @@ impl<'a> InlineModalProcessor<'a> {
 
     pub(crate) fn active_primary_agent_name(&self) -> Option<String> {
         self.model_picker.header_context.primary_agent.clone()
+    }
+
+    pub(crate) fn restore_input_draft(&self, input: SubmittedInput) {
+        self.model_picker.handle.restore_input_draft(input);
     }
 
     pub(crate) fn request_url_guard(
@@ -442,7 +446,7 @@ impl<'a> InlineModalProcessor<'a> {
                 if action == ACTION_CONFIGURE_EDITOR =>
             {
                 self.palette.state.take();
-                Some(InlineLoopAction::Submit("/config tools.editor".to_string()))
+                Some(InlineLoopAction::Submit("/config tools.editor".into()))
             }
             _ => None,
         }

--- a/src/agent/runloop/unified/inline_events/queue.rs
+++ b/src/agent/runloop/unified/inline_events/queue.rs
@@ -1,25 +1,25 @@
 use std::collections::VecDeque;
 
-use vtcode_ui::tui::app::InlineHandle;
+use vtcode_ui::tui::app::{InlineHandle, SubmittedInput};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct QueuedInput {
-    pub(crate) text: String,
+    pub(crate) input: SubmittedInput,
     pub(crate) primary_agent: Option<String>,
 }
 
 impl QueuedInput {
-    pub(crate) fn new(text: String, primary_agent: Option<String>) -> Self {
+    pub(crate) fn new(input: SubmittedInput, primary_agent: Option<String>) -> Self {
         Self {
-            text,
+            input,
             primary_agent: primary_agent.filter(|name| !name.trim().is_empty()),
         }
     }
 
     fn display_label(&self) -> String {
         match self.primary_agent.as_deref() {
-            Some(agent) => format!("{agent}: {}", self.text),
-            None => self.text.clone(),
+            Some(agent) => format!("{agent}: {}", self.input.text),
+            None => self.input.text.clone(),
         }
     }
 }
@@ -43,9 +43,9 @@ impl<'a> InlineQueueState<'a> {
         }
     }
 
-    pub(crate) fn push(&mut self, text: String, primary_agent: Option<String>) {
+    pub(crate) fn push(&mut self, input: SubmittedInput, primary_agent: Option<String>) {
         self.queued_inputs
-            .push_back(QueuedInput::new(text, primary_agent));
+            .push_back(QueuedInput::new(input, primary_agent));
         *self.prefer_latest_once = true;
         self.sync_handle_queue();
     }
@@ -66,7 +66,10 @@ impl<'a> InlineQueueState<'a> {
     }
 
     pub(crate) fn edit_latest(&mut self) -> Option<String> {
-        let result = self.queued_inputs.pop_back().map(|queued| queued.text);
+        let result = self
+            .queued_inputs
+            .pop_back()
+            .map(|queued| queued.input.text);
         if result.is_some() {
             *self.prefer_latest_once = false;
         }
@@ -102,28 +105,28 @@ mod tests {
         let mut prefer_latest_once = false;
         let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
 
-        queue.push("first".to_string(), Some("duck".to_string()));
-        queue.push("second".to_string(), Some("build".to_string()));
-        queue.push("third".to_string(), Some("review".to_string()));
+        queue.push("first".into(), Some("duck".to_string()));
+        queue.push("second".into(), Some("build".to_string()));
+        queue.push("third".into(), Some("review".to_string()));
 
         assert_eq!(
             queue
                 .take_next_submission()
-                .map(|queued| queued.text)
+                .map(|queued| queued.input.text)
                 .as_deref(),
             Some("third")
         );
         assert_eq!(
             queue
                 .take_next_submission()
-                .map(|queued| queued.text)
+                .map(|queued| queued.input.text)
                 .as_deref(),
             Some("first")
         );
         assert_eq!(
             queue
                 .take_next_submission()
-                .map(|queued| queued.text)
+                .map(|queued| queued.input.text)
                 .as_deref(),
             Some("second")
         );
@@ -134,9 +137,9 @@ mod tests {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let handle = InlineHandle::new_for_tests(tx);
         let mut queued_inputs = VecDeque::from([
-            QueuedInput::new("first".to_string(), Some("duck".to_string())),
-            QueuedInput::new("second".to_string(), Some("build".to_string())),
-            QueuedInput::new("third".to_string(), Some("review".to_string())),
+            QueuedInput::new("first".into(), Some("duck".to_string())),
+            QueuedInput::new("second".into(), Some("build".to_string())),
+            QueuedInput::new("third".into(), Some("review".to_string())),
         ]);
         let mut prefer_latest_once = false;
         let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
@@ -146,21 +149,21 @@ mod tests {
         assert_eq!(
             queue
                 .take_next_submission()
-                .map(|queued| queued.text)
+                .map(|queued| queued.input.text)
                 .as_deref(),
             Some("third")
         );
         assert_eq!(
             queue
                 .take_next_submission()
-                .map(|queued| queued.text)
+                .map(|queued| queued.input.text)
                 .as_deref(),
             Some("first")
         );
         assert_eq!(
             queue
                 .take_next_submission()
-                .map(|queued| queued.text)
+                .map(|queued| queued.input.text)
                 .as_deref(),
             Some("second")
         );
@@ -174,15 +177,35 @@ mod tests {
         let mut prefer_latest_once = false;
         let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
 
-        queue.push("first".to_string(), Some("planner".to_string()));
-        queue.push("second".to_string(), Some("builder".to_string()));
+        queue.push("first".into(), Some("planner".to_string()));
+        queue.push("second".into(), Some("builder".to_string()));
 
         let latest = queue.take_next_submission().expect("latest queued input");
-        assert_eq!(latest.text, "second");
+        assert_eq!(latest.input.text, "second");
         assert_eq!(latest.primary_agent.as_deref(), Some("builder"));
 
         let first = queue.take_next_submission().expect("first queued input");
-        assert_eq!(first.text, "first");
+        assert_eq!(first.input.text, "first");
         assert_eq!(first.primary_agent.as_deref(), Some("planner"));
+    }
+
+    #[test]
+    fn queued_input_preserves_attachments_in_order() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        let first = vtcode_ui::tui::app::ContentPart::image("first", "image/png");
+        let second = vtcode_ui::tui::app::ContentPart::image("second", "image/jpeg");
+        queue.push(
+            SubmittedInput::new("see images", vec![first.clone(), second.clone()]),
+            None,
+        );
+
+        let queued = queue.take_next_submission().expect("queued input");
+        assert_eq!(queued.input.text, "see images");
+        assert_eq!(queued.input.attachments, vec![first, second]);
     }
 }

--- a/src/agent/runloop/unified/inline_events/tests.rs
+++ b/src/agent/runloop/unified/inline_events/tests.rs
@@ -26,8 +26,8 @@ use vtcode_core::core::agent::snapshots::{
 use vtcode_core::llm::provider::{self as uni, LLMRequest, LLMResponse};
 use vtcode_core::utils::ansi::AnsiRenderer;
 use vtcode_ui::tui::app::{
-    InlineCommand, InlineEvent, InlineHandle, InlineListSelection, TransientEvent,
-    TransientRequest, TransientSubmission,
+    ContentPart, InlineCommand, InlineEvent, InlineHandle, InlineListSelection, SubmittedInput,
+    TransientEvent, TransientRequest, TransientSubmission,
 };
 
 #[derive(Clone)]
@@ -156,7 +156,7 @@ async fn launch_editor_event_submits_edit_command() {
         .expect("process launch editor");
     assert!(matches!(
         action,
-        InlineLoopAction::Submit(ref command) if command == "/edit"
+        InlineLoopAction::Submit(ref command) if command.text == "/edit"
     ));
 }
 
@@ -250,7 +250,7 @@ async fn open_file_in_editor_event_submits_edit_command_with_path() {
         .expect("process open file in editor");
     assert!(matches!(
         action,
-        InlineLoopAction::Submit(ref command) if command == &format!("/edit {path}")
+        InlineLoopAction::Submit(ref command) if command.text == format!("/edit {path}")
     ));
 }
 
@@ -571,7 +571,7 @@ async fn settings_editor_selection_submits_editor_config_command() {
 
     assert!(matches!(
         action,
-        InlineLoopAction::Submit(ref command) if command == "/config tools.editor"
+        InlineLoopAction::Submit(ref command) if command.text == "/config tools.editor"
     ));
     assert!(palette_state.is_none());
 }
@@ -838,7 +838,7 @@ async fn steering_events_are_passive_in_idle_loop() {
     for event in [
         InlineEvent::Pause,
         InlineEvent::Resume,
-        InlineEvent::Steer("keep going".to_string()),
+        InlineEvent::Steer("keep going".into()),
     ] {
         let action = context
             .process_event(event, &mut queue)
@@ -846,6 +846,78 @@ async fn steering_events_are_passive_in_idle_loop() {
             .expect("process steering event");
         assert!(matches!(action, InlineLoopAction::Continue));
     }
+}
+
+#[tokio::test]
+async fn steer_with_attachments_restores_full_draft_and_continues() {
+    let (handle, mut commands, mut renderer) = renderer_with_handle_and_commands();
+    let (ctrl_c_state, ctrl_c_notify) = ctrl_c_handles();
+    let interrupts = InlineInterruptCoordinator::new(ctrl_c_state.as_ref());
+    let mut ctrl_c_notice_displayed = false;
+    let mut model_picker_state: Option<ModelPickerState> = None;
+    let mut palette_state: Option<ActivePalette> = None;
+    let mut config = runtime_config();
+    let mut vt_cfg = None;
+    let mut provider_client: Box<dyn uni::LLMProvider> = Box::new(DummyProvider);
+    let session_bootstrap = SessionBootstrap::default();
+    let mut header_context = vtcode_ui::tui::app::InlineHeaderContext::default();
+    let mut context = InlineEventContext::new(
+        &mut renderer,
+        &handle,
+        interrupts,
+        &mut ctrl_c_notice_displayed,
+        &mut header_context,
+        &mut model_picker_state,
+        &mut palette_state,
+        &mut config,
+        &mut vt_cfg,
+        &mut provider_client,
+        &ctrl_c_state,
+        &ctrl_c_notify,
+        &session_bootstrap,
+        false,
+        0,
+    );
+    let mut queued_inputs = VecDeque::new();
+    let mut prefer_latest_once = false;
+    let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+    let first_attachment = ContentPart::image("first-image", "image/png");
+    let second_attachment = ContentPart::image("second-image", "image/png");
+    let input = SubmittedInput::new(
+        "keep going",
+        vec![first_attachment.clone(), second_attachment.clone()],
+    );
+    let action = context
+        .process_event(InlineEvent::Steer(input.clone()), &mut queue)
+        .await
+        .expect("process steer with attachment");
+
+    assert!(matches!(action, InlineLoopAction::Continue));
+    let mut restored_draft = false;
+    let mut warning_rendered = false;
+    while let Ok(command) = commands.try_recv() {
+        if let InlineCommand::AppendLine { segments, .. } = &command
+            && segments.iter().any(|segment| {
+                segment.text.contains(
+                    "Live steering supports text only. Remove image attachments before steering.",
+                )
+            })
+        {
+            warning_rendered = true;
+        }
+        if let InlineCommand::RestoreInputDraft(restored_input) = command {
+            assert_eq!(restored_input.text, "keep going");
+            assert_eq!(
+                restored_input.attachments,
+                vec![first_attachment.clone(), second_attachment.clone()]
+            );
+            assert_eq!(restored_input, input);
+            restored_draft = true;
+        }
+    }
+    assert!(warning_rendered);
+    assert!(restored_draft);
 }
 
 #[tokio::test]
@@ -879,8 +951,8 @@ async fn process_latest_queued_event_primes_newest_queue_priority() {
         0,
     );
     let mut queued_inputs = VecDeque::from([
-        QueuedInput::new("first".to_string(), Some("duck".to_string())),
-        QueuedInput::new("latest".to_string(), Some("builder".to_string())),
+        QueuedInput::new("first".into(), Some("duck".to_string())),
+        QueuedInput::new("latest".into(), Some("builder".to_string())),
     ]);
     let mut prefer_latest_once = false;
     let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
@@ -970,6 +1042,7 @@ fn other_name(command: &InlineCommand) -> &'static str {
         InlineCommand::SetCursorVisible(_) => "SetCursorVisible",
         InlineCommand::SetInputEnabled(_) => "SetInputEnabled",
         InlineCommand::SetInput(_) => "SetInput",
+        InlineCommand::RestoreInputDraft(_) => "RestoreInputDraft",
         InlineCommand::ApplySuggestedPrompt(_) => "ApplySuggestedPrompt",
         InlineCommand::SetInlinePromptSuggestion { .. } => "SetInlinePromptSuggestion",
         InlineCommand::ClearInlinePromptSuggestion => "ClearInlinePromptSuggestion",

--- a/src/agent/runloop/unified/inline_events/tests.rs
+++ b/src/agent/runloop/unified/inline_events/tests.rs
@@ -1041,6 +1041,7 @@ fn other_name(command: &InlineCommand) -> &'static str {
         InlineCommand::SetArchivedHistory { .. } => "SetArchivedHistory",
         InlineCommand::SetCursorVisible(_) => "SetCursorVisible",
         InlineCommand::SetInputEnabled(_) => "SetInputEnabled",
+        InlineCommand::SetImageInputEnabled(_) => "SetImageInputEnabled",
         InlineCommand::SetInput(_) => "SetInput",
         InlineCommand::RestoreInputDraft(_) => "RestoreInputDraft",
         InlineCommand::ApplySuggestedPrompt(_) => "ApplySuggestedPrompt",

--- a/src/agent/runloop/unified/session_setup/ui.rs
+++ b/src/agent/runloop/unified/session_setup/ui.rs
@@ -180,9 +180,11 @@ pub(crate) async fn initialize_session_ui(
                     let _ = sender.send(SteeringMessage::Resume);
                 }
             }
-            InlineEvent::Steer(text) => {
-                if let Some(sender) = steering_sender.as_ref() {
-                    let _ = sender.send(SteeringMessage::FollowUpInput(text.clone()));
+            InlineEvent::Steer(input) => {
+                if !input.has_attachments()
+                    && let Some(sender) = steering_sender.as_ref()
+                {
+                    let _ = sender.send(SteeringMessage::FollowUpInput(input.text.clone()));
                 }
             }
             _ => {}

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner.rs
@@ -29,7 +29,7 @@ use vtcode_config::loader::SimpleConfigWatcher;
 use super::interaction_loop::{InteractionLoopContext, InteractionOutcome, InteractionState};
 use support::{
     InlineLoopActionResolution, apply_live_theme_and_appearance, build_durable_scheduler_daemon,
-    build_user_message_content, extract_recent_follow_up_hint, fallback_args_preview,
+    build_submitted_user_message_content, extract_recent_follow_up_hint, fallback_args_preview,
     refresh_ide_context_before_user_turn, refresh_live_ide_context_update,
     resolve_inline_loop_action, scheduler_enabled, stalled_follow_up_recovery_prompt,
     sync_mcp_approval_policy_for_context,
@@ -392,7 +392,7 @@ pub(super) async fn run_interaction_loop_impl(
             for task in due {
                 state.queued_inputs.push_back(
                     crate::agent::runloop::unified::inline_events::QueuedInput::new(
-                        task.prompt,
+                        task.prompt.into(),
                         Some(ctx.active_primary_agent.active().display_name.clone()),
                     ),
                 );
@@ -406,13 +406,15 @@ pub(super) async fn run_interaction_loop_impl(
             }
         }
 
-        let mut input_owned = match resolve_inline_loop_action(ctx, state, inline_action).await? {
-            InlineLoopActionResolution::ContinueLoop => continue,
-            InlineLoopActionResolution::Submit(text) => text,
-            InlineLoopActionResolution::Outcome(outcome) => return Ok(outcome),
-        };
+        let mut submitted_input =
+            match resolve_inline_loop_action(ctx, state, inline_action).await? {
+                InlineLoopActionResolution::ContinueLoop => continue,
+                InlineLoopActionResolution::Submit(input) => input,
+                InlineLoopActionResolution::Outcome(outcome) => return Ok(outcome),
+            };
+        let mut input_owned = submitted_input.text.clone();
 
-        if input_owned.is_empty() {
+        if submitted_input.is_empty() {
             continue;
         }
 
@@ -471,6 +473,7 @@ pub(super) async fn run_interaction_loop_impl(
             slash_command_handler::CommandProcessingResult::ContinueLoop => continue,
             slash_command_handler::CommandProcessingResult::UpdateInput(new_input) => {
                 input_owned = new_input;
+                submitted_input = input_owned.clone().into();
             }
             slash_command_handler::CommandProcessingResult::NotHandled => {}
         }
@@ -674,9 +677,10 @@ pub(super) async fn run_interaction_loop_impl(
                 )?;
             }
         }
-        let input = input_owned.as_str();
+        submitted_input.text = input_owned;
+        let input = submitted_input.text.as_str();
 
-        let refined_content = build_user_message_content(ctx, input).await;
+        let refined_content = build_submitted_user_message_content(ctx, &submitted_input).await;
         refresh_ide_context_before_user_turn(ctx, state.input_status_state);
 
         display_user_message(ctx.renderer, input)?;

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner.rs
@@ -29,9 +29,10 @@ use vtcode_config::loader::SimpleConfigWatcher;
 use super::interaction_loop::{InteractionLoopContext, InteractionOutcome, InteractionState};
 use support::{
     InlineLoopActionResolution, apply_live_theme_and_appearance, build_durable_scheduler_daemon,
-    build_submitted_user_message_content, extract_recent_follow_up_hint, fallback_args_preview,
+    build_user_message_content, extract_recent_follow_up_hint, fallback_args_preview,
     refresh_ide_context_before_user_turn, refresh_live_ide_context_update,
-    resolve_inline_loop_action, scheduler_enabled, stalled_follow_up_recovery_prompt,
+    replace_submitted_input_text, resolve_inline_loop_action, scheduler_enabled,
+    stalled_follow_up_recovery_prompt, submitted_images_are_unsupported,
     sync_mcp_approval_policy_for_context,
 };
 pub(crate) use support::{handle_select_primary_agent, try_resume_latest_session};
@@ -472,10 +473,23 @@ pub(super) async fn run_interaction_loop_impl(
             slash_command_handler::CommandProcessingResult::Outcome(outcome) => return Ok(outcome),
             slash_command_handler::CommandProcessingResult::ContinueLoop => continue,
             slash_command_handler::CommandProcessingResult::UpdateInput(new_input) => {
-                input_owned = new_input;
-                submitted_input = input_owned.clone().into();
+                replace_submitted_input_text(&mut submitted_input, new_input);
+                input_owned.clone_from(&submitted_input.text);
             }
             slash_command_handler::CommandProcessingResult::NotHandled => {}
+        }
+
+        if submitted_images_are_unsupported(
+            &submitted_input,
+            ctx.provider_client.supports_vision(&ctx.config.model),
+            &ctx.config.workspace,
+        ) {
+            ctx.renderer.line(
+                MessageStyle::Warning,
+                "The selected model does not support image input. Choose a vision-capable model or remove image attachments before submitting.",
+            )?;
+            ctx.handle.restore_input_draft(submitted_input);
+            continue;
         }
 
         let turn_id = SessionId::generate().into_inner();
@@ -680,7 +694,7 @@ pub(super) async fn run_interaction_loop_impl(
         submitted_input.text = input_owned;
         let input = submitted_input.text.as_str();
 
-        let refined_content = build_submitted_user_message_content(ctx, &submitted_input).await;
+        let refined_content = build_user_message_content(ctx, &submitted_input).await;
         refresh_ide_context_before_user_turn(ctx, state.input_status_state);
 
         display_user_message(ctx.renderer, input)?;

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner.rs
@@ -32,8 +32,8 @@ use support::{
     build_user_message_content, extract_recent_follow_up_hint, fallback_args_preview,
     refresh_ide_context_before_user_turn, refresh_live_ide_context_update,
     replace_submitted_input_text, resolve_inline_loop_action, scheduler_enabled,
-    stalled_follow_up_recovery_prompt, submitted_images_are_unsupported,
-    sync_mcp_approval_policy_for_context,
+    selected_model_supports_image_input, stalled_follow_up_recovery_prompt,
+    submitted_images_are_unsupported, sync_mcp_approval_policy_for_context,
 };
 pub(crate) use support::{handle_select_primary_agent, try_resume_latest_session};
 
@@ -94,6 +94,15 @@ pub(super) async fn run_interaction_loop_impl(
         }
 
         if should_refresh_status {
+            let provider_supports_vision = ctx.provider_client.supports_vision(&ctx.config.model);
+            let model_supports_image_input = selected_model_supports_image_input(
+                &ctx.config.provider,
+                &ctx.config.model,
+                provider_supports_vision,
+            );
+            ctx.handle
+                .set_image_input_enabled(model_supports_image_input);
+
             let live_ide_context = refresh_live_ide_context_update(ctx.ide_context_bridge);
             if live_ide_context.changed || workspace_config_reloaded {
                 apply_ide_context_snapshot(
@@ -481,7 +490,11 @@ pub(super) async fn run_interaction_loop_impl(
 
         if submitted_images_are_unsupported(
             &submitted_input,
-            ctx.provider_client.supports_vision(&ctx.config.model),
+            selected_model_supports_image_input(
+                &ctx.config.provider,
+                &ctx.config.model,
+                ctx.provider_client.supports_vision(&ctx.config.model),
+            ),
             &ctx.config.workspace,
         ) {
             ctx.renderer.line(

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
@@ -1881,6 +1881,34 @@ mod tests {
     }
 
     #[test]
+    fn inline_image_placeholder_text_stays_before_pasted_image_part() {
+        let mut content = uni::MessageContent::text("[Image #1] and here?".to_string());
+
+        append_submitted_attachments(
+            &mut content,
+            &[UiContentPart::image("pasted-image", "image/png")],
+        );
+
+        match content {
+            uni::MessageContent::Parts(parts) => {
+                assert!(matches!(
+                    parts.as_slice(),
+                    [
+                        uni::ContentPart::Text { .. },
+                        uni::ContentPart::Image { .. }
+                    ]
+                ));
+                assert_eq!(parts[0].as_text(), Some("[Image #1] and here?"));
+                assert_eq!(
+                    image_payloads(&uni::MessageContent::parts(parts)),
+                    vec!["pasted-image".to_string()]
+                );
+            }
+            uni::MessageContent::Text(_) => panic!("expected parts"),
+        }
+    }
+
+    #[test]
     fn metadata_remains_trailing_after_all_image_parts() {
         let temp_dir = TempDir::new().expect("temp dir");
         let file_path = temp_dir.path().join("README.md");

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
@@ -369,30 +369,28 @@ pub(super) fn stalled_follow_up_recovery_prompt(
     }
 }
 
-fn append_file_reference_metadata(
-    content: uni::MessageContent,
-    input: &str,
-    workspace: &Path,
-) -> uni::MessageContent {
-    let Some(metadata) = build_file_reference_metadata(input, workspace) else {
-        return content;
-    };
-
+fn append_trailing_text_part(content: &mut uni::MessageContent, trailing_text: String) {
     match content {
-        uni::MessageContent::Text(text) => uni::MessageContent::text(format!("{text}{metadata}")),
-        uni::MessageContent::Parts(mut parts) => {
-            parts.push(uni::ContentPart::text(metadata));
-            uni::MessageContent::parts(parts)
-        }
+        uni::MessageContent::Text(text) => text.push_str(&trailing_text),
+        uni::MessageContent::Parts(parts) => parts.push(uni::ContentPart::text(trailing_text)),
     }
 }
 
-fn append_agent_reference_metadata(
-    content: uni::MessageContent,
-    selected_agents: &[String],
-) -> uni::MessageContent {
+fn append_file_reference_metadata(
+    content: &mut uni::MessageContent,
+    input: &str,
+    workspace: &Path,
+) {
+    let Some(metadata) = build_file_reference_metadata(input, workspace) else {
+        return;
+    };
+
+    append_trailing_text_part(content, metadata);
+}
+
+fn append_agent_reference_metadata(content: &mut uni::MessageContent, selected_agents: &[String]) {
     if selected_agents.is_empty() {
-        return content;
+        return;
     }
 
     let mut metadata = String::from("\n\n[agent_reference_metadata]\n");
@@ -400,13 +398,7 @@ fn append_agent_reference_metadata(
         metadata.push_str(&format!("selected=@agent-{mention}\n"));
     }
 
-    match content {
-        uni::MessageContent::Text(text) => uni::MessageContent::text(format!("{text}{metadata}")),
-        uni::MessageContent::Parts(mut parts) => {
-            parts.push(uni::ContentPart::text(metadata));
-            uni::MessageContent::parts(parts)
-        }
-    }
+    append_trailing_text_part(content, metadata);
 }
 
 fn supports_native_openai_file_inputs(
@@ -506,15 +498,16 @@ fn resolve_full_path_for_alias(alias: &str, workspace: &Path) -> Option<String> 
 
 pub(super) async fn build_user_message_content(
     ctx: &mut InteractionLoopContext<'_>,
-    input: &str,
+    input: &SubmittedInput,
 ) -> uni::MessageContent {
+    let text = input.text.as_str();
     let allow_structured_non_image_file_inputs = supports_native_openai_file_inputs(
         &ctx.config.provider,
         ctx.provider_client
             .supports_responses_compaction(&ctx.config.model),
     );
     let processed_content = match vtcode_core::utils::at_pattern::parse_at_patterns_with_options(
-        input,
+        text,
         &ctx.config.workspace,
         vtcode_core::utils::at_pattern::AtPatternOptions {
             allow_local_non_image_file_inputs: allow_structured_non_image_file_inputs,
@@ -526,7 +519,7 @@ pub(super) async fn build_user_message_content(
         Ok(content) => content,
         Err(err) => {
             tracing::warn!("Failed to parse @ patterns: {}", err);
-            uni::MessageContent::text(input.to_string())
+            uni::MessageContent::text(text.to_string())
         }
     };
 
@@ -553,32 +546,23 @@ pub(super) async fn build_user_message_content(
     };
     let selected_agents: Vec<String> =
         if let Some(controller) = ctx.tool_registry.subagent_controller() {
-            controller.set_turn_delegation_hints_from_input(input).await
+            controller.set_turn_delegation_hints_from_input(text).await
         } else {
             Vec::new()
         };
-    let refined_content =
-        append_file_reference_metadata(refined_content, input, &ctx.config.workspace);
-    append_agent_reference_metadata(refined_content, selected_agents.as_slice())
+    let mut refined_content = refined_content;
+    append_submitted_attachments(&mut refined_content, input.attachments.as_slice());
+    append_file_reference_metadata(&mut refined_content, text, &ctx.config.workspace);
+    append_agent_reference_metadata(&mut refined_content, selected_agents.as_slice());
+    refined_content
 }
 
-pub(super) async fn build_submitted_user_message_content(
-    ctx: &mut InteractionLoopContext<'_>,
-    input: &SubmittedInput,
-) -> uni::MessageContent {
-    let content = build_user_message_content(ctx, input.text.as_str()).await;
-    append_submitted_attachments(content, input.attachments.as_slice())
-}
-
-fn append_submitted_attachments(
-    content: uni::MessageContent,
-    attachments: &[UiContentPart],
-) -> uni::MessageContent {
+fn append_submitted_attachments(content: &mut uni::MessageContent, attachments: &[UiContentPart]) {
     if attachments.is_empty() {
-        return content;
+        return;
     }
 
-    let mut parts = match content {
+    let mut parts = match std::mem::take(content) {
         uni::MessageContent::Text(text) => {
             if text.is_empty() {
                 Vec::new()
@@ -596,7 +580,24 @@ fn append_submitted_attachments(
         }
     }));
 
-    uni::MessageContent::parts(parts)
+    *content = uni::MessageContent::parts(parts);
+}
+
+pub(super) fn submitted_images_are_unsupported(
+    input: &SubmittedInput,
+    model_supports_vision: bool,
+    workspace: &Path,
+) -> bool {
+    !model_supports_vision
+        && (input
+            .attachments
+            .iter()
+            .any(vtcode_ui::tui::app::ContentPart::is_image)
+            || vtcode_core::utils::at_pattern::input_may_parse_image_parts(&input.text, workspace))
+}
+
+pub(super) fn replace_submitted_input_text(input: &mut SubmittedInput, text: String) {
+    input.text = text;
 }
 
 pub(super) fn refresh_ide_context_before_user_turn(
@@ -1665,9 +1666,8 @@ mod tests {
         let file_path = temp_dir.path().join("README.md");
         fs::write(&file_path, "# test\n").expect("write file");
 
-        let content = uni::MessageContent::text("check @README.md".to_string());
-        let augmented =
-            append_file_reference_metadata(content, "check @README.md", temp_dir.path());
+        let mut augmented = uni::MessageContent::text("check @README.md".to_string());
+        append_file_reference_metadata(&mut augmented, "check @README.md", temp_dir.path());
 
         match augmented {
             uni::MessageContent::Text(text) => {
@@ -1682,8 +1682,8 @@ mod tests {
 
     #[test]
     fn append_agent_reference_metadata_adds_selected_agent_hint() {
-        let content = uni::MessageContent::text("use rust-engineer agent".to_string());
-        let augmented = append_agent_reference_metadata(content, &[String::from("rust-engineer")]);
+        let mut augmented = uni::MessageContent::text("use rust-engineer agent".to_string());
+        append_agent_reference_metadata(&mut augmented, &[String::from("rust-engineer")]);
 
         match augmented {
             uni::MessageContent::Text(text) => {
@@ -1707,6 +1707,265 @@ mod tests {
         let temp_dir = TempDir::new().expect("temp dir");
         let metadata = build_file_reference_metadata("check @/tmp/example.rs", temp_dir.path());
         assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn append_submitted_attachments_leaves_text_only_content_unchanged() {
+        let mut content = uni::MessageContent::text("plain prompt".to_string());
+
+        append_submitted_attachments(&mut content, &[]);
+
+        assert_eq!(
+            content,
+            uni::MessageContent::text("plain prompt".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn parsed_at_image_stays_before_pasted_image() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let image_path = temp_dir.path().join("sample.png");
+        fs::write(&image_path, tiny_png_bytes()).expect("write image");
+        let mut content = vtcode_core::utils::at_pattern::parse_at_patterns_with_options(
+            "look @sample.png",
+            temp_dir.path(),
+            vtcode_core::utils::at_pattern::AtPatternOptions::default(),
+        )
+        .await
+        .expect("parse image");
+
+        append_submitted_attachments(
+            &mut content,
+            &[UiContentPart::image("pasted-image", "image/png")],
+        );
+
+        assert_image_payload_order(&content, &["iVBOR", "pasted-image"]);
+    }
+
+    #[tokio::test]
+    async fn data_image_stays_before_pasted_image() {
+        let mut content = vtcode_core::utils::at_pattern::parse_at_patterns_with_options(
+            "look data:image/png;base64,parsedimage",
+            Path::new("."),
+            vtcode_core::utils::at_pattern::AtPatternOptions::default(),
+        )
+        .await
+        .expect("parse data image");
+
+        append_submitted_attachments(
+            &mut content,
+            &[UiContentPart::image("pasted-image", "image/png")],
+        );
+
+        assert_image_payload_order(&content, &["parsedimage", "pasted-image"]);
+    }
+
+    #[test]
+    fn clipboard_images_are_appended_after_refined_text_and_parsed_parts() {
+        let mut content = uni::MessageContent::parts(vec![
+            uni::ContentPart::text("refined prompt".to_string()),
+            uni::ContentPart::image("parsed-image".to_string(), "image/png".to_string()),
+        ]);
+
+        append_submitted_attachments(
+            &mut content,
+            &[UiContentPart::image("pasted-image", "image/png")],
+        );
+
+        match content {
+            uni::MessageContent::Parts(parts) => {
+                assert!(matches!(
+                    parts.as_slice(),
+                    [
+                        uni::ContentPart::Text { .. },
+                        uni::ContentPart::Image { .. },
+                        uni::ContentPart::Image { .. }
+                    ]
+                ));
+                assert_eq!(
+                    image_payloads(&uni::MessageContent::parts(parts)),
+                    vec!["parsed-image".to_string(), "pasted-image".to_string()]
+                );
+            }
+            uni::MessageContent::Text(_) => panic!("expected parts"),
+        }
+    }
+
+    #[test]
+    fn metadata_remains_trailing_after_all_image_parts() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let file_path = temp_dir.path().join("README.md");
+        fs::write(&file_path, "# test\n").expect("write file");
+        let mut content = uni::MessageContent::parts(vec![
+            uni::ContentPart::text("check @README.md".to_string()),
+            uni::ContentPart::image("parsed-image".to_string(), "image/png".to_string()),
+        ]);
+        append_submitted_attachments(
+            &mut content,
+            &[UiContentPart::image("pasted-image", "image/png")],
+        );
+
+        append_file_reference_metadata(&mut content, "check @README.md", temp_dir.path());
+        append_agent_reference_metadata(&mut content, &[String::from("rust-engineer")]);
+
+        match content {
+            uni::MessageContent::Parts(parts) => {
+                assert!(matches!(parts[1], uni::ContentPart::Image { .. }));
+                assert!(matches!(parts[2], uni::ContentPart::Image { .. }));
+                assert!(matches!(parts[3], uni::ContentPart::Text { .. }));
+                assert!(matches!(parts[4], uni::ContentPart::Text { .. }));
+                assert!(
+                    parts[3]
+                        .as_text()
+                        .unwrap_or("")
+                        .contains("[file_reference_metadata]")
+                );
+                assert!(
+                    parts[4]
+                        .as_text()
+                        .unwrap_or("")
+                        .contains("[agent_reference_metadata]")
+                );
+            }
+            uni::MessageContent::Text(_) => panic!("expected parts"),
+        }
+    }
+
+    #[test]
+    fn unsupported_model_rejects_submitted_image_attachments() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let input = SubmittedInput::new(
+            "please inspect this",
+            vec![UiContentPart::image("pasted-image", "image/png")],
+        );
+
+        assert!(submitted_images_are_unsupported(
+            &input,
+            false,
+            temp_dir.path()
+        ));
+        assert!(!submitted_images_are_unsupported(
+            &input,
+            true,
+            temp_dir.path()
+        ));
+        assert_eq!(input.text, "please inspect this");
+        assert_eq!(
+            input.attachments,
+            vec![UiContentPart::image("pasted-image", "image/png")]
+        );
+    }
+
+    #[test]
+    fn unsupported_model_rejects_text_data_image() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let input = SubmittedInput::from("look data:image/png;base64,parsedimage".to_string());
+
+        assert!(submitted_images_are_unsupported(
+            &input,
+            false,
+            temp_dir.path()
+        ));
+        assert!(!submitted_images_are_unsupported(
+            &input,
+            true,
+            temp_dir.path()
+        ));
+        assert_eq!(input.text, "look data:image/png;base64,parsedimage");
+        assert!(input.attachments.is_empty());
+    }
+
+    #[test]
+    fn unsupported_model_rejects_text_at_image_path() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let image_path = temp_dir.path().join("sample.png");
+        fs::write(&image_path, tiny_png_bytes()).expect("write image");
+        let input = SubmittedInput::from("look @sample.png".to_string());
+
+        assert!(submitted_images_are_unsupported(
+            &input,
+            false,
+            temp_dir.path()
+        ));
+        assert!(input.attachments.is_empty());
+    }
+
+    #[test]
+    fn unsupported_model_rejects_text_raw_image_path() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let image_path = temp_dir.path().join("raw.png");
+        fs::write(&image_path, tiny_png_bytes()).expect("write image");
+        let input = SubmittedInput::from(format!("look {}", image_path.display()));
+
+        assert!(submitted_images_are_unsupported(
+            &input,
+            false,
+            temp_dir.path()
+        ));
+        assert!(input.attachments.is_empty());
+    }
+
+    #[test]
+    fn unsupported_model_rejects_text_image_url() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let input =
+            SubmittedInput::from("look @https://example.com/sample.png?cache=1".to_string());
+
+        assert!(submitted_images_are_unsupported(
+            &input,
+            false,
+            temp_dir.path()
+        ));
+        assert!(input.attachments.is_empty());
+    }
+
+    #[test]
+    fn update_input_text_preserves_attachments_for_submit_time_gating() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let image = UiContentPart::image("pasted-image", "image/png");
+        let mut input = SubmittedInput::new("/compact please inspect this", vec![image.clone()]);
+
+        replace_submitted_input_text(&mut input, "please inspect this".to_string());
+
+        assert_eq!(input.text, "please inspect this");
+        assert_eq!(input.attachments, vec![image]);
+        assert!(submitted_images_are_unsupported(
+            &input,
+            false,
+            temp_dir.path()
+        ));
+    }
+
+    fn tiny_png_bytes() -> &'static [u8] {
+        &[
+            137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1,
+            8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 10, 73, 68, 65, 84, 120, 156, 99, 0, 1, 0, 0,
+            5, 0, 1, 13, 10, 45, 180, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]
+    }
+
+    fn image_payloads(content: &uni::MessageContent) -> Vec<String> {
+        let uni::MessageContent::Parts(parts) = content else {
+            return Vec::new();
+        };
+        parts
+            .iter()
+            .filter_map(|part| match part {
+                uni::ContentPart::Image { data, .. } => Some(data.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn assert_image_payload_order(content: &uni::MessageContent, expected_prefixes: &[&str]) {
+        let payloads = image_payloads(content);
+        assert_eq!(payloads.len(), expected_prefixes.len());
+        for (payload, expected_prefix) in payloads.iter().zip(expected_prefixes) {
+            assert!(
+                payload.starts_with(expected_prefix),
+                "payload {payload:?} should start with {expected_prefix:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
 
-use vtcode_config::models::Provider;
+use vtcode_config::models::{ModelId, Provider};
 use vtcode_core::config::EditorToolConfig;
 use vtcode_core::config::constants::tools as tool_names;
 use vtcode_core::config::loader::VTCodeConfig;
@@ -603,9 +603,15 @@ pub(super) fn selected_model_supports_image_input(
     model: &str,
     provider_supports_vision: bool,
 ) -> bool {
-    let Ok(provider) = provider_key.trim().parse::<Provider>() else {
+    let Some(provider) = parse_image_capability_provider(provider_key) else {
         return provider_supports_vision;
     };
+
+    if let Some(input_modalities) = model_id_input_modalities_for_provider(provider, model) {
+        return input_modalities
+            .iter()
+            .any(|modality| modality.eq_ignore_ascii_case("image"));
+    }
 
     let Some(resolved) = ModelResolver::resolve(Some(provider.as_ref()), model, &[], None) else {
         return provider_supports_vision;
@@ -618,6 +624,65 @@ pub(super) fn selected_model_supports_image_input(
     input_modalities
         .iter()
         .any(|modality| modality.eq_ignore_ascii_case("image"))
+}
+
+fn parse_image_capability_provider(provider_key: &str) -> Option<Provider> {
+    let trimmed = provider_key.trim();
+    if let Ok(provider) = trimmed.parse::<Provider>() {
+        return Some(provider);
+    }
+
+    // Runtime header labels may include the auth mode. Capability checks should
+    // still use the selected provider's model metadata.
+    trimmed.starts_with("OpenAI").then_some(Provider::OpenAI)
+}
+
+fn model_id_input_modalities_for_provider(
+    provider: Provider,
+    model: &str,
+) -> Option<&'static [&'static str]> {
+    for candidate in model_id_candidates(model) {
+        let Ok(model_id) = candidate.parse::<ModelId>() else {
+            continue;
+        };
+        if model_id.provider() != provider {
+            continue;
+        }
+        let input_modalities = model_id.input_modalities();
+        if !input_modalities.is_empty() {
+            return Some(input_modalities);
+        }
+    }
+
+    None
+}
+
+fn model_id_candidates(model: &str) -> Vec<String> {
+    let trimmed = model.trim();
+    let mut candidates = Vec::new();
+    push_unique_candidate(&mut candidates, trimmed);
+
+    let lower = trimmed.to_ascii_lowercase();
+    push_unique_candidate(&mut candidates, &lower);
+
+    if let Some((prefix, _)) = trimmed.split_once(" (") {
+        let prefix = prefix.trim();
+        push_unique_candidate(&mut candidates, prefix);
+        let lower_prefix = prefix.to_ascii_lowercase();
+        push_unique_candidate(&mut candidates, &lower_prefix);
+    }
+
+    candidates
+}
+
+fn push_unique_candidate(candidates: &mut Vec<String>, value: &str) {
+    if value.is_empty() {
+        return;
+    }
+    if candidates.iter().any(|candidate| candidate == value) {
+        return;
+    }
+    candidates.push(value.to_string());
 }
 
 pub(super) fn replace_submitted_input_text(input: &mut SubmittedInput, text: String) {
@@ -1903,6 +1968,33 @@ mod tests {
     fn selected_model_image_support_uses_image_modality_metadata() {
         assert!(selected_model_supports_image_input(
             "openai", "gpt-5.4", false
+        ));
+    }
+
+    #[test]
+    fn selected_model_image_support_uses_alias_modality_metadata() {
+        assert!(selected_model_supports_image_input(
+            "openai",
+            "gpt-5.5-2026-04-23",
+            false
+        ));
+    }
+
+    #[test]
+    fn selected_model_image_support_accepts_chatgpt_provider_label() {
+        assert!(selected_model_supports_image_input(
+            "OpenAI (ChatGPT)",
+            "gpt-5.5",
+            false
+        ));
+    }
+
+    #[test]
+    fn selected_model_image_support_accepts_display_model_label() {
+        assert!(selected_model_supports_image_input(
+            "OpenAI (ChatGPT)",
+            "GPT-5.5 (128K)",
+            false
         ));
     }
 

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
@@ -7,11 +7,13 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
 
+use vtcode_config::models::Provider;
 use vtcode_core::config::EditorToolConfig;
 use vtcode_core::config::constants::tools as tool_names;
 use vtcode_core::config::loader::VTCodeConfig;
 use vtcode_core::core::threads::ArchivedSessionIntent;
 use vtcode_core::hooks::{LifecycleHookEngine, SessionStartTrigger};
+use vtcode_core::llm::ModelResolver;
 use vtcode_core::llm::provider as uni;
 use vtcode_core::notifications::set_global_notification_hook_engine;
 use vtcode_core::scheduler::{DurableTaskStore, SchedulerDaemon};
@@ -594,6 +596,28 @@ pub(super) fn submitted_images_are_unsupported(
             .iter()
             .any(vtcode_ui::tui::app::ContentPart::is_image)
             || vtcode_core::utils::at_pattern::input_may_parse_image_parts(&input.text, workspace))
+}
+
+pub(super) fn selected_model_supports_image_input(
+    provider_key: &str,
+    model: &str,
+    provider_supports_vision: bool,
+) -> bool {
+    let Ok(provider) = provider_key.trim().parse::<Provider>() else {
+        return provider_supports_vision;
+    };
+
+    let Some(resolved) = ModelResolver::resolve(Some(provider.as_ref()), model, &[], None) else {
+        return provider_supports_vision;
+    };
+    let input_modalities = resolved.input_modalities();
+    if input_modalities.is_empty() {
+        return provider_supports_vision;
+    }
+
+    input_modalities
+        .iter()
+        .any(|modality| modality.eq_ignore_ascii_case("image"))
 }
 
 pub(super) fn replace_submitted_input_text(input: &mut SubmittedInput, text: String) {
@@ -1873,6 +1897,36 @@ mod tests {
         ));
         assert_eq!(input.text, "look data:image/png;base64,parsedimage");
         assert!(input.attachments.is_empty());
+    }
+
+    #[test]
+    fn selected_model_image_support_uses_image_modality_metadata() {
+        assert!(selected_model_supports_image_input(
+            "openai", "gpt-5.4", false
+        ));
+    }
+
+    #[test]
+    fn selected_model_image_support_rejects_text_only_metadata() {
+        assert!(!selected_model_supports_image_input(
+            "openai",
+            "gpt-oss-20b",
+            true
+        ));
+    }
+
+    #[test]
+    fn selected_model_image_support_falls_back_without_metadata() {
+        assert!(selected_model_supports_image_input(
+            "openai",
+            "custom-vision-model",
+            true
+        ));
+        assert!(!selected_model_supports_image_input(
+            "custom-provider",
+            "gpt-5.4",
+            false
+        ));
     }
 
     #[test]

--- a/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
+++ b/src/agent/runloop/unified/turn/session/interaction_loop_runner/support.rs
@@ -21,6 +21,7 @@ use vtcode_core::ui::theme;
 use vtcode_core::ui::{inline_theme_from_core_styles, to_tui_appearance};
 use vtcode_core::utils::ansi::MessageStyle;
 use vtcode_core::{build_primary_agent_hook_config, build_primary_agent_runtime_config};
+use vtcode_ui::tui::app::{ContentPart as UiContentPart, SubmittedInput};
 
 use crate::agent::runloop::prompt::refine_and_enrich_prompt;
 use crate::agent::runloop::unified::async_mcp_manager::{
@@ -67,7 +68,7 @@ pub(super) struct LiveIdeContextUpdate {
 
 pub(super) enum InlineLoopActionResolution {
     ContinueLoop,
-    Submit(String),
+    Submit(SubmittedInput),
     Outcome(InteractionOutcome),
 }
 
@@ -561,6 +562,43 @@ pub(super) async fn build_user_message_content(
     append_agent_reference_metadata(refined_content, selected_agents.as_slice())
 }
 
+pub(super) async fn build_submitted_user_message_content(
+    ctx: &mut InteractionLoopContext<'_>,
+    input: &SubmittedInput,
+) -> uni::MessageContent {
+    let content = build_user_message_content(ctx, input.text.as_str()).await;
+    append_submitted_attachments(content, input.attachments.as_slice())
+}
+
+fn append_submitted_attachments(
+    content: uni::MessageContent,
+    attachments: &[UiContentPart],
+) -> uni::MessageContent {
+    if attachments.is_empty() {
+        return content;
+    }
+
+    let mut parts = match content {
+        uni::MessageContent::Text(text) => {
+            if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![uni::ContentPart::text(text)]
+            }
+        }
+        uni::MessageContent::Parts(parts) => parts,
+    };
+
+    parts.extend(attachments.iter().map(|attachment| match attachment {
+        UiContentPart::Text { text } => uni::ContentPart::text(text.clone()),
+        UiContentPart::Image { data, media_type } => {
+            uni::ContentPart::image(data.clone(), media_type.clone())
+        }
+    }));
+
+    uni::MessageContent::parts(parts)
+}
+
 pub(super) fn refresh_ide_context_before_user_turn(
     ctx: &mut InteractionLoopContext<'_>,
     input_status_state: &mut InputStatusState,
@@ -777,7 +815,7 @@ pub(super) async fn resolve_inline_loop_action(
             if let Some(primary_agent) = queued.primary_agent {
                 handle_select_primary_agent(ctx, state, Some(primary_agent)).await?;
             }
-            InlineLoopActionResolution::Submit(queued.text)
+            InlineLoopActionResolution::Submit(queued.input)
         }
         InlineLoopAction::CyclePrimaryAgent => {
             handle_cycle_primary_agent(ctx, state).await?;

--- a/vtcode-config/src/models/tests.rs
+++ b/vtcode-config/src/models/tests.rs
@@ -476,6 +476,10 @@ fn test_generated_model_capability_lookup() {
     assert_eq!(gpt54_catalog.context_window, 1_050_000);
     assert!(gpt54_catalog.tool_call);
     assert_eq!(gpt54_catalog.input_modalities, &["text", "image"]);
+    let gpt55_catalog = model_catalog_entry("openai", "gpt-5.5").expect("gpt-5.5 metadata");
+    assert_eq!(gpt55_catalog.context_window, 1_050_000);
+    assert!(gpt55_catalog.tool_call);
+    assert_eq!(gpt55_catalog.input_modalities, &["text", "image"]);
 
     let gemini_catalog = model_catalog_entry("google", "gemini-3-flash-preview")
         .expect("gemini-3-flash-preview metadata");
@@ -523,6 +527,7 @@ fn test_gpt_5_5_dated_alias_round_trips_to_gpt55_capabilities() {
         ModelId::from_str(models::openai::GPT_5_5_DATED).unwrap(),
         ModelId::GPT55
     );
+    assert_eq!(ModelId::GPT55.input_modalities(), &["text", "image"]);
     assert!(
         models::openai::RESPONSES_API_MODELS.contains(&models::openai::GPT_5_5_DATED),
         "dated GPT-5.5 alias should stay on the Responses API path"

--- a/vtcode-core/src/ui/tui.rs
+++ b/vtcode-core/src/ui/tui.rs
@@ -36,13 +36,14 @@ mod headless {
     };
 
     use crate::ui::theme::ThemeStyles;
+    pub use vtcode_ui::tui::app::{ContentPart, SubmittedInput};
 
     /// Headless `InlineEvent` — all variants present so match arms compile.
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum InlineEvent {
-        Submit(String),
-        QueueSubmit(String),
-        Steer(String),
+        Submit(SubmittedInput),
+        QueueSubmit(SubmittedInput),
+        Steer(SubmittedInput),
         ProcessLatestQueued,
         EditQueue,
         Cancel,
@@ -85,6 +86,7 @@ mod headless {
             kind: InlineMessageKind,
             lines: Vec<Vec<InlineSegment>>,
         },
+        RestoreInputDraft(SubmittedInput),
         ForceRedraw,
         Shutdown,
         ClearScreen,
@@ -164,6 +166,9 @@ mod headless {
         }
         pub fn close_modal(&self) {
             self.send_command(InlineCommand::CloseModal);
+        }
+        pub fn restore_input_draft(&self, input: SubmittedInput) {
+            self.send_command(InlineCommand::RestoreInputDraft(input));
         }
         pub fn set_reasoning_stage(&self, stage: Option<String>) {
             self.send_command(InlineCommand::SetReasoningStage(stage));

--- a/vtcode-core/src/ui/tui.rs
+++ b/vtcode-core/src/ui/tui.rs
@@ -86,6 +86,7 @@ mod headless {
             kind: InlineMessageKind,
             lines: Vec<Vec<InlineSegment>>,
         },
+        SetImageInputEnabled(bool),
         RestoreInputDraft(SubmittedInput),
         ForceRedraw,
         Shutdown,
@@ -169,6 +170,9 @@ mod headless {
         }
         pub fn restore_input_draft(&self, input: SubmittedInput) {
             self.send_command(InlineCommand::RestoreInputDraft(input));
+        }
+        pub fn set_image_input_enabled(&self, enabled: bool) {
+            self.send_command(InlineCommand::SetImageInputEnabled(enabled));
         }
         pub fn set_reasoning_stage(&self, stage: Option<String>) {
             self.send_command(InlineCommand::SetReasoningStage(stage));

--- a/vtcode-core/src/utils/at_pattern.rs
+++ b/vtcode-core/src/utils/at_pattern.rs
@@ -220,6 +220,37 @@ pub async fn parse_at_patterns_with_options(
     Ok(MessageContent::parts(parts))
 }
 
+/// Returns true when `input` contains an image reference that this parser would
+/// attempt to turn into an image content part.
+pub fn input_may_parse_image_parts(input: &str, base_dir: &Path) -> bool {
+    let at_matches = vtcode_commons::at_pattern::find_at_patterns(input);
+    let protected_ranges: Vec<(usize, usize)> =
+        at_matches.iter().map(|m| (m.start, m.end)).collect();
+
+    if at_matches.iter().any(|m| {
+        let path = m.path;
+        if path.starts_with("http://") || path.starts_with("https://") {
+            looks_like_image_url(path)
+        } else {
+            resolve_image_path(path, base_dir).is_some_and(|file_path| {
+                crate::utils::image_processing::has_supported_image_extension(&file_path)
+                    && file_path.exists()
+            })
+        }
+    }) {
+        return true;
+    }
+
+    if find_raw_image_path_matches(input, &protected_ranges)
+        .iter()
+        .any(|m| resolve_image_path(&m.raw, base_dir).is_some_and(|image_path| image_path.exists()))
+    {
+        return true;
+    }
+
+    !find_data_url_matches(input, &protected_ranges).is_empty()
+}
+
 #[derive(Debug)]
 struct RawPathMatch {
     start: usize,

--- a/vtcode-ui/Cargo.toml
+++ b/vtcode-ui/Cargo.toml
@@ -23,6 +23,7 @@ anstyle          = { workspace = true }
 anstyle-git      = { workspace = true }
 anstyle-ls       = "1.0"
 anyhow           = { workspace = true }
+base64           = { workspace = true }
 better-panic     = "0.3"
 catppuccin       = { version = "2.8", default-features = false }
 chrono           = { workspace = true }
@@ -32,6 +33,7 @@ futures          = { workspace = true }
 hashbrown        = { workspace = true }
 humantime        = "2.1"
 human-panic      = "2.0"
+image            = { workspace = true }
 line-clipping    = "0.3"
 nucleo-matcher   = "0.3"
 once_cell        = { workspace = true }
@@ -57,6 +59,9 @@ unicode-segmentation = "1.13"
 unicode-width    = { workspace = true }
 vtcode-commons   = { path = "../vtcode-commons", version = "0.134.3" }
 vtcode-config    = { path = "../vtcode-config", version = "0.134.3" }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+arboard          = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/vtcode-ui/src/tui/core.rs
+++ b/vtcode-ui/src/tui/core.rs
@@ -16,7 +16,7 @@ pub use crate::tui::core_tui::types::{
     InlineMessageKind, InlineSegment, InlineTextStyle, InlineTheme, ListOverlayRequest,
     ModalOverlayRequest, OpenAIServiceTierChoice, OverlayEvent, OverlayHotkey, OverlayHotkeyAction,
     OverlayHotkeyKey, OverlayRequest, OverlaySelectionChange, OverlaySubmission, RewindAction,
-    SecurePromptConfig, WizardModalMode, WizardOverlayRequest, WizardStep,
+    SecurePromptConfig, SubmittedInput, WizardModalMode, WizardOverlayRequest, WizardStep,
 };
 pub use crate::tui::options::{
     FullscreenInteractionSettings, KeyboardProtocolSettings, SessionSurface,

--- a/vtcode-ui/src/tui/core_tui/app/session/events.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/events.rs
@@ -173,7 +173,9 @@ fn handle_image_paste_shortcut_with(
                     .input_manager
                     .insert_text(&format!("[Image #{attachment_number}]"));
             }
-            session.core.set_input_compact_mode(false);
+            session
+                .core
+                .set_input_compact_mode(session.core.input_compact_placeholder().is_some());
             session.update_input_triggers();
             session.mark_dirty();
         }

--- a/vtcode-ui/src/tui/core_tui/app/session/events.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/events.rs
@@ -14,7 +14,7 @@ use crate::tui::core_tui::session::reverse_search;
 use crate::tui::core_tui::style::theme_from_styles;
 use crate::tui::core_tui::types::InlineSegment;
 use crate::tui::core_tui::types::{
-    InlineEvent as CoreInlineEvent, OverlayEvent, OverlaySelectionChange,
+    InlineEvent as CoreInlineEvent, OverlayEvent, OverlaySelectionChange, SubmittedInput,
 };
 use crate::tui::ui::theme;
 
@@ -51,7 +51,7 @@ pub(super) fn handle_paste(session: &mut Session, content: &str) -> Option<Inlin
         // while the event is in-flight to the interaction loop.
         session.close_overlay();
         session.mark_dirty();
-        return Some(InlineEvent::Submit(submitted));
+        return Some(InlineEvent::Submit(submitted.into()));
     }
 
     if let Some(review) = session.transcript_review_state_mut()
@@ -429,11 +429,11 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
         }
         KeyCode::Char('m') | KeyCode::Char('M') if has_control && !has_alt && !has_command => {
             session.mark_dirty();
-            Some(InlineEvent::Submit("/model".to_string()))
+            Some(InlineEvent::Submit("/model".into()))
         }
         KeyCode::Char('s') | KeyCode::Char('S') if has_alt && !has_control && !has_command => {
             session.mark_dirty();
-            Some(InlineEvent::Submit("/subprocesses".to_string()))
+            Some(InlineEvent::Submit("/subprocesses".into()))
         }
         KeyCode::Char('a') | KeyCode::Char('A') if has_control && !has_command && !has_alt => {
             if session.core.input_enabled() {
@@ -495,7 +495,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
         }
         KeyCode::Char('l') | KeyCode::Char('L') if has_control => {
             session.mark_dirty();
-            Some(InlineEvent::Submit("/clear".to_string()))
+            Some(InlineEvent::Submit("/clear".into()))
         }
         KeyCode::BackTab => {
             session.clear_inline_prompt_suggestion();
@@ -529,7 +529,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
                 if is_double_esc {
                     session.core.last_esc_press = None;
                     session.mark_dirty();
-                    Some(InlineEvent::Submit("/rewind".to_string()))
+                    Some(InlineEvent::Submit("/rewind".into()))
                 } else {
                     session.core.last_esc_press = Some(now);
                     session.mark_dirty();
@@ -633,7 +633,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
                 && session.active_pty_session_count() > 0
             {
                 session.mark_dirty();
-                return Some(InlineEvent::Submit("/jobs".to_string()));
+                return Some(InlineEvent::Submit("/jobs".into()));
             }
 
             // Check for backslash + Enter quick escape (insert newline without submitting)
@@ -688,7 +688,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
             // If a turn is actively running, queue the message so it starts immediately after
             // the current turn completes. Otherwise submit directly so the turn starts now.
             if session.is_running_activity() {
-                session.push_queued_input(submitted.clone());
+                session.push_queued_input(submitted.text.clone());
                 Some(InlineEvent::QueueSubmit(submitted))
             } else {
                 Some(InlineEvent::Submit(submitted))
@@ -821,7 +821,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
         KeyCode::Char('o') | KeyCode::Char('O') if has_control && !has_alt && !has_command => {
             // Ctrl+O: Copy last agent response as markdown to clipboard
             session.mark_dirty();
-            Some(InlineEvent::Submit("/copy".to_string()))
+            Some(InlineEvent::Submit("/copy".into()))
         }
         KeyCode::Char('t') | KeyCode::Char('T') if has_control => {
             session.toggle_logs();
@@ -1209,17 +1209,18 @@ fn can_cycle_primary_agent(session: &Session, key: &KeyEvent) -> bool {
         && !session.has_active_overlay()
 }
 
-fn take_submitted_input(session: &mut Session) -> Option<String> {
+fn take_submitted_input(session: &mut Session) -> Option<SubmittedInput> {
     let submitted = session.core.input_manager.content().to_owned();
     let submitted_entry = session.core.input_manager.current_history_entry();
     clear_submitted_input(session);
 
-    if submitted.trim().is_empty() {
+    if submitted_entry.is_empty() {
         return None;
     }
 
+    let attachments = submitted_entry.attachment_elements();
     session.remember_submitted_input(submitted_entry);
-    Some(submitted)
+    Some(SubmittedInput::new(submitted, attachments))
 }
 
 fn clear_submitted_input(session: &mut Session) {

--- a/vtcode-ui/src/tui/core_tui/app/session/events.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/events.rs
@@ -167,10 +167,13 @@ fn handle_image_paste_shortcut_with(
 
     match image_reader() {
         Ok(image) => {
-            session.core.input_manager.push_attachment(image);
-            session
-                .core
-                .set_input_compact_mode(session.core.input_compact_placeholder().is_some());
+            if let Some(attachment_number) = session.core.input_manager.push_attachment(image) {
+                session
+                    .core
+                    .input_manager
+                    .insert_text(&format!("[Image #{attachment_number}]"));
+            }
+            session.core.set_input_compact_mode(false);
             session.update_input_triggers();
             session.mark_dirty();
         }

--- a/vtcode-ui/src/tui/core_tui/app/session/events.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/events.rs
@@ -9,6 +9,7 @@ use super::super::types::{
 };
 use crate::tui::core_tui::app::session::transient::TransientSurface;
 use crate::tui::core_tui::app::types::InlineMessageKind;
+use crate::tui::core_tui::session::clipboard_image::{ClipboardImageError, read_clipboard_image};
 use crate::tui::core_tui::session::modal::{ModalKeyModifiers, ModalListKeyResult};
 use crate::tui::core_tui::session::reverse_search;
 use crate::tui::core_tui::style::theme_from_styles;
@@ -116,7 +117,73 @@ fn copy_selected_input_if_requested(
     false
 }
 
+fn image_paste_warning(error: ClipboardImageError) -> &'static str {
+    match error {
+        ClipboardImageError::NoImage => "No image found in clipboard.",
+        ClipboardImageError::ClipboardUnavailable => {
+            "Clipboard image paste is unavailable in this terminal or desktop session."
+        }
+        ClipboardImageError::UnsupportedModel => "The selected model does not support image input.",
+        ClipboardImageError::WslFallbackFailure => {
+            "Could not read a clipboard image from Windows via PowerShell."
+        }
+    }
+}
+
+fn push_warning_line(session: &mut Session, text: &'static str) {
+    session.push_line(
+        InlineMessageKind::Warning,
+        vec![InlineSegment {
+            text: text.to_string(),
+            style: Arc::new(InlineTextStyle::default()),
+        }],
+    );
+    session.core.request_transcript_clear();
+    session.mark_dirty();
+}
+
+fn is_image_paste_shortcut(
+    key: &KeyEvent,
+    has_control: bool,
+    has_alt: bool,
+    has_command: bool,
+) -> bool {
+    matches!(key.code, KeyCode::Char('v') | KeyCode::Char('V'))
+        && !has_command
+        && ((has_control && !has_alt) || (has_alt && !has_control))
+}
+
+fn handle_image_paste_shortcut_with(
+    session: &mut Session,
+    mut image_reader: impl FnMut() -> Result<ContentPart, ClipboardImageError>,
+) {
+    if !session.core.image_input_enabled() {
+        push_warning_line(
+            session,
+            image_paste_warning(ClipboardImageError::UnsupportedModel),
+        );
+        return;
+    }
+
+    match image_reader() {
+        Ok(image) => {
+            session.core.input_manager.push_attachment(image);
+            session.update_input_triggers();
+            session.mark_dirty();
+        }
+        Err(error) => push_warning_line(session, image_paste_warning(error)),
+    }
+}
+
 pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<InlineEvent> {
+    process_key_with_clipboard_image_reader(session, key, read_clipboard_image)
+}
+
+pub(super) fn process_key_with_clipboard_image_reader(
+    session: &mut Session,
+    key: KeyEvent,
+    image_reader: impl FnMut() -> Result<ContentPart, ClipboardImageError>,
+) -> Option<InlineEvent> {
     let modifiers = key.modifiers;
     let has_control = modifiers.contains(KeyModifiers::CONTROL);
     let has_shift = modifiers.contains(KeyModifiers::SHIFT);
@@ -129,6 +196,13 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
     let has_alt = raw_alt && !has_command;
 
     if copy_selected_input_if_requested(session, &key, has_command) {
+        return None;
+    }
+
+    if is_image_paste_shortcut(&key, has_control, has_alt, has_command) {
+        if session.core.input_enabled() {
+            handle_image_paste_shortcut_with(session, image_reader);
+        }
         return None;
     }
 

--- a/vtcode-ui/src/tui/core_tui/app/session/events.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/events.rs
@@ -168,6 +168,9 @@ fn handle_image_paste_shortcut_with(
     match image_reader() {
         Ok(image) => {
             session.core.input_manager.push_attachment(image);
+            session
+                .core
+                .set_input_compact_mode(session.core.input_compact_placeholder().is_some());
             session.update_input_triggers();
             session.mark_dirty();
         }

--- a/vtcode-ui/src/tui/core_tui/app/session/impl_events.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/impl_events.rs
@@ -17,6 +17,18 @@ impl Session {
         events::process_key(self, key)
     }
 
+    #[cfg(test)]
+    pub(crate) fn process_key_with_clipboard_image_reader(
+        &mut self,
+        key: KeyEvent,
+        image_reader: impl FnMut() -> Result<
+            crate::tui::core_tui::types::ContentPart,
+            crate::tui::core_tui::session::clipboard_image::ClipboardImageError,
+        >,
+    ) -> Option<InlineEvent> {
+        events::process_key_with_clipboard_image_reader(self, key, image_reader)
+    }
+
     fn input_area_contains(&self, column: u16, row: u16) -> bool {
         self.core.input_area().is_some_and(|area| {
             row >= area.y

--- a/vtcode-ui/src/tui/core_tui/app/session/local_agents.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/local_agents.rs
@@ -201,14 +201,17 @@ impl AppSession {
     fn selected_local_agent_inspect_event(&mut self) -> Option<InlineEvent> {
         let entry = self.local_agents_state.selected_entry()?.clone();
         self.mark_dirty();
-        Some(InlineEvent::Submit(match entry.kind {
-            crate::tui::core_tui::types::LocalAgentKind::Delegated => {
-                format!("/agent inspect {}", entry.id)
+        Some(InlineEvent::Submit(
+            match entry.kind {
+                crate::tui::core_tui::types::LocalAgentKind::Delegated => {
+                    format!("/agent inspect {}", entry.id)
+                }
+                crate::tui::core_tui::types::LocalAgentKind::Background => {
+                    format!("/subprocesses inspect {}", entry.id)
+                }
             }
-            crate::tui::core_tui::types::LocalAgentKind::Background => {
-                format!("/subprocesses inspect {}", entry.id)
-            }
-        }))
+            .into(),
+        ))
     }
 
     fn selected_local_agent_transcript_event(&mut self) -> Option<InlineEvent> {
@@ -226,26 +229,32 @@ impl AppSession {
     fn selected_local_agent_stop_event(&mut self) -> Option<InlineEvent> {
         let entry = self.local_agents_state.selected_entry()?.clone();
         self.mark_dirty();
-        Some(InlineEvent::Submit(match entry.kind {
-            crate::tui::core_tui::types::LocalAgentKind::Delegated => {
-                format!("/agent close {}", entry.id)
+        Some(InlineEvent::Submit(
+            match entry.kind {
+                crate::tui::core_tui::types::LocalAgentKind::Delegated => {
+                    format!("/agent close {}", entry.id)
+                }
+                crate::tui::core_tui::types::LocalAgentKind::Background => {
+                    format!("/subprocesses stop {}", entry.id)
+                }
             }
-            crate::tui::core_tui::types::LocalAgentKind::Background => {
-                format!("/subprocesses stop {}", entry.id)
-            }
-        }))
+            .into(),
+        ))
     }
 
     fn selected_local_agent_force_cancel_event(&mut self) -> Option<InlineEvent> {
         let entry = self.local_agents_state.selected_entry()?.clone();
         self.mark_dirty();
-        Some(InlineEvent::Submit(match entry.kind {
-            crate::tui::core_tui::types::LocalAgentKind::Delegated => {
-                format!("/agent close {}", entry.id)
+        Some(InlineEvent::Submit(
+            match entry.kind {
+                crate::tui::core_tui::types::LocalAgentKind::Delegated => {
+                    format!("/agent close {}", entry.id)
+                }
+                crate::tui::core_tui::types::LocalAgentKind::Background => {
+                    format!("/subprocesses cancel {}", entry.id)
+                }
             }
-            crate::tui::core_tui::types::LocalAgentKind::Background => {
-                format!("/subprocesses cancel {}", entry.id)
-            }
-        }))
+            .into(),
+        ))
     }
 }

--- a/vtcode-ui/src/tui/core_tui/app/session/mod.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/mod.rs
@@ -798,6 +798,7 @@ fn to_core_command(command: &InlineCommand) -> Option<crate::tui::core_tui::type
         },
         InlineCommand::SetCursorVisible(value) => CoreCommand::SetCursorVisible(*value),
         InlineCommand::SetInputEnabled(value) => CoreCommand::SetInputEnabled(*value),
+        InlineCommand::SetImageInputEnabled(value) => CoreCommand::SetImageInputEnabled(*value),
         InlineCommand::SetInput(value) => CoreCommand::SetInput(value.clone()),
         InlineCommand::RestoreInputDraft(input) => CoreCommand::RestoreInputDraft(input.clone()),
         InlineCommand::ApplySuggestedPrompt(value) => {

--- a/vtcode-ui/src/tui/core_tui/app/session/mod.rs
+++ b/vtcode-ui/src/tui/core_tui/app/session/mod.rs
@@ -650,6 +650,12 @@ impl AppSession {
                     .handle_command(crate::tui::core_tui::types::InlineCommand::SetInput(value));
                 self.update_input_triggers();
             }
+            InlineCommand::RestoreInputDraft(input) => {
+                self.core.handle_command(
+                    crate::tui::core_tui::types::InlineCommand::RestoreInputDraft(input),
+                );
+                self.update_input_triggers();
+            }
             InlineCommand::ApplySuggestedPrompt(value) => {
                 self.core.handle_command(
                     crate::tui::core_tui::types::InlineCommand::ApplySuggestedPrompt(value),
@@ -793,6 +799,7 @@ fn to_core_command(command: &InlineCommand) -> Option<crate::tui::core_tui::type
         InlineCommand::SetCursorVisible(value) => CoreCommand::SetCursorVisible(*value),
         InlineCommand::SetInputEnabled(value) => CoreCommand::SetInputEnabled(*value),
         InlineCommand::SetInput(value) => CoreCommand::SetInput(value.clone()),
+        InlineCommand::RestoreInputDraft(input) => CoreCommand::RestoreInputDraft(input.clone()),
         InlineCommand::ApplySuggestedPrompt(value) => {
             CoreCommand::ApplySuggestedPrompt(value.clone())
         }

--- a/vtcode-ui/src/tui/core_tui/app/types/mod.rs
+++ b/vtcode-ui/src/tui/core_tui/app/types/mod.rs
@@ -15,7 +15,7 @@ pub use overlay::{
 pub use plan::{PlanContent, PlanPhase, PlanStep};
 pub use protocol::{
     ArchivedPromptEntry, InlineCommand, InlineEvent, InlineEventCallback, InlineHandle,
-    InlineSession,
+    InlineSession, SubmittedInput,
 };
 pub use slash::SlashCommandItem;
 

--- a/vtcode-ui/src/tui/core_tui/app/types/protocol.rs
+++ b/vtcode-ui/src/tui/core_tui/app/types/protocol.rs
@@ -101,6 +101,7 @@ pub enum InlineCommand {
     },
     SetCursorVisible(bool),
     SetInputEnabled(bool),
+    SetImageInputEnabled(bool),
     SetInput(String),
     RestoreInputDraft(SubmittedInput),
     ApplySuggestedPrompt(String),
@@ -380,6 +381,10 @@ impl InlineHandle {
 
     pub fn set_input_enabled(&self, enabled: bool) {
         self.send_command(InlineCommand::SetInputEnabled(enabled));
+    }
+
+    pub fn set_image_input_enabled(&self, enabled: bool) {
+        self.send_command(InlineCommand::SetImageInputEnabled(enabled));
     }
 
     pub fn set_input(&self, content: String) {

--- a/vtcode-ui/src/tui/core_tui/app/types/protocol.rs
+++ b/vtcode-ui/src/tui/core_tui/app/types/protocol.rs
@@ -9,6 +9,7 @@ use super::overlay::{
     TaskPanelTransientRequest, TransientEvent, TransientRequest,
 };
 use crate::tui::core_tui::session::config::AppearanceConfig;
+pub use crate::tui::core_tui::types::SubmittedInput;
 use crate::tui::core_tui::types::{
     InlineHeaderContext, InlineLinkRange, InlineListItem, InlineListSearchConfig,
     InlineListSelection, InlineMessageKind, InlineSegment, InlineTextStyle, InlineTheme,
@@ -101,6 +102,7 @@ pub enum InlineCommand {
     SetCursorVisible(bool),
     SetInputEnabled(bool),
     SetInput(String),
+    RestoreInputDraft(SubmittedInput),
     ApplySuggestedPrompt(String),
     SetInlinePromptSuggestion {
         suggestion: String,
@@ -127,9 +129,9 @@ pub enum InlineCommand {
 
 #[derive(Debug, Clone)]
 pub enum InlineEvent {
-    Submit(String),
-    QueueSubmit(String),
-    Steer(String),
+    Submit(SubmittedInput),
+    QueueSubmit(SubmittedInput),
+    Steer(SubmittedInput),
     ProcessLatestQueued,
     /// Edit the newest queued input (pop into input buffer)
     EditQueue,
@@ -382,6 +384,10 @@ impl InlineHandle {
 
     pub fn set_input(&self, content: String) {
         self.send_command(InlineCommand::SetInput(content));
+    }
+
+    pub fn restore_input_draft(&self, input: SubmittedInput) {
+        self.send_command(InlineCommand::RestoreInputDraft(input));
     }
 
     pub fn apply_suggested_prompt(&self, content: String) {

--- a/vtcode-ui/src/tui/core_tui/mod.rs
+++ b/vtcode-ui/src/tui/core_tui/mod.rs
@@ -26,7 +26,7 @@ pub use types::{
     InlineSession, InlineTextStyle, InlineTheme, ListOverlayRequest, ModalOverlayRequest,
     OverlayEvent, OverlayHotkey, OverlayHotkeyAction, OverlayHotkeyKey, OverlayRequest,
     OverlaySelectionChange, OverlaySubmission, PreviewCallback, RewindAction, SecurePromptConfig,
-    WizardModalMode, WizardOverlayRequest, WizardStep,
+    SubmittedInput, WizardModalMode, WizardOverlayRequest, WizardStep,
 };
 
 use runner::{TuiOptions, run_tui};

--- a/vtcode-ui/src/tui/core_tui/runner/drive.rs
+++ b/vtcode-ui/src/tui/core_tui/runner/drive.rs
@@ -77,6 +77,11 @@ fn suspend_to_shell<B: Backend, S: TuiSessionDriver>(
 
     let suspend_result = (|| -> Result<()> {
         let mut stderr = io::stderr();
+        if !keyboard_flags.is_empty()
+            && let Err(error) = execute!(stderr, PopKeyboardEnhancementFlags)
+        {
+            tracing::debug!(%error, "failed to suspend keyboard enhancement flags");
+        }
         if use_alternate_screen {
             execute!(stderr, LeaveAlternateScreen)
                 .context("failed to leave alternate screen before suspend")?;
@@ -89,11 +94,6 @@ fn suspend_to_shell<B: Backend, S: TuiSessionDriver>(
             && let Err(error) = execute!(stderr, DisableMouseCapture)
         {
             tracing::debug!(%error, "failed to disable mouse capture before suspend");
-        }
-        if !keyboard_flags.is_empty()
-            && let Err(error) = execute!(stderr, PopKeyboardEnhancementFlags)
-        {
-            tracing::debug!(%error, "failed to suspend keyboard enhancement flags");
         }
         // Drain any terminal responses from the disable sequences above
         // while raw mode is still active so individual bytes remain readable.
@@ -114,17 +114,17 @@ fn suspend_to_shell<B: Backend, S: TuiSessionDriver>(
         {
             tracing::debug!(%error, "failed to restore mouse capture after resume");
         }
-        if !keyboard_flags.is_empty()
-            && let Err(error) = execute!(stderr, PushKeyboardEnhancementFlags(keyboard_flags))
-        {
-            tracing::debug!(%error, "failed to restore keyboard enhancement flags after resume");
-        }
         if use_alternate_screen {
             execute!(stderr, EnterAlternateScreen)
                 .context("failed to re-enter alternate screen after resume")?;
             terminal.clear().map_err(|error| {
                 anyhow::anyhow!("failed to clear terminal after resume: {error}")
             })?;
+        }
+        if !keyboard_flags.is_empty()
+            && let Err(error) = execute!(stderr, PushKeyboardEnhancementFlags(keyboard_flags))
+        {
+            tracing::debug!(%error, "failed to restore keyboard enhancement flags after resume");
         }
 
         Ok(())

--- a/vtcode-ui/src/tui/core_tui/runner/mod.rs
+++ b/vtcode-ui/src/tui/core_tui/runner/mod.rs
@@ -283,11 +283,8 @@ where
 
     let keyboard_flags = crate::tui::config::keyboard_protocol_to_flags(&options.keyboard_protocol);
     let mut stderr = io::stderr();
-    let mut mode_restore_guard = TerminalModeRestoreGuard::new(enable_terminal_modes(
-        &mut stderr,
-        keyboard_flags,
-        &options.fullscreen,
-    )?);
+    let mut mode_restore_guard =
+        TerminalModeRestoreGuard::new(enable_terminal_modes(&mut stderr, &options.fullscreen)?);
     mode_restore_guard
         .state_mut()
         .save_cursor_position(&mut stderr);
@@ -296,6 +293,9 @@ where
             .state_mut()
             .enter_alternate_screen(&mut stderr)?;
     }
+    mode_restore_guard
+        .state_mut()
+        .push_keyboard_enhancement_flags(&mut stderr, keyboard_flags);
 
     session.update_terminal_title();
 

--- a/vtcode-ui/src/tui/core_tui/runner/terminal_modes.rs
+++ b/vtcode-ui/src/tui/core_tui/runner/terminal_modes.rs
@@ -64,6 +64,28 @@ impl TerminalModeState {
         self.alternate_screen_active = true;
         Ok(())
     }
+
+    pub(super) fn push_keyboard_enhancement_flags(
+        &mut self,
+        stderr: &mut io::Stderr,
+        keyboard_flags: crossterm::event::KeyboardEnhancementFlags,
+    ) {
+        use ratatui::crossterm::event::PushKeyboardEnhancementFlags;
+
+        if keyboard_flags.is_empty() {
+            return;
+        }
+
+        match execute!(stderr, PushKeyboardEnhancementFlags(keyboard_flags)) {
+            Ok(_) => {
+                self.keyboard_enhancements_pushed = true;
+                crate::tui::ui::tui::panic_hook::mark_keyboard_enhancements_pushed(true);
+            }
+            Err(error) => {
+                tracing::debug!(%error, "failed to push keyboard enhancement flags");
+            }
+        }
+    }
 }
 
 impl Default for TerminalModeState {
@@ -74,11 +96,8 @@ impl Default for TerminalModeState {
 
 pub(super) fn enable_terminal_modes(
     stderr: &mut io::Stderr,
-    keyboard_flags: crossterm::event::KeyboardEnhancementFlags,
     fullscreen: &FullscreenInteractionSettings,
 ) -> Result<TerminalModeState> {
-    use ratatui::crossterm::event::PushKeyboardEnhancementFlags;
-
     let mut state = TerminalModeState::new();
 
     // Enable bracketed paste
@@ -114,19 +133,6 @@ pub(super) fn enable_terminal_modes(
         }
     }
 
-    // Push keyboard enhancement flags
-    if !keyboard_flags.is_empty() {
-        match execute!(stderr, PushKeyboardEnhancementFlags(keyboard_flags)) {
-            Ok(_) => {
-                state.keyboard_enhancements_pushed = true;
-                crate::tui::ui::tui::panic_hook::mark_keyboard_enhancements_pushed(true);
-            }
-            Err(error) => {
-                tracing::debug!(%error, "failed to push keyboard enhancement flags");
-            }
-        }
-    }
-
     Ok(state)
 }
 
@@ -138,13 +144,6 @@ pub(super) fn restore_terminal_modes(state: &TerminalModeState) -> Result<()> {
 
     // Restore in reverse order of enabling/entering.
 
-    if state.alternate_screen_active
-        && let Err(error) = execute!(stderr, LeaveAlternateScreen)
-    {
-        tracing::debug!(%error, "failed to leave alternate screen");
-        errors.push(format!("alternate screen: {error}"));
-    }
-
     // 1. Pop keyboard enhancement flags (if they were pushed)
     if state.keyboard_enhancements_pushed {
         crate::tui::ui::tui::panic_hook::mark_keyboard_enhancements_pushed(false);
@@ -152,6 +151,13 @@ pub(super) fn restore_terminal_modes(state: &TerminalModeState) -> Result<()> {
             tracing::debug!(%error, "failed to pop keyboard enhancement flags");
             errors.push(format!("keyboard enhancements: {error}"));
         }
+    }
+
+    if state.alternate_screen_active
+        && let Err(error) = execute!(stderr, LeaveAlternateScreen)
+    {
+        tracing::debug!(%error, "failed to leave alternate screen");
+        errors.push(format!("alternate screen: {error}"));
     }
 
     // 2. Disable focus change events (if they were enabled)

--- a/vtcode-ui/src/tui/core_tui/session.rs
+++ b/vtcode-ui/src/tui/core_tui/session.rs
@@ -229,6 +229,7 @@ pub struct Session {
     #[expect(dead_code)]
     navigation_state: ListState,
     input_enabled: bool,
+    image_input_enabled: bool,
     cursor_visible: bool,
     pub(crate) needs_redraw: bool,
     pub(crate) needs_full_clear: bool,

--- a/vtcode-ui/src/tui/core_tui/session.rs
+++ b/vtcode-ui/src/tui/core_tui/session.rs
@@ -62,6 +62,7 @@ mod command;
 mod editing;
 
 pub mod action;
+pub(crate) mod clipboard_image;
 pub mod config;
 mod driver;
 mod events;

--- a/vtcode-ui/src/tui/core_tui/session/clipboard_image.rs
+++ b/vtcode-ui/src/tui/core_tui/session/clipboard_image.rs
@@ -1,0 +1,649 @@
+// Slice 4 wires this helper into application shortcut handling.
+#![allow(dead_code)]
+
+use std::{
+    env, fs,
+    io::{Cursor, Read},
+    path::PathBuf,
+    process::{Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use image::{DynamicImage, ImageBuffer, ImageFormat, Rgba};
+use thiserror::Error;
+
+use super::super::types::ContentPart;
+
+const PNG_MEDIA_TYPE: &str = "image/png";
+const WSL_FALLBACK_TIMEOUT: Duration = Duration::from_secs(3);
+const POWERSHELL_CLIPBOARD_SCRIPT: &str = r#"
+$ErrorActionPreference = 'Stop'
+$action = {
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+    $image = [System.Windows.Forms.Clipboard]::GetImage()
+    if ($null -eq $image) { [Environment]::Exit(2) }
+    $stream = New-Object System.IO.MemoryStream
+    $image.Save($stream, [System.Drawing.Imaging.ImageFormat]::Png)
+    [Console]::Out.Write([Convert]::ToBase64String($stream.ToArray()))
+}
+if ([System.Threading.Thread]::CurrentThread.GetApartmentState() -eq [System.Threading.ApartmentState]::STA) {
+    & $action
+    exit 0
+}
+$thread = [System.Threading.Thread]::new([System.Threading.ThreadStart]$action)
+$thread.SetApartmentState([System.Threading.ApartmentState]::STA)
+$thread.Start()
+$thread.Join()
+exit 0
+"#;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum ClipboardImageError {
+    #[error("no image in clipboard")]
+    NoImage,
+    #[error("clipboard image paste unavailable")]
+    ClipboardUnavailable,
+    #[error("selected model does not support image input")]
+    UnsupportedModel,
+    #[error("WSL PowerShell clipboard fallback failed")]
+    WslFallbackFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClipboardRgbaImage {
+    pub width: usize,
+    pub height: usize,
+    pub bytes: Vec<u8>,
+}
+
+trait ClipboardImageSource {
+    fn file_paths(&mut self) -> Result<Vec<PathBuf>, ClipboardImageError>;
+
+    fn rgba_image(&mut self) -> Result<ClipboardRgbaImage, ClipboardImageError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandRunOutput {
+    status_code: Option<i32>,
+    stdout: Vec<u8>,
+    timed_out: bool,
+}
+
+trait ClipboardCommandRunner {
+    fn run(
+        &self,
+        program: &str,
+        args: &[&str],
+        timeout: Duration,
+    ) -> std::io::Result<CommandRunOutput>;
+}
+
+pub(crate) fn read_clipboard_image() -> Result<ContentPart, ClipboardImageError> {
+    let wsl = is_wsl();
+
+    #[cfg(not(target_os = "android"))]
+    {
+        let mut source = match ArboardClipboardSource::new() {
+            Ok(source) => source,
+            Err(_) if wsl => return read_wsl_fallback_image(&SystemCommandRunner),
+            Err(error) => return Err(error),
+        };
+        read_clipboard_image_with(&mut source, &SystemCommandRunner, wsl)
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        if wsl {
+            read_wsl_fallback_image(&SystemCommandRunner)
+        } else {
+            Err(ClipboardImageError::ClipboardUnavailable)
+        }
+    }
+}
+
+fn read_clipboard_image_with(
+    source: &mut impl ClipboardImageSource,
+    command_runner: &impl ClipboardCommandRunner,
+    wsl: bool,
+) -> Result<ContentPart, ClipboardImageError> {
+    match read_clipboard_png(source) {
+        Ok(png_bytes) => png_bytes_to_content_part(&png_bytes),
+        Err(ClipboardImageError::NoImage | ClipboardImageError::ClipboardUnavailable) if wsl => {
+            read_wsl_fallback_image(command_runner)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn read_clipboard_png(
+    source: &mut impl ClipboardImageSource,
+) -> Result<Vec<u8>, ClipboardImageError> {
+    let mut file_list_error = None;
+    match source.file_paths() {
+        Ok(paths) => {
+            if let Some(png_bytes) = first_readable_image_file_as_png(paths) {
+                return Ok(png_bytes);
+            }
+        }
+        Err(error) => {
+            file_list_error = Some(error);
+        }
+    }
+
+    match source.rgba_image() {
+        Ok(image) => encode_rgba_png(image.width, image.height, &image.bytes),
+        Err(ClipboardImageError::NoImage) => match file_list_error {
+            Some(ClipboardImageError::ClipboardUnavailable) => {
+                Err(ClipboardImageError::ClipboardUnavailable)
+            }
+            Some(error) if error != ClipboardImageError::NoImage => Err(error),
+            _ => Err(ClipboardImageError::NoImage),
+        },
+        Err(error) => Err(error),
+    }
+}
+
+fn first_readable_image_file_as_png(paths: Vec<PathBuf>) -> Option<Vec<u8>> {
+    paths.into_iter().find_map(|path| {
+        image::open(path)
+            .ok()
+            .and_then(|image| encode_dynamic_image_png(&image).ok())
+    })
+}
+
+fn encode_rgba_png(
+    width: usize,
+    height: usize,
+    bytes: &[u8],
+) -> Result<Vec<u8>, ClipboardImageError> {
+    let width_u32 = u32::try_from(width).map_err(|_| ClipboardImageError::NoImage)?;
+    let height_u32 = u32::try_from(height).map_err(|_| ClipboardImageError::NoImage)?;
+    let buffer = ImageBuffer::<Rgba<u8>, _>::from_raw(width_u32, height_u32, bytes.to_vec())
+        .ok_or(ClipboardImageError::NoImage)?;
+    encode_dynamic_image_png(&DynamicImage::ImageRgba8(buffer))
+}
+
+fn encode_dynamic_image_png(image: &DynamicImage) -> Result<Vec<u8>, ClipboardImageError> {
+    let mut cursor = Cursor::new(Vec::new());
+    image
+        .write_to(&mut cursor, ImageFormat::Png)
+        .map_err(|_| ClipboardImageError::NoImage)?;
+    Ok(cursor.into_inner())
+}
+
+fn png_bytes_to_content_part(png_bytes: &[u8]) -> Result<ContentPart, ClipboardImageError> {
+    image::load_from_memory_with_format(png_bytes, ImageFormat::Png)
+        .map_err(|_| ClipboardImageError::WslFallbackFailure)?;
+    Ok(ContentPart::image(BASE64.encode(png_bytes), PNG_MEDIA_TYPE))
+}
+
+fn read_wsl_fallback_image(
+    command_runner: &impl ClipboardCommandRunner,
+) -> Result<ContentPart, ClipboardImageError> {
+    let attempts: [(&str, &[&str]); 2] = [
+        (
+            "powershell.exe",
+            &[
+                "-NoProfile",
+                "-NonInteractive",
+                "-Sta",
+                "-Command",
+                POWERSHELL_CLIPBOARD_SCRIPT,
+            ],
+        ),
+        (
+            "pwsh.exe",
+            &[
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                POWERSHELL_CLIPBOARD_SCRIPT,
+            ],
+        ),
+    ];
+
+    for (program, args) in attempts {
+        let output = match command_runner.run(program, args, WSL_FALLBACK_TIMEOUT) {
+            Ok(output) => output,
+            Err(_) => continue,
+        };
+        if output.timed_out {
+            continue;
+        }
+        if output.status_code == Some(2) {
+            return Err(ClipboardImageError::NoImage);
+        }
+        if output.status_code == Some(0) {
+            let stdout = String::from_utf8(output.stdout)
+                .map_err(|_| ClipboardImageError::WslFallbackFailure)?;
+            let png_bytes = BASE64
+                .decode(stdout.trim())
+                .map_err(|_| ClipboardImageError::WslFallbackFailure)?;
+            if png_bytes.is_empty() {
+                return Err(ClipboardImageError::WslFallbackFailure);
+            }
+            return png_bytes_to_content_part(&png_bytes);
+        }
+    }
+
+    Err(ClipboardImageError::WslFallbackFailure)
+}
+
+fn is_wsl() -> bool {
+    if env::var_os("WSL_DISTRO_NAME").is_some() {
+        return true;
+    }
+    fs::read_to_string("/proc/version")
+        .map(|version| version.to_ascii_lowercase().contains("microsoft"))
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "android"))]
+struct ArboardClipboardSource {
+    clipboard: arboard::Clipboard,
+}
+
+#[cfg(not(target_os = "android"))]
+impl ArboardClipboardSource {
+    fn new() -> Result<Self, ClipboardImageError> {
+        arboard::Clipboard::new()
+            .map(|clipboard| Self { clipboard })
+            .map_err(map_arboard_error)
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+impl ClipboardImageSource for ArboardClipboardSource {
+    fn file_paths(&mut self) -> Result<Vec<PathBuf>, ClipboardImageError> {
+        self.clipboard.get().file_list().map_err(map_arboard_error)
+    }
+
+    fn rgba_image(&mut self) -> Result<ClipboardRgbaImage, ClipboardImageError> {
+        let image = self.clipboard.get_image().map_err(map_arboard_error)?;
+        Ok(ClipboardRgbaImage {
+            width: image.width,
+            height: image.height,
+            bytes: image.bytes.into_owned(),
+        })
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn map_arboard_error(error: arboard::Error) -> ClipboardImageError {
+    match error {
+        arboard::Error::ContentNotAvailable | arboard::Error::ConversionFailure => {
+            ClipboardImageError::NoImage
+        }
+        arboard::Error::ClipboardNotSupported
+        | arboard::Error::ClipboardOccupied
+        | arboard::Error::Unknown { .. } => ClipboardImageError::ClipboardUnavailable,
+        _ => ClipboardImageError::ClipboardUnavailable,
+    }
+}
+
+struct SystemCommandRunner;
+
+impl ClipboardCommandRunner for SystemCommandRunner {
+    fn run(
+        &self,
+        program: &str,
+        args: &[&str],
+        timeout: Duration,
+    ) -> std::io::Result<CommandRunOutput> {
+        let mut child = Command::new(program)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| std::io::Error::other("missing stdout pipe"))?;
+        let (stdout_tx, stdout_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let mut stdout_bytes = Vec::new();
+            let result = stdout.read_to_end(&mut stdout_bytes).map(|_| stdout_bytes);
+            let _ = stdout_tx.send(result);
+        });
+
+        let start = Instant::now();
+        loop {
+            if let Some(status) = child.try_wait()? {
+                let stdout = stdout_rx
+                    .recv()
+                    .unwrap_or_else(|_| Ok(Vec::new()))
+                    .unwrap_or_default();
+                return Ok(CommandRunOutput {
+                    status_code: status.code(),
+                    stdout,
+                    timed_out: false,
+                });
+            }
+
+            if start.elapsed() >= timeout {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stdout = stdout_rx
+                    .recv()
+                    .unwrap_or_else(|_| Ok(Vec::new()))
+                    .unwrap_or_default();
+                return Ok(CommandRunOutput {
+                    status_code: None,
+                    stdout,
+                    timed_out: true,
+                });
+            }
+
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, fs, path::PathBuf};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockClipboardSource {
+        file_paths_result: Option<Result<Vec<PathBuf>, ClipboardImageError>>,
+        rgba_result: Option<Result<ClipboardRgbaImage, ClipboardImageError>>,
+    }
+
+    impl ClipboardImageSource for MockClipboardSource {
+        fn file_paths(&mut self) -> Result<Vec<PathBuf>, ClipboardImageError> {
+            self.file_paths_result
+                .take()
+                .unwrap_or(Err(ClipboardImageError::NoImage))
+        }
+
+        fn rgba_image(&mut self) -> Result<ClipboardRgbaImage, ClipboardImageError> {
+            self.rgba_result
+                .take()
+                .unwrap_or(Err(ClipboardImageError::NoImage))
+        }
+    }
+
+    #[derive(Default)]
+    struct MockCommandRunner {
+        outputs: std::sync::Mutex<VecDeque<std::io::Result<CommandRunOutput>>>,
+        calls: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl MockCommandRunner {
+        fn with_outputs(outputs: Vec<std::io::Result<CommandRunOutput>>) -> Self {
+            Self {
+                outputs: std::sync::Mutex::new(outputs.into()),
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn called_programs(&self) -> Vec<String> {
+            self.calls
+                .lock()
+                .expect("mock command calls should not be poisoned")
+                .clone()
+        }
+    }
+
+    impl ClipboardCommandRunner for MockCommandRunner {
+        fn run(
+            &self,
+            program: &str,
+            _args: &[&str],
+            _timeout: Duration,
+        ) -> std::io::Result<CommandRunOutput> {
+            self.calls
+                .lock()
+                .expect("mock command calls should not be poisoned")
+                .push(program.to_owned());
+            self.outputs
+                .lock()
+                .expect("mock command outputs should not be poisoned")
+                .pop_front()
+                .unwrap_or_else(|| {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "missing mock command",
+                    ))
+                })
+        }
+    }
+
+    fn temp_file(name: &str) -> PathBuf {
+        let mut path = env::temp_dir();
+        path.push(format!(
+            "vtcode-clipboard-image-{}-{name}",
+            std::process::id()
+        ));
+        path
+    }
+
+    fn tiny_rgba() -> ClipboardRgbaImage {
+        ClipboardRgbaImage {
+            width: 2,
+            height: 1,
+            bytes: vec![255, 0, 0, 255, 0, 255, 0, 255],
+        }
+    }
+
+    fn decoded_content_part_png(part: ContentPart) -> Vec<u8> {
+        match part {
+            ContentPart::Image { data, media_type } => {
+                assert_eq!(media_type, PNG_MEDIA_TYPE);
+                BASE64.decode(data).expect("image data should be base64")
+            }
+            ContentPart::Text { .. } => panic!("expected image content part"),
+        }
+    }
+
+    fn assert_png_decodes(png_bytes: &[u8]) {
+        image::load_from_memory_with_format(png_bytes, ImageFormat::Png)
+            .expect("PNG bytes should decode");
+    }
+
+    #[test]
+    fn encodes_png_from_small_rgba_buffer() {
+        let image = tiny_rgba();
+        let png = encode_rgba_png(image.width, image.height, &image.bytes)
+            .expect("RGBA buffer should encode as PNG");
+
+        assert_png_decodes(&png);
+    }
+
+    #[test]
+    fn decodes_file_path_image_as_png() {
+        let path = temp_file("single.png");
+        let image = tiny_rgba();
+        let png = encode_rgba_png(image.width, image.height, &image.bytes)
+            .expect("RGBA buffer should encode as PNG");
+        fs::write(&path, &png).expect("write generated PNG");
+
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(vec![path.clone()])),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+        let runner = MockCommandRunner::default();
+
+        let part = read_clipboard_image_with(&mut source, &runner, false)
+            .expect("file path image should be read");
+        let decoded = decoded_content_part_png(part);
+        assert_png_decodes(&decoded);
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn file_list_chooses_first_readable_image_and_ignores_later_entries() {
+        let missing = temp_file("missing.png");
+        let first = temp_file("first.png");
+        let later = temp_file("later.png");
+
+        let first_png = encode_rgba_png(1, 1, &[1, 2, 3, 255]).expect("first PNG should encode");
+        let later_png = encode_rgba_png(1, 1, &[9, 8, 7, 255]).expect("later PNG should encode");
+        fs::write(&first, &first_png).expect("write first PNG");
+        fs::write(&later, &later_png).expect("write later PNG");
+
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(vec![missing, first.clone(), later.clone()])),
+            rgba_result: Some(Ok(tiny_rgba())),
+        };
+        let runner = MockCommandRunner::default();
+
+        let part = read_clipboard_image_with(&mut source, &runner, false)
+            .expect("first readable file should be used");
+        assert_eq!(decoded_content_part_png(part), first_png);
+
+        let _ = fs::remove_file(first);
+        let _ = fs::remove_file(later);
+    }
+
+    #[test]
+    fn converts_raw_clipboard_image_when_no_file_image_exists() {
+        let image = tiny_rgba();
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(Vec::new())),
+            rgba_result: Some(Ok(image)),
+        };
+        let runner = MockCommandRunner::default();
+
+        let part = read_clipboard_image_with(&mut source, &runner, false)
+            .expect("raw clipboard image should be converted");
+        let decoded = decoded_content_part_png(part);
+
+        assert_png_decodes(&decoded);
+    }
+
+    #[test]
+    fn maps_no_image_without_wsl_fallback() {
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(Vec::new())),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+        let runner = MockCommandRunner::default();
+
+        let error = read_clipboard_image_with(&mut source, &runner, false)
+            .expect_err("empty clipboard should map to no image");
+
+        assert_eq!(error, ClipboardImageError::NoImage);
+        assert!(runner.called_programs().is_empty());
+    }
+
+    #[test]
+    fn maps_clipboard_unavailable_without_wsl_fallback() {
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Err(ClipboardImageError::ClipboardUnavailable)),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+        let runner = MockCommandRunner::default();
+
+        let error = read_clipboard_image_with(&mut source, &runner, false)
+            .expect_err("unavailable clipboard should map distinctly");
+
+        assert_eq!(error, ClipboardImageError::ClipboardUnavailable);
+        assert!(runner.called_programs().is_empty());
+    }
+
+    #[test]
+    fn wsl_fallback_success_returns_png_content_part() {
+        let png = encode_rgba_png(1, 1, &[1, 2, 3, 255]).expect("PNG should encode");
+        let runner = MockCommandRunner::with_outputs(vec![Ok(CommandRunOutput {
+            status_code: Some(0),
+            stdout: BASE64.encode(&png).into_bytes(),
+            timed_out: false,
+        })]);
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(Vec::new())),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+
+        let part = read_clipboard_image_with(&mut source, &runner, true)
+            .expect("WSL fallback should provide image");
+
+        assert_eq!(decoded_content_part_png(part), png);
+        assert_eq!(runner.called_programs(), vec!["powershell.exe"]);
+    }
+
+    #[test]
+    fn wsl_fallback_no_image_exit_maps_to_no_image() {
+        let runner = MockCommandRunner::with_outputs(vec![Ok(CommandRunOutput {
+            status_code: Some(2),
+            stdout: Vec::new(),
+            timed_out: false,
+        })]);
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(Vec::new())),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+
+        let error = read_clipboard_image_with(&mut source, &runner, true)
+            .expect_err("WSL no-image exit should stay no-image");
+
+        assert_eq!(error, ClipboardImageError::NoImage);
+    }
+
+    #[test]
+    fn wsl_fallback_failures_try_pwsh_then_map_to_failure() {
+        let runner = MockCommandRunner::with_outputs(vec![
+            Ok(CommandRunOutput {
+                status_code: Some(1),
+                stdout: Vec::new(),
+                timed_out: false,
+            }),
+            Ok(CommandRunOutput {
+                status_code: Some(0),
+                stdout: b"not-base64".to_vec(),
+                timed_out: false,
+            }),
+        ]);
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(Vec::new())),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+
+        let error = read_clipboard_image_with(&mut source, &runner, true)
+            .expect_err("invalid WSL fallback output should fail");
+
+        assert_eq!(error, ClipboardImageError::WslFallbackFailure);
+        assert_eq!(runner.called_programs(), vec!["powershell.exe", "pwsh.exe"]);
+    }
+
+    #[test]
+    fn wsl_fallback_timeout_maps_to_failure() {
+        let runner = MockCommandRunner::with_outputs(vec![Ok(CommandRunOutput {
+            status_code: None,
+            stdout: Vec::new(),
+            timed_out: true,
+        })]);
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(Vec::new())),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+
+        let error = read_clipboard_image_with(&mut source, &runner, true)
+            .expect_err("timed out WSL fallback should fail");
+
+        assert_eq!(error, ClipboardImageError::WslFallbackFailure);
+    }
+
+    #[test]
+    fn wsl_fallback_missing_commands_map_to_failure() {
+        let runner = MockCommandRunner::default();
+        let mut source = MockClipboardSource {
+            file_paths_result: Some(Ok(Vec::new())),
+            rgba_result: Some(Err(ClipboardImageError::NoImage)),
+        };
+
+        let error = read_clipboard_image_with(&mut source, &runner, true)
+            .expect_err("missing WSL fallback commands should fail");
+
+        assert_eq!(error, ClipboardImageError::WslFallbackFailure);
+        assert_eq!(runner.called_programs(), vec!["powershell.exe", "pwsh.exe"]);
+    }
+}

--- a/vtcode-ui/src/tui/core_tui/session/editing.rs
+++ b/vtcode-ui/src/tui/core_tui/session/editing.rs
@@ -182,7 +182,17 @@ impl Session {
             return;
         }
 
+        let paste_start = self
+            .input_manager
+            .selection_range()
+            .map_or_else(|| self.input_manager.cursor(), |(start, _)| start);
+        let paste_end = paste_start.saturating_add(sanitized.len());
+        let line_count = sanitized.split('\n').count();
         self.input_manager.insert_text(&sanitized);
+        if line_count >= ui::INLINE_PASTE_COLLAPSE_LINE_THRESHOLD {
+            self.input_manager
+                .set_compact_paste_range(paste_start..paste_end);
+        }
         self.refresh_input_edit_state();
     }
 

--- a/vtcode-ui/src/tui/core_tui/session/editing.rs
+++ b/vtcode-ui/src/tui/core_tui/session/editing.rs
@@ -224,9 +224,19 @@ impl Session {
 
     /// Calculate remaining newline capacity in the input field
     pub(crate) fn remaining_newline_capacity(&self) -> usize {
+        let content = self.input_manager.content();
+        let mut newline_count = content.matches('\n').count();
+        if let Some(range) = self.input_manager.compact_paste_range()
+            && range.end <= content.len()
+            && content.is_char_boundary(range.start)
+            && content.is_char_boundary(range.end)
+        {
+            newline_count = newline_count.saturating_sub(content[range].matches('\n').count());
+        }
+
         ui::INLINE_INPUT_MAX_LINES
             .saturating_sub(1)
-            .saturating_sub(self.input_manager.content().matches('\n').count())
+            .saturating_sub(newline_count)
     }
 
     /// Check if a newline can be inserted

--- a/vtcode-ui/src/tui/core_tui/session/events.rs
+++ b/vtcode-ui/src/tui/core_tui/session/events.rs
@@ -1,7 +1,7 @@
 use super::*;
 use ratatui::crossterm::event::KeyModifiers;
 
-use super::super::types::{OverlayEvent, OverlaySubmission};
+use super::super::types::{OverlayEvent, OverlaySubmission, SubmittedInput};
 use crate::tui::ui::tui::session::modal::{ModalKeyModifiers, ModalListKeyResult};
 
 pub(super) fn handle_paste(session: &mut Session, content: &str) {
@@ -91,11 +91,11 @@ fn dispatch_action(session: &mut Session, action: Action) -> Option<InlineEvent>
         }
         Action::OpenModelPicker => {
             session.mark_dirty();
-            Some(InlineEvent::Submit("/model".to_string()))
+            Some(InlineEvent::Submit("/model".into()))
         }
         Action::ClearScreen => {
             session.mark_dirty();
-            Some(InlineEvent::Submit("/clear".to_string()))
+            Some(InlineEvent::Submit("/clear".into()))
         }
         Action::ScrollPageUp => {
             session.scroll_page_up();
@@ -485,7 +485,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
                 if is_double_esc {
                     session.last_esc_press = None;
                     session.mark_dirty();
-                    Some(InlineEvent::Submit("/rewind".to_string()))
+                    Some(InlineEvent::Submit("/rewind".into()))
                 } else {
                     session.last_esc_press = Some(now);
                     session.mark_dirty();
@@ -505,7 +505,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
                 && session.active_pty_session_count() > 0
             {
                 session.mark_dirty();
-                return Some(InlineEvent::Submit("/jobs".to_string()));
+                return Some(InlineEvent::Submit("/jobs".into()));
             }
 
             // Check for backslash + Enter quick escape (insert newline without submitting)
@@ -553,7 +553,7 @@ pub(super) fn process_key(session: &mut Session, key: KeyEvent) -> Option<Inline
             // If a turn is actively running, queue the message so it starts immediately after
             // the current turn completes. Otherwise submit directly so the turn starts now.
             if session.is_running_activity() {
-                session.push_queued_input(submitted.clone());
+                session.push_queued_input(submitted.text.clone());
                 Some(InlineEvent::QueueSubmit(submitted))
             } else {
                 Some(InlineEvent::Submit(submitted))
@@ -759,17 +759,18 @@ fn can_cycle_primary_agent(session: &Session, key: &KeyEvent) -> bool {
     key.modifiers == KeyModifiers::NONE && !session.has_active_overlay()
 }
 
-fn take_submitted_input(session: &mut Session) -> Option<String> {
+fn take_submitted_input(session: &mut Session) -> Option<SubmittedInput> {
     let submitted = session.input_manager.content().to_owned();
     let submitted_entry = session.input_manager.current_history_entry();
     clear_submitted_input(session);
 
-    if submitted.trim().is_empty() {
+    if submitted_entry.is_empty() {
         return None;
     }
 
+    let attachments = submitted_entry.attachment_elements();
     session.remember_submitted_input(submitted_entry);
-    Some(submitted)
+    Some(SubmittedInput::new(submitted, attachments))
 }
 
 fn clear_submitted_input(session: &mut Session) {

--- a/vtcode-ui/src/tui/core_tui/session/impl_init.rs
+++ b/vtcode-ui/src/tui/core_tui/session/impl_init.rs
@@ -125,6 +125,7 @@ impl Session {
             // --- UI State ---
             navigation_state: ListState::default(), // Kept for backward compatibility
             input_enabled: true,
+            image_input_enabled: false,
             cursor_visible: true,
             needs_redraw: true,
             needs_full_clear: false,

--- a/vtcode-ui/src/tui/core_tui/session/impl_input.rs
+++ b/vtcode-ui/src/tui/core_tui/session/impl_input.rs
@@ -162,6 +162,9 @@ impl Session {
             InlineCommand::SetInputEnabled(value) => {
                 self.input_enabled = value;
             }
+            InlineCommand::SetImageInputEnabled(value) => {
+                self.image_input_enabled = value;
+            }
             InlineCommand::SetInput(content) => {
                 // Check if the content appears to be an error message
                 // If it looks like an error, redirect to transcript instead

--- a/vtcode-ui/src/tui/core_tui/session/impl_input.rs
+++ b/vtcode-ui/src/tui/core_tui/session/impl_input.rs
@@ -176,6 +176,14 @@ impl Session {
                     self.scroll_manager.set_offset(0);
                 }
             }
+            InlineCommand::RestoreInputDraft(input) => {
+                self.clear_suggested_prompt_state();
+                self.clear_inline_prompt_suggestion();
+                self.input_manager.set_content(input.text);
+                self.input_manager.set_attachments(input.attachments);
+                self.input_compact_mode = self.input_compact_placeholder().is_some();
+                self.scroll_manager.set_offset(0);
+            }
             InlineCommand::ApplySuggestedPrompt(content) => {
                 self.apply_suggested_prompt(content);
                 self.scroll_manager.set_offset(0);

--- a/vtcode-ui/src/tui/core_tui/session/input.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input.rs
@@ -795,24 +795,12 @@ impl Session {
     pub(crate) fn input_compact_placeholder(&self) -> Option<String> {
         let content = self.input_manager.content();
         let trimmed = content.trim();
-        let attachment_count = self.input_manager.attachments().len();
-        if trimmed.is_empty() && attachment_count == 0 {
+        if trimmed.is_empty() {
             return None;
         }
 
         if let Some(label) = compact_image_label(trimmed) {
             return Some(format!("[Image: {label}]"));
-        }
-
-        if attachment_count > 0 {
-            let label = image_attachment_placeholder(attachment_count);
-            if trimmed.is_empty() {
-                return Some(label);
-            }
-            if let Some(compact) = compact_image_placeholders(content) {
-                return Some(format!("{label} {compact}"));
-            }
-            return Some(format!("{label} {trimmed}"));
         }
 
         if let Some(preview) = self.input_compact_preview() {
@@ -1283,17 +1271,6 @@ fn compact_image_placeholders(content: &str) -> Option<String> {
     }
 
     Some(result)
-}
-
-fn image_attachment_placeholder(attachment_count: usize) -> String {
-    let mut result = String::new();
-    for index in 1..=attachment_count {
-        if !result.is_empty() {
-            result.push(' ');
-        }
-        let _ = write!(result, "[Image #{index}]");
-    }
-    result
 }
 
 fn image_label_for_path(raw: &str) -> Option<String> {

--- a/vtcode-ui/src/tui/core_tui/session/input.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input.rs
@@ -26,7 +26,13 @@ struct InputRender {
 struct CompactInputPreview {
     before: String,
     placeholder: String,
-    after: String,
+    after_lines: Vec<String>,
+}
+
+impl CompactInputPreview {
+    fn line_count(&self) -> usize {
+        self.after_lines.len().max(1)
+    }
 }
 
 #[derive(Default)]
@@ -320,9 +326,13 @@ impl Session {
 
         if self.input_compact_mode
             && self.input_manager.cursor() == self.input_manager.content().len()
-            && self.input_compact_placeholder().is_some()
         {
-            return 1;
+            if let Some(preview) = self.input_compact_preview() {
+                return preview.line_count().min(ui::INLINE_INPUT_MAX_LINES.max(1)) as u16;
+            }
+            if self.input_compact_placeholder().is_some() {
+                return 1;
+            }
         }
 
         if self.input_manager.content().is_empty() {
@@ -499,7 +509,7 @@ impl Session {
                     .map(|placeholder| CompactInputPreview {
                         before: String::new(),
                         placeholder,
-                        after: String::new(),
+                        after_lines: Vec::new(),
                     })
             })
         {
@@ -521,24 +531,49 @@ impl Session {
                     spans.push(Span::styled(" ".to_string(), accent_style));
                 }
             }
+            let first_after = preview
+                .after_lines
+                .first()
+                .map(String::as_str)
+                .unwrap_or_default();
             let needs_after_space =
-                !preview.after.is_empty() && !preview.after.starts_with(char::is_whitespace);
+                !first_after.is_empty() && !first_after.starts_with(char::is_whitespace);
             spans.push(Span::styled(preview.placeholder, style));
             if needs_after_space {
                 spans.push(Span::styled(" ".to_string(), accent_style));
             }
-            if !preview.after.is_empty() {
-                spans.push(Span::styled(preview.after, accent_style));
+            if !first_after.is_empty() {
+                spans.push(Span::styled(first_after.to_string(), accent_style));
             }
-            let cursor_x = spans
-                .iter()
-                .skip(1)
-                .map(|span| UnicodeWidthStr::width(span.content.as_ref()) as u16)
-                .fold(prompt_display_width, u16::saturating_add);
+            let indent_prefix = " ".repeat(prompt_display_width as usize);
+            let mut lines = vec![Line::from(spans)];
+            for line in preview.after_lines.iter().skip(1) {
+                let mut spans = vec![Span::styled(indent_prefix.clone(), prompt_style)];
+                if !line.is_empty() {
+                    spans.push(Span::styled(line.clone(), accent_style));
+                }
+                lines.push(Line::from(spans));
+            }
+            let cursor_y = lines.len().saturating_sub(1) as u16;
+            let cursor_x = if cursor_y == 0 {
+                lines[0]
+                    .spans
+                    .iter()
+                    .skip(1)
+                    .map(|span| UnicodeWidthStr::width(span.content.as_ref()) as u16)
+                    .fold(prompt_display_width, u16::saturating_add)
+            } else {
+                let last_line = preview
+                    .after_lines
+                    .last()
+                    .map(String::as_str)
+                    .unwrap_or_default();
+                prompt_display_width.saturating_add(UnicodeWidthStr::width(last_line) as u16)
+            };
             return InputRender {
-                text: Text::from(vec![Line::from(spans)]),
+                text: Text::from(lines),
                 cursor_x,
-                cursor_y: 0,
+                cursor_y,
             };
         }
 
@@ -818,12 +853,15 @@ impl Session {
         }
 
         let before = compact_inline_segment(&content[..range.start]);
-        let after = compact_inline_segment(&content[range.end..]);
+        let after_lines = content[range.end..]
+            .split('\n')
+            .map(compact_inline_segment)
+            .collect();
         let char_count = pasted.chars().count();
         Some(CompactInputPreview {
             before,
             placeholder: format!("[Pasted Content {char_count} chars]"),
-            after,
+            after_lines,
         })
     }
 

--- a/vtcode-ui/src/tui/core_tui/session/input.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input.rs
@@ -23,6 +23,12 @@ struct InputRender {
     cursor_y: u16,
 }
 
+struct CompactInputPreview {
+    before: String,
+    placeholder: String,
+    after: String,
+}
+
 #[derive(Default)]
 struct InputLineBuffer {
     prefix: String,
@@ -482,11 +488,20 @@ impl Session {
         let prompt_style = ratatui_style_from_inline(&prompt_style, self.theme.foreground);
         let prompt_width = UnicodeWidthStr::width(self.prompt_prefix.as_str()) as u16;
         let prompt_display_width = prompt_width.min(width);
+        let accent_style =
+            ratatui_style_from_inline(&self.styles.accent_inline_style(), self.theme.foreground);
 
         let cursor_at_end = self.input_manager.cursor() == self.input_manager.content().len();
         if self.input_compact_mode
             && cursor_at_end
-            && let Some(placeholder) = self.input_compact_placeholder()
+            && let Some(preview) = self.input_compact_preview().or_else(|| {
+                self.input_compact_placeholder()
+                    .map(|placeholder| CompactInputPreview {
+                        before: String::new(),
+                        placeholder,
+                        after: String::new(),
+                    })
+            })
         {
             let placeholder_style = InlineTextStyle {
                 color: Some(AnsiColorEnum::Rgb(PLACEHOLDER_COLOR)),
@@ -497,13 +512,32 @@ impl Session {
                 &placeholder_style,
                 Some(AnsiColorEnum::Rgb(PLACEHOLDER_COLOR)),
             );
-            let placeholder_width = UnicodeWidthStr::width(placeholder.as_str()) as u16;
+            let mut spans = Vec::new();
+            spans.push(Span::styled(self.prompt_prefix.clone(), prompt_style));
+            if !preview.before.is_empty() {
+                let needs_space = !preview.before.ends_with(char::is_whitespace);
+                spans.push(Span::styled(preview.before, accent_style));
+                if needs_space {
+                    spans.push(Span::styled(" ".to_string(), accent_style));
+                }
+            }
+            let needs_after_space =
+                !preview.after.is_empty() && !preview.after.starts_with(char::is_whitespace);
+            spans.push(Span::styled(preview.placeholder, style));
+            if needs_after_space {
+                spans.push(Span::styled(" ".to_string(), accent_style));
+            }
+            if !preview.after.is_empty() {
+                spans.push(Span::styled(preview.after, accent_style));
+            }
+            let cursor_x = spans
+                .iter()
+                .skip(1)
+                .map(|span| UnicodeWidthStr::width(span.content.as_ref()) as u16)
+                .fold(prompt_display_width, u16::saturating_add);
             return InputRender {
-                text: Text::from(vec![Line::from(vec![
-                    Span::styled(self.prompt_prefix.clone(), prompt_style),
-                    Span::styled(placeholder, style),
-                ])]),
-                cursor_x: prompt_display_width.saturating_add(placeholder_width),
+                text: Text::from(vec![Line::from(spans)]),
+                cursor_x,
                 cursor_y: 0,
             };
         }
@@ -542,8 +576,6 @@ impl Session {
             };
         }
 
-        let accent_style =
-            ratatui_style_from_inline(&self.styles.accent_inline_style(), self.theme.foreground);
         let slash_style = accent_style.fg(Color::Yellow).add_modifier(Modifier::BOLD);
         let file_ref_style = accent_style
             .fg(Color::Cyan)
@@ -752,6 +784,10 @@ impl Session {
             return Some(format!("[Image: {label}] {trimmed}"));
         }
 
+        if let Some(preview) = self.input_compact_preview() {
+            return Some(preview.placeholder);
+        }
+
         let line_count = content.split('\n').count();
         if line_count >= ui::INLINE_PASTE_COLLAPSE_LINE_THRESHOLD {
             let char_count = content.chars().count();
@@ -763,6 +799,32 @@ impl Session {
         }
 
         None
+    }
+
+    fn input_compact_preview(&self) -> Option<CompactInputPreview> {
+        let content = self.input_manager.content();
+        let range = self.input_manager.compact_paste_range()?;
+        if range.start >= range.end
+            || range.end > content.len()
+            || !content.is_char_boundary(range.start)
+            || !content.is_char_boundary(range.end)
+        {
+            return None;
+        }
+
+        let pasted = &content[range.clone()];
+        if pasted.split('\n').count() < ui::INLINE_PASTE_COLLAPSE_LINE_THRESHOLD {
+            return None;
+        }
+
+        let before = compact_inline_segment(&content[..range.start]);
+        let after = compact_inline_segment(&content[range.end..]);
+        let char_count = pasted.chars().count();
+        Some(CompactInputPreview {
+            before,
+            placeholder: format!("[Pasted Content {char_count} chars]"),
+            after,
+        })
     }
 
     pub(crate) fn visible_inline_prompt_suggestion_suffix(&self) -> Option<String> {
@@ -1295,6 +1357,13 @@ fn char_index_to_byte_index(content: &str, char_index: usize) -> usize {
 
 fn byte_index_to_char_index(content: &str, byte_index: usize) -> usize {
     content[..byte_index.min(content.len())].chars().count()
+}
+
+fn compact_inline_segment(content: &str) -> String {
+    content
+        .chars()
+        .map(|ch| if ch == '\n' || ch == '\r' { ' ' } else { ch })
+        .collect()
 }
 
 fn display_width_for_char_range(content: &str, char_count: usize) -> u16 {

--- a/vtcode-ui/src/tui/core_tui/session/input.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input.rs
@@ -805,18 +805,14 @@ impl Session {
         }
 
         if attachment_count > 0 {
-            let label = if attachment_count == 1 {
-                "1 attachment".to_string()
-            } else {
-                format!("{attachment_count} attachments")
-            };
+            let label = image_attachment_placeholder(attachment_count);
             if trimmed.is_empty() {
-                return Some(format!("[Image: {label}]"));
+                return Some(label);
             }
             if let Some(compact) = compact_image_placeholders(content) {
-                return Some(format!("[Image: {label}] {compact}"));
+                return Some(format!("{label} {compact}"));
             }
-            return Some(format!("[Image: {label}] {trimmed}"));
+            return Some(format!("{label} {trimmed}"));
         }
 
         if let Some(preview) = self.input_compact_preview() {
@@ -1287,6 +1283,17 @@ fn compact_image_placeholders(content: &str) -> Option<String> {
     }
 
     Some(result)
+}
+
+fn image_attachment_placeholder(attachment_count: usize) -> String {
+    let mut result = String::new();
+    for index in 1..=attachment_count {
+        if !result.is_empty() {
+            result.push(' ');
+        }
+        let _ = write!(result, "[Image #{index}]");
+    }
+    result
 }
 
 fn image_label_for_path(raw: &str) -> Option<String> {

--- a/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -5,6 +5,7 @@
 /// delegated to [`ratatui_textarea::TextArea`], which provides undo/redo,
 /// proper UTF-8 handling, and a battle-tested editing model.
 use std::collections::HashSet;
+use std::ops::Range;
 
 use chrono::{DateTime, Utc};
 use ratatui_textarea::{CursorMove, DataCursor, TextArea};
@@ -95,6 +96,8 @@ pub struct InputManager {
     selection_copied: bool,
     /// Non-text input elements (e.g. image attachments)
     attachments: Vec<ContentPart>,
+    /// Byte range for a large paste that should render as a compact marker.
+    compact_paste_range: Option<Range<usize>>,
     /// Command history entries
     history: Vec<InputHistoryEntry>,
     /// Current position in history (None = viewing current input)
@@ -117,6 +120,7 @@ impl InputManager {
             selection_anchor: None,
             selection_copied: false,
             attachments: Vec::new(),
+            compact_paste_range: None,
             history: Vec::new(),
             history_index: None,
             history_draft: None,
@@ -141,8 +145,43 @@ impl InputManager {
         self.textarea = TextArea::from(content.split('\n'));
         configure_textarea(&mut self.textarea);
         self.textarea.move_cursor(CursorMove::End);
+        self.compact_paste_range = None;
         self.clear_selection();
         self.reset_history_navigation();
+    }
+
+    pub(crate) fn compact_paste_range(&self) -> Option<Range<usize>> {
+        self.compact_paste_range.clone()
+    }
+
+    pub(crate) fn set_compact_paste_range(&mut self, range: Range<usize>) {
+        self.compact_paste_range = Some(range);
+    }
+
+    fn track_compact_paste_replace(&mut self, start: usize, end: usize, replacement_len: usize) {
+        let Some(range) = self.compact_paste_range.as_mut() else {
+            return;
+        };
+
+        if end <= range.start {
+            let removed_len = end.saturating_sub(start);
+            if replacement_len >= removed_len {
+                let delta = replacement_len - removed_len;
+                range.start = range.start.saturating_add(delta);
+                range.end = range.end.saturating_add(delta);
+            } else {
+                let delta = removed_len - replacement_len;
+                range.start = range.start.saturating_sub(delta);
+                range.end = range.end.saturating_sub(delta);
+            }
+            return;
+        }
+
+        if start >= range.end {
+            return;
+        }
+
+        self.compact_paste_range = None;
     }
 
     pub fn cursor(&self) -> usize {
@@ -239,6 +278,7 @@ impl InputManager {
     // ------------------------------------------------------------------
 
     pub(crate) fn replace_range(&mut self, start: usize, end: usize, replacement: &str) {
+        self.track_compact_paste_replace(start, end, replacement.len());
         let lines: Vec<String> = self.textarea.lines().to_vec();
         let (start_line, start_col) = textarea_bridge::byte_offset_to_row_col(&lines, start);
         let (end_line, end_col) = textarea_bridge::byte_offset_to_row_col(&lines, end);
@@ -391,6 +431,8 @@ impl InputManager {
             let mut buf = [0_u8; 4];
             self.replace_range(start, end, ch.encode_utf8(&mut buf));
         } else {
+            let cursor = self.cursor();
+            self.track_compact_paste_replace(cursor, cursor, ch.len_utf8());
             self.textarea.insert_char(ch);
         }
     }
@@ -399,6 +441,8 @@ impl InputManager {
         if let Some((start, end)) = self.selection_range() {
             self.replace_range(start, end, text);
         } else {
+            let cursor = self.cursor();
+            self.track_compact_paste_replace(cursor, cursor, text.len());
             self.textarea.insert_str(text);
         }
     }
@@ -407,12 +451,30 @@ impl InputManager {
         if self.delete_selection() {
             return;
         }
+        let cursor = self.cursor();
+        if cursor > 0 {
+            let content = self.content();
+            let start = content[..cursor]
+                .char_indices()
+                .next_back()
+                .map_or(0, |(idx, _)| idx);
+            self.track_compact_paste_replace(start, cursor, 0);
+        }
         self.textarea.delete_char();
     }
 
     pub fn delete(&mut self) {
         if self.delete_selection() {
             return;
+        }
+        let cursor = self.cursor();
+        let content = self.content();
+        if cursor < content.len() {
+            let end = content[cursor..]
+                .char_indices()
+                .nth(1)
+                .map_or(content.len(), |(idx, _)| cursor + idx);
+            self.track_compact_paste_replace(cursor, end, 0);
         }
         self.textarea.delete_next_char();
     }
@@ -614,6 +676,7 @@ impl InputManager {
         configure_textarea(&mut self.textarea);
         self.clear_selection();
         self.attachments.clear();
+        self.compact_paste_range = None;
         self.reset_history_navigation();
     }
 
@@ -622,11 +685,19 @@ impl InputManager {
     // ------------------------------------------------------------------
 
     pub fn undo(&mut self) -> bool {
-        self.textarea.undo()
+        let changed = self.textarea.undo();
+        if changed {
+            self.compact_paste_range = None;
+        }
+        changed
     }
 
     pub fn redo(&mut self) -> bool {
-        self.textarea.redo()
+        let changed = self.textarea.redo();
+        if changed {
+            self.compact_paste_range = None;
+        }
+        changed
     }
 
     // ------------------------------------------------------------------
@@ -767,6 +838,7 @@ impl InputManager {
         self.textarea.move_cursor(CursorMove::End);
         self.clear_selection();
         self.attachments = entry.attachment_elements();
+        self.compact_paste_range = None;
     }
 
     pub fn apply_history_index(&mut self, index: usize) -> bool {

--- a/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -19,6 +19,76 @@ fn configure_textarea(textarea: &mut TextArea<'static>) {
     textarea.set_tab_length(4);
 }
 
+fn image_attachment_placeholder(number: usize) -> String {
+    format!("[Image #{number}]")
+}
+
+fn image_attachment_placeholders(content: &str) -> Vec<(usize, String)> {
+    let marker = "[Image #";
+    let mut placeholders = Vec::new();
+    let mut search_start = 0;
+
+    while let Some(offset) = content[search_start..].find(marker) {
+        let start = search_start + offset;
+        let digits_start = start + marker.len();
+        let rest = &content[digits_start..];
+        let digits_len = rest
+            .bytes()
+            .take_while(|byte| byte.is_ascii_digit())
+            .count();
+        let placeholder_end = digits_start + digits_len + 1;
+
+        if digits_len > 0 && content.as_bytes().get(placeholder_end - 1) == Some(&b']') {
+            if let Ok(number) = content[digits_start..digits_start + digits_len].parse::<usize>() {
+                if number > 0 {
+                    placeholders.push((number, content[start..placeholder_end].to_owned()));
+                }
+            }
+            search_start = placeholder_end;
+        } else {
+            search_start = digits_start;
+        }
+    }
+
+    placeholders
+}
+
+fn attachment_placeholders_for_content(
+    content: &str,
+    attachment_count: usize,
+) -> Vec<Option<String>> {
+    let placeholders = image_attachment_placeholders(content);
+    let mut sorted_visible_placeholders = placeholders.clone();
+    sorted_visible_placeholders.sort_by_key(|(number, _)| *number);
+    sorted_visible_placeholders.dedup_by_key(|(number, _)| *number);
+
+    if sorted_visible_placeholders.len() >= attachment_count {
+        return sorted_visible_placeholders
+            .into_iter()
+            .take(attachment_count)
+            .map(|(_, placeholder)| Some(placeholder))
+            .collect();
+    }
+
+    (0..attachment_count)
+        .map(|index| {
+            let expected_number = index + 1;
+            placeholders
+                .iter()
+                .find_map(|(number, placeholder)| {
+                    (*number == expected_number).then(|| placeholder.clone())
+                })
+                .or_else(|| {
+                    if attachment_count == 1 && placeholders.len() == 1 {
+                        Some(placeholders[0].1.clone())
+                    } else {
+                        None
+                    }
+                })
+        })
+        .collect()
+}
+
 #[derive(Clone, Debug)]
 pub struct InputHistoryEntry {
     content: String,
@@ -96,6 +166,11 @@ pub struct InputManager {
     selection_copied: bool,
     /// Non-text input elements (e.g. image attachments)
     attachments: Vec<ContentPart>,
+    /// Inline placeholder text for pasted image attachments.
+    ///
+    /// `None` means the attachment was restored or set without inline
+    /// placeholder provenance and should keep the legacy attachment behaviour.
+    attachment_placeholders: Vec<Option<String>>,
     /// Byte range for a large paste that should render as a compact marker.
     compact_paste_range: Option<Range<usize>>,
     /// Command history entries
@@ -120,6 +195,7 @@ impl InputManager {
             selection_anchor: None,
             selection_copied: false,
             attachments: Vec::new(),
+            attachment_placeholders: Vec::new(),
             compact_paste_range: None,
             history: Vec::new(),
             history_index: None,
@@ -676,6 +752,7 @@ impl InputManager {
         configure_textarea(&mut self.textarea);
         self.clear_selection();
         self.attachments.clear();
+        self.attachment_placeholders.clear();
         self.compact_paste_range = None;
         self.reset_history_navigation();
     }
@@ -821,21 +898,67 @@ impl InputManager {
             .into_iter()
             .filter(ContentPart::is_image)
             .collect();
+        let content = self.content().to_owned();
+        self.attachment_placeholders =
+            attachment_placeholders_for_content(&content, self.attachments.len());
     }
 
     pub fn push_attachment(&mut self, attachment: ContentPart) -> Option<usize> {
         if attachment.is_image() {
+            let placeholder_number = self.next_image_attachment_placeholder_number();
+            let placeholder = image_attachment_placeholder(placeholder_number);
             self.attachments.push(attachment);
-            return Some(self.attachments.len());
+            self.attachment_placeholders.push(Some(placeholder));
+            return Some(placeholder_number);
         }
         None
     }
 
+    fn next_image_attachment_placeholder_number(&self) -> usize {
+        let visible_max = image_attachment_placeholders(&self.content())
+            .into_iter()
+            .map(|(number, _)| number)
+            .max()
+            .unwrap_or(0);
+        let tracked_max = self
+            .attachment_placeholders
+            .iter()
+            .filter_map(|placeholder| placeholder.as_deref())
+            .flat_map(image_attachment_placeholders)
+            .map(|(number, _)| number)
+            .max()
+            .unwrap_or(0);
+
+        visible_max
+            .max(tracked_max)
+            .max(self.attachments.len())
+            .saturating_add(1)
+    }
+
     pub fn current_history_entry(&self) -> InputHistoryEntry {
+        let content = self.content().to_string();
         InputHistoryEntry::from_content_and_attachments(
-            self.content().to_string(),
-            self.attachments.clone(),
+            content.clone(),
+            self.attachments_for_content(&content),
         )
+    }
+
+    fn attachments_for_content(&self, content: &str) -> Vec<ContentPart> {
+        self.attachments
+            .iter()
+            .enumerate()
+            .filter_map(|(index, attachment)| {
+                if !attachment.is_image() {
+                    return Some(attachment.clone());
+                }
+
+                let Some(Some(placeholder)) = self.attachment_placeholders.get(index) else {
+                    return Some(attachment.clone());
+                };
+
+                content.contains(placeholder).then(|| attachment.clone())
+            })
+            .collect()
     }
 
     pub fn apply_history_entry(&mut self, entry: InputHistoryEntry) {
@@ -846,6 +969,8 @@ impl InputManager {
         self.textarea.move_cursor(CursorMove::End);
         self.clear_selection();
         self.attachments = entry.attachment_elements();
+        self.attachment_placeholders =
+            attachment_placeholders_for_content(&entry.content, self.attachments.len());
         self.compact_paste_range = None;
     }
 

--- a/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -823,6 +823,12 @@ impl InputManager {
             .collect();
     }
 
+    pub fn push_attachment(&mut self, attachment: ContentPart) {
+        if attachment.is_image() {
+            self.attachments.push(attachment);
+        }
+    }
+
     pub fn current_history_entry(&self) -> InputHistoryEntry {
         InputHistoryEntry::from_content_and_attachments(
             self.content().to_string(),

--- a/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -823,10 +823,12 @@ impl InputManager {
             .collect();
     }
 
-    pub fn push_attachment(&mut self, attachment: ContentPart) {
+    pub fn push_attachment(&mut self, attachment: ContentPart) -> Option<usize> {
         if attachment.is_image() {
             self.attachments.push(attachment);
+            return Some(self.attachments.len());
         }
+        None
     }
 
     pub fn current_history_entry(&self) -> InputHistoryEntry {

--- a/vtcode-ui/src/tui/core_tui/session/state.rs
+++ b/vtcode-ui/src/tui/core_tui/session/state.rs
@@ -212,6 +212,10 @@ impl Session {
         self.input_enabled = enabled;
     }
 
+    pub(crate) fn image_input_enabled(&self) -> bool {
+        self.image_input_enabled
+    }
+
     pub(crate) fn input_compact_mode(&self) -> bool {
         self.input_compact_mode
     }

--- a/vtcode-ui/src/tui/core_tui/session/tests.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests.rs
@@ -4,6 +4,7 @@ mod file_palette;
 mod header_status;
 mod helpers;
 mod history;
+mod image_paste;
 mod input_navigation;
 mod local_agents;
 mod misc;

--- a/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
@@ -44,6 +44,30 @@ fn ctrl_v_attaches_clipboard_image_when_enabled() {
 }
 
 #[test]
+fn pasted_image_is_included_in_submit_payload() {
+    let mut session = app_session_with_input("describe this", "describe this".len());
+    let attachment = image_part();
+    set_image_input_enabled(&mut session, true);
+
+    let paste_event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Ok(attachment.clone())
+        });
+
+    assert!(paste_event.is_none());
+
+    let submit_event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    let Some(app_types::InlineEvent::Submit(submitted)) = submit_event else {
+        panic!("expected submit event with pasted image, got {submit_event:?}");
+    };
+    assert_eq!(submitted.text, "describe this");
+    assert_eq!(submitted.attachments, vec![attachment]);
+    assert!(session.core.input_manager.content().is_empty());
+    assert!(session.core.input_manager.attachments().is_empty());
+}
+
+#[test]
 fn alt_v_attaches_clipboard_image_when_enabled() {
     let mut session = app_session_with_input("describe this", "describe this".len());
     let attachment = image_part();

--- a/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
@@ -44,6 +44,44 @@ fn ctrl_v_attaches_clipboard_image_when_enabled() {
 }
 
 #[test]
+fn pasted_image_renders_immediately_as_numbered_chip() {
+    let mut session = app_session_with_input("", 0);
+    set_image_input_enabled(&mut session, true);
+
+    let event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Ok(image_part())
+        });
+
+    assert!(event.is_none());
+    let data = session.core.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
+    let rendered = text_content(&data.text);
+    assert!(rendered.contains("[Image #1]"));
+    assert!(!rendered.contains("attachment"));
+}
+
+#[test]
+fn pasted_images_keep_numbered_chips_after_typing() {
+    let mut session = app_session_with_input("", 0);
+    set_image_input_enabled(&mut session, true);
+
+    for _ in 0..2 {
+        let event = session.process_key_with_clipboard_image_reader(
+            image_paste_key(KeyModifiers::CONTROL),
+            || Ok(image_part()),
+        );
+        assert!(event.is_none());
+    }
+    let event = session.process_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+
+    assert!(event.is_none());
+    let data = session.core.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
+    let rendered = text_content(&data.text);
+    assert!(rendered.contains("[Image #1] [Image #2] o"));
+    assert!(!rendered.contains("attachments"));
+}
+
+#[test]
 fn pasted_image_is_included_in_submit_payload() {
     let mut session = app_session_with_input("describe this", "describe this".len());
     let attachment = image_part();

--- a/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
@@ -1,0 +1,155 @@
+use super::helpers::*;
+use crate::tui::core_tui::session::clipboard_image::ClipboardImageError;
+use crate::tui::core_tui::types::ContentPart;
+
+fn image_part() -> ContentPart {
+    ContentPart::image("png-data", "image/png")
+}
+
+fn set_image_input_enabled(session: &mut AppSession, enabled: bool) {
+    session.handle_command(app_types::InlineCommand::SetImageInputEnabled(enabled));
+}
+
+fn image_paste_key(modifiers: KeyModifiers) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char('v'), modifiers)
+}
+
+fn warning_text(session: &AppSession) -> String {
+    session
+        .core
+        .lines
+        .iter()
+        .filter(|line| line.kind == InlineMessageKind::Warning)
+        .flat_map(|line| line.segments.iter())
+        .map(|segment| segment.text.as_str())
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+#[test]
+fn ctrl_v_attaches_clipboard_image_when_enabled() {
+    let mut session = app_session_with_input("describe this", "describe this".len());
+    let attachment = image_part();
+    set_image_input_enabled(&mut session, true);
+
+    let event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Ok(attachment.clone())
+        });
+
+    assert!(event.is_none());
+    assert_eq!(session.core.input_manager.content(), "describe this");
+    assert_eq!(session.core.input_manager.attachments(), &[attachment]);
+    assert!(warning_text(&session).is_empty());
+}
+
+#[test]
+fn alt_v_attaches_clipboard_image_when_enabled() {
+    let mut session = app_session_with_input("describe this", "describe this".len());
+    let attachment = image_part();
+    set_image_input_enabled(&mut session, true);
+
+    let event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::ALT), || {
+            Ok(attachment.clone())
+        });
+
+    assert!(event.is_none());
+    assert_eq!(session.core.input_manager.attachments(), &[attachment]);
+}
+
+#[test]
+fn unsupported_model_warning_does_not_read_or_attach() {
+    let mut session = app_session_with_input("describe this", "describe this".len());
+    let mut reader_called = false;
+    set_image_input_enabled(&mut session, false);
+
+    let event = session.process_key_with_clipboard_image_reader(
+        image_paste_key(KeyModifiers::CONTROL),
+        || {
+            reader_called = true;
+            Ok(image_part())
+        },
+    );
+
+    assert!(event.is_none());
+    assert!(!reader_called);
+    assert_eq!(session.core.input_manager.content(), "describe this");
+    assert!(session.core.input_manager.attachments().is_empty());
+    assert_eq!(
+        warning_text(&session),
+        "The selected model does not support image input."
+    );
+}
+
+#[test]
+fn no_image_warning_leaves_text_and_attachments_unchanged() {
+    let mut session = app_session_with_input("keep text", "keep text".len());
+    let existing_attachment = ContentPart::image("existing", "image/png");
+    session
+        .core
+        .input_manager
+        .set_attachments(vec![existing_attachment.clone()]);
+    set_image_input_enabled(&mut session, true);
+
+    let event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Err(ClipboardImageError::NoImage)
+        });
+
+    assert!(event.is_none());
+    assert_eq!(session.core.input_manager.content(), "keep text");
+    assert_eq!(
+        session.core.input_manager.attachments(),
+        &[existing_attachment]
+    );
+    assert_eq!(warning_text(&session), "No image found in clipboard.");
+}
+
+#[test]
+fn clipboard_unavailable_warning_leaves_text_unchanged() {
+    let mut session = app_session_with_input("keep text", "keep text".len());
+    set_image_input_enabled(&mut session, true);
+
+    let event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::ALT), || {
+            Err(ClipboardImageError::ClipboardUnavailable)
+        });
+
+    assert!(event.is_none());
+    assert_eq!(session.core.input_manager.content(), "keep text");
+    assert_eq!(
+        warning_text(&session),
+        "Clipboard image paste is unavailable in this terminal or desktop session."
+    );
+}
+
+#[test]
+fn wsl_fallback_failure_warning_leaves_text_unchanged() {
+    let mut session = app_session_with_input("keep text", "keep text".len());
+    set_image_input_enabled(&mut session, true);
+
+    let event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Err(ClipboardImageError::WslFallbackFailure)
+        });
+
+    assert!(event.is_none());
+    assert_eq!(session.core.input_manager.content(), "keep text");
+    assert_eq!(
+        warning_text(&session),
+        "Could not read a clipboard image from Windows via PowerShell."
+    );
+}
+
+#[test]
+fn bracketed_text_paste_still_inserts_text() {
+    let mut session = app_session_with_input("prefix", "prefix".len());
+    set_image_input_enabled(&mut session, true);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    session.handle_event(CrosstermEvent::Paste(" pasted text".to_string()), &tx, None);
+
+    assert_eq!(session.core.input_manager.content(), "prefix pasted text");
+    assert!(session.core.input_manager.attachments().is_empty());
+}

--- a/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
@@ -1,9 +1,14 @@
 use super::helpers::*;
 use crate::tui::core_tui::session::clipboard_image::ClipboardImageError;
+use crate::tui::core_tui::session::input_manager::InputHistoryEntry;
 use crate::tui::core_tui::types::ContentPart;
 
 fn image_part() -> ContentPart {
-    ContentPart::image("png-data", "image/png")
+    image_part_with_data("png-data")
+}
+
+fn image_part_with_data(data: &str) -> ContentPart {
+    ContentPart::image(data, "image/png")
 }
 
 fn set_image_input_enabled(session: &mut AppSession, enabled: bool) {
@@ -12,6 +17,22 @@ fn set_image_input_enabled(session: &mut AppSession, enabled: bool) {
 
 fn image_paste_key(modifiers: KeyModifiers) -> KeyEvent {
     KeyEvent::new(KeyCode::Char('v'), modifiers)
+}
+
+fn paste_image(session: &mut AppSession, attachment: &ContentPart) {
+    let event = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Ok(attachment.clone())
+        });
+    assert!(event.is_none());
+}
+
+fn submit(session: &mut AppSession) -> app_types::SubmittedInput {
+    let event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    let Some(app_types::InlineEvent::Submit(submitted)) = event else {
+        panic!("expected submit event, got {event:?}");
+    };
+    submitted
 }
 
 fn warning_text(session: &AppSession) -> String {
@@ -132,6 +153,160 @@ fn pasted_image_is_included_in_submit_payload() {
     assert_eq!(submitted.attachments, vec![attachment]);
     assert!(session.core.input_manager.content().is_empty());
     assert!(session.core.input_manager.attachments().is_empty());
+}
+
+#[test]
+fn orphaned_first_pasted_image_placeholder_deleted_is_not_submitted() {
+    let mut session = app_session_with_input("", 0);
+    let first_attachment = image_part_with_data("first-image");
+    let second_attachment = image_part_with_data("second-image");
+    set_image_input_enabled(&mut session, true);
+
+    paste_image(&mut session, &first_attachment);
+    paste_image(&mut session, &second_attachment);
+    session
+        .core
+        .input_manager
+        .set_content("[Image #2] describe remaining".to_owned());
+
+    let submitted = submit(&mut session);
+
+    assert_eq!(submitted.text, "[Image #2] describe remaining");
+    assert_eq!(submitted.attachments, vec![second_attachment]);
+}
+
+#[test]
+fn orphaned_second_pasted_image_placeholder_deleted_keeps_first_attachment() {
+    let mut session = app_session_with_input("", 0);
+    let first_attachment = image_part_with_data("first-image");
+    let second_attachment = image_part_with_data("second-image");
+    set_image_input_enabled(&mut session, true);
+
+    paste_image(&mut session, &first_attachment);
+    paste_image(&mut session, &second_attachment);
+    session
+        .core
+        .input_manager
+        .set_content("[Image #1] describe first".to_owned());
+
+    let submitted = submit(&mut session);
+
+    assert_eq!(submitted.text, "[Image #1] describe first");
+    assert_eq!(submitted.attachments, vec![first_attachment]);
+}
+
+#[test]
+fn reordered_pasted_image_placeholders_keep_original_attachment_order() {
+    let mut session = app_session_with_input("", 0);
+    let first_attachment = image_part_with_data("first-image");
+    let second_attachment = image_part_with_data("second-image");
+    set_image_input_enabled(&mut session, true);
+
+    paste_image(&mut session, &first_attachment);
+    paste_image(&mut session, &second_attachment);
+    session
+        .core
+        .input_manager
+        .set_content("[Image #2] then [Image #1]".to_owned());
+
+    let submitted = submit(&mut session);
+
+    assert_eq!(submitted.text, "[Image #2] then [Image #1]");
+    assert_eq!(
+        submitted.attachments,
+        vec![first_attachment, second_attachment]
+    );
+}
+
+#[test]
+fn orphaned_restored_single_attachment_uses_visible_compacted_placeholder_provenance() {
+    let mut session = app_session_with_input("", 0);
+    let attachment = image_part_with_data("second-image");
+
+    session.handle_command(app_types::InlineCommand::RestoreInputDraft(
+        app_types::SubmittedInput::new("[Image #2] describe remaining", vec![attachment]),
+    ));
+    session
+        .core
+        .input_manager
+        .set_content("describe remaining".to_owned());
+
+    let submitted = submit(&mut session);
+
+    assert_eq!(submitted.text, "describe remaining");
+    assert!(submitted.attachments.is_empty());
+}
+
+#[test]
+fn orphaned_history_restored_single_attachment_uses_visible_compacted_placeholder_provenance() {
+    let mut session = app_session_with_input("", 0);
+    let attachment = image_part_with_data("second-image");
+    let entry = InputHistoryEntry::from_content_and_attachments(
+        "[Image #2] describe remaining".to_owned(),
+        vec![attachment],
+    );
+
+    session.core.input_manager.apply_history_entry(entry);
+    session
+        .core
+        .input_manager
+        .set_content("describe remaining".to_owned());
+
+    let submitted = submit(&mut session);
+
+    assert_eq!(submitted.text, "describe remaining");
+    assert!(submitted.attachments.is_empty());
+}
+
+#[test]
+fn orphaned_restored_non_contiguous_placeholders_keep_visible_attachment() {
+    let mut session = app_session_with_input("", 0);
+    let second_attachment = image_part_with_data("second-image");
+    let third_attachment = image_part_with_data("third-image");
+
+    session.handle_command(app_types::InlineCommand::RestoreInputDraft(
+        app_types::SubmittedInput::new(
+            "[Image #2][Image #3] describe remaining",
+            vec![second_attachment.clone(), third_attachment],
+        ),
+    ));
+    session
+        .core
+        .input_manager
+        .set_content("[Image #2] describe remaining".to_owned());
+
+    let submitted = submit(&mut session);
+
+    assert_eq!(submitted.text, "[Image #2] describe remaining");
+    assert_eq!(submitted.attachments, vec![second_attachment]);
+}
+
+#[test]
+fn orphaned_later_paste_after_restored_placeholder_keeps_restored_attachment() {
+    let mut session = app_session_with_input("", 0);
+    let restored_attachment = image_part_with_data("restored-image");
+    let pasted_attachment = image_part_with_data("pasted-image");
+    set_image_input_enabled(&mut session, true);
+
+    session.handle_command(app_types::InlineCommand::RestoreInputDraft(
+        app_types::SubmittedInput::new("[Image #2] restored", vec![restored_attachment.clone()]),
+    ));
+    paste_image(&mut session, &pasted_attachment);
+
+    assert_eq!(
+        session.core.input_manager.content(),
+        "[Image #2] restored[Image #3]"
+    );
+
+    session
+        .core
+        .input_manager
+        .set_content("[Image #2] restored".to_owned());
+
+    let submitted = submit(&mut session);
+
+    assert_eq!(submitted.text, "[Image #2] restored");
+    assert_eq!(submitted.attachments, vec![restored_attachment]);
 }
 
 #[test]

--- a/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
@@ -115,6 +115,33 @@ fn pasted_images_insert_placeholders_at_cursor_and_keep_typed_order() {
 }
 
 #[test]
+fn pasted_image_keeps_large_text_paste_collapsed() {
+    let mut session = app_session_with_input("before", "before".len());
+    set_image_input_enabled(&mut session, true);
+    let line_total = ui::INLINE_PASTE_COLLAPSE_LINE_THRESHOLD + 1;
+    let pasted_lines: Vec<String> = (1..=line_total).map(|idx| format!("line-{idx}")).collect();
+    let pasted_text = pasted_lines.join("\n");
+
+    session.core.insert_paste_text(&pasted_text);
+    session.core.insert_char(' ');
+    for ch in "after".chars() {
+        session.core.insert_char(ch);
+    }
+    paste_image(&mut session, &image_part());
+
+    assert_eq!(
+        session.core.input_manager.content(),
+        format!("before{pasted_text} after[Image #1]")
+    );
+    let data = session.core.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
+    let rendered = text_content(&data.text);
+    assert!(rendered.contains("before"));
+    assert!(rendered.contains("[Pasted Content"));
+    assert!(rendered.contains("after[Image #1]"));
+    assert!(!rendered.contains("line-1\nline-2"));
+}
+
+#[test]
 fn consecutive_pasted_images_insert_consecutive_placeholders() {
     let mut session = app_session_with_input("", 0);
     set_image_input_enabled(&mut session, true);

--- a/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/image_paste.rs
@@ -38,13 +38,16 @@ fn ctrl_v_attaches_clipboard_image_when_enabled() {
         });
 
     assert!(event.is_none());
-    assert_eq!(session.core.input_manager.content(), "describe this");
+    assert_eq!(
+        session.core.input_manager.content(),
+        "describe this[Image #1]"
+    );
     assert_eq!(session.core.input_manager.attachments(), &[attachment]);
     assert!(warning_text(&session).is_empty());
 }
 
 #[test]
-fn pasted_image_renders_immediately_as_numbered_chip() {
+fn pasted_image_renders_immediately_as_inline_text_placeholder() {
     let mut session = app_session_with_input("", 0);
     set_image_input_enabled(&mut session, true);
 
@@ -54,6 +57,7 @@ fn pasted_image_renders_immediately_as_numbered_chip() {
         });
 
     assert!(event.is_none());
+    assert_eq!(session.core.input_manager.content(), "[Image #1]");
     let data = session.core.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
     let rendered = text_content(&data.text);
     assert!(rendered.contains("[Image #1]"));
@@ -61,7 +65,36 @@ fn pasted_image_renders_immediately_as_numbered_chip() {
 }
 
 #[test]
-fn pasted_images_keep_numbered_chips_after_typing() {
+fn pasted_images_insert_placeholders_at_cursor_and_keep_typed_order() {
+    let mut session = app_session_with_input("", 0);
+    set_image_input_enabled(&mut session, true);
+
+    let first_paste = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Ok(image_part())
+        });
+    assert!(first_paste.is_none());
+    let event = session.process_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+    assert!(event.is_none());
+    session.core.set_cursor(0);
+    let second_paste = session
+        .process_key_with_clipboard_image_reader(image_paste_key(KeyModifiers::CONTROL), || {
+            Ok(image_part())
+        });
+
+    assert!(second_paste.is_none());
+    assert_eq!(
+        session.core.input_manager.content(),
+        "[Image #2][Image #1]o"
+    );
+    let data = session.core.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
+    let rendered = text_content(&data.text);
+    assert!(rendered.contains("[Image #2][Image #1]o"));
+    assert!(!rendered.contains("attachments"));
+}
+
+#[test]
+fn consecutive_pasted_images_insert_consecutive_placeholders() {
     let mut session = app_session_with_input("", 0);
     set_image_input_enabled(&mut session, true);
 
@@ -72,18 +105,13 @@ fn pasted_images_keep_numbered_chips_after_typing() {
         );
         assert!(event.is_none());
     }
-    let event = session.process_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
 
-    assert!(event.is_none());
-    let data = session.core.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
-    let rendered = text_content(&data.text);
-    assert!(rendered.contains("[Image #1] [Image #2] o"));
-    assert!(!rendered.contains("attachments"));
+    assert_eq!(session.core.input_manager.content(), "[Image #1][Image #2]");
 }
 
 #[test]
 fn pasted_image_is_included_in_submit_payload() {
-    let mut session = app_session_with_input("describe this", "describe this".len());
+    let mut session = app_session_with_input("", 0);
     let attachment = image_part();
     set_image_input_enabled(&mut session, true);
 
@@ -93,13 +121,14 @@ fn pasted_image_is_included_in_submit_payload() {
         });
 
     assert!(paste_event.is_none());
+    session.core.input_manager.insert_text(" and here?");
 
     let submit_event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
     let Some(app_types::InlineEvent::Submit(submitted)) = submit_event else {
         panic!("expected submit event with pasted image, got {submit_event:?}");
     };
-    assert_eq!(submitted.text, "describe this");
+    assert_eq!(submitted.text, "[Image #1] and here?");
     assert_eq!(submitted.attachments, vec![attachment]);
     assert!(session.core.input_manager.content().is_empty());
     assert!(session.core.input_manager.attachments().is_empty());
@@ -117,6 +146,10 @@ fn alt_v_attaches_clipboard_image_when_enabled() {
         });
 
     assert!(event.is_none());
+    assert_eq!(
+        session.core.input_manager.content(),
+        "describe this[Image #1]"
+    );
     assert_eq!(session.core.input_manager.attachments(), &[attachment]);
 }
 

--- a/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use super::helpers::*;
+use crate::tui::core_tui::types::{ContentPart, SubmittedInput};
 
 #[test]
 fn shift_enter_inserts_newline() {
@@ -611,6 +612,47 @@ fn busy_control_enter_steers_active_run() {
 
     let event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL));
     assert!(matches!(event, Some(InlineEvent::Steer(value)) if value == "keep searching in docs/"));
+}
+
+#[test]
+fn restore_input_draft_command_preserves_attachments_in_order() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    let first_attachment = ContentPart::image("first-image", "image/png");
+    let second_attachment = ContentPart::image("second-image", "image/png");
+
+    session.handle_command(InlineCommand::RestoreInputDraft(SubmittedInput::new(
+        "keep searching in docs/",
+        vec![first_attachment.clone(), second_attachment.clone()],
+    )));
+
+    assert_eq!(session.input_manager.content(), "keep searching in docs/");
+    assert_eq!(
+        session.input_manager.attachments(),
+        &[first_attachment, second_attachment]
+    );
+}
+
+#[test]
+fn app_restore_input_draft_command_preserves_attachments_in_order() {
+    let mut session = AppSession::new(InlineTheme::default(), None, VIEW_ROWS);
+    let first_attachment = ContentPart::image("first-image", "image/png");
+    let second_attachment = ContentPart::image("second-image", "image/png");
+
+    session.handle_command(app_types::InlineCommand::RestoreInputDraft(
+        SubmittedInput::new(
+            "keep searching in docs/",
+            vec![first_attachment.clone(), second_attachment.clone()],
+        ),
+    ));
+
+    assert_eq!(
+        session.core.input_manager.content(),
+        "keep searching in docs/"
+    );
+    assert_eq!(
+        session.core.input_manager.attachments(),
+        &[first_attachment, second_attachment]
+    );
 }
 
 #[test]

--- a/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
@@ -117,6 +117,31 @@ fn input_compact_preview_for_large_paste() {
 }
 
 #[test]
+fn input_compact_preview_keeps_text_after_large_paste_visible() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.set_input("before".to_string());
+    let line_total = ui::INLINE_PASTE_COLLAPSE_LINE_THRESHOLD + 1;
+    let pasted_lines: Vec<String> = (1..=line_total).map(|idx| format!("line-{idx}")).collect();
+    let pasted_text = pasted_lines.join("\n");
+
+    session.insert_paste_text(&pasted_text);
+    session.insert_char(' ');
+    for ch in "after".chars() {
+        session.insert_char(ch);
+    }
+
+    let data = session.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
+    let rendered = text_content(&data.text);
+    assert!(rendered.contains("before"));
+    assert!(rendered.contains("[Pasted Content"));
+    assert!(rendered.contains("after"));
+    assert_eq!(
+        session.input_manager.content(),
+        format!("before{pasted_text} after")
+    );
+}
+
+#[test]
 fn idle_enter_submits_immediately() {
     let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
 

--- a/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
+++ b/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
@@ -142,6 +142,39 @@ fn input_compact_preview_keeps_text_after_large_paste_visible() {
 }
 
 #[test]
+fn shift_enter_after_large_paste_inserts_newline() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.set_input("hello ".to_string());
+    let line_total = ui::INLINE_PASTE_COLLAPSE_LINE_THRESHOLD + 1;
+    let pasted_lines: Vec<String> = (1..=line_total).map(|idx| format!("line-{idx}")).collect();
+    let pasted_text = pasted_lines.join("\n");
+
+    session.insert_paste_text(&pasted_text);
+    session.insert_char(' ');
+    for ch in "and what are you talking about??".chars() {
+        session.insert_char(ch);
+    }
+
+    let result = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+
+    assert!(result.is_none());
+    assert_eq!(
+        session.input_manager.content(),
+        format!("hello {pasted_text} and what are you talking about??\n")
+    );
+    assert_eq!(
+        session.input_manager.cursor(),
+        session.input_manager.content().len()
+    );
+
+    let data = session.build_input_widget_data(VIEW_WIDTH, VIEW_ROWS);
+    let rendered = text_content(&data.text);
+    assert!(rendered.contains("talking about??\n"));
+    assert_eq!(data.cursor_y, 1);
+    assert!(session.desired_input_lines(VIEW_WIDTH) >= 2);
+}
+
+#[test]
 fn idle_enter_submits_immediately() {
     let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
 

--- a/vtcode-ui/src/tui/core_tui/types.rs
+++ b/vtcode-ui/src/tui/core_tui/types.rs
@@ -14,7 +14,7 @@ pub use overlay::{
 };
 pub use protocol::{
     FocusChangeCallback, InlineCommand, InlineEvent, InlineEventCallback, InlineHandle,
-    InlineMessageKind, InlineSession, PreviewCallback,
+    InlineMessageKind, InlineSession, PreviewCallback, SubmittedInput,
 };
 pub use selection::{
     InlineListItem, InlineListSearchConfig, InlineListSelection, OpenAIServiceTierChoice,

--- a/vtcode-ui/src/tui/core_tui/types/protocol.rs
+++ b/vtcode-ui/src/tui/core_tui/types/protocol.rs
@@ -1,7 +1,9 @@
+use std::ops::Deref;
 use std::sync::Arc;
 
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
+use super::ContentPart;
 use super::overlay::{ListOverlayRequest, ModalOverlayRequest, OverlayEvent, OverlayRequest};
 use super::selection::{
     InlineListItem, InlineListSearchConfig, InlineListSelection, SecurePromptConfig,
@@ -12,6 +14,84 @@ use super::style::{
 use crate::tui::core_tui::session::config::AppearanceConfig;
 
 pub use vtcode_commons::ui_protocol::InlineMessageKind;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubmittedInput {
+    pub text: String,
+    pub attachments: Vec<ContentPart>,
+}
+
+impl SubmittedInput {
+    pub fn new(text: impl Into<String>, attachments: Vec<ContentPart>) -> Self {
+        Self {
+            text: text.into(),
+            attachments,
+        }
+    }
+
+    pub fn text_only(text: impl Into<String>) -> Self {
+        Self::new(text, Vec::new())
+    }
+
+    pub fn trim_text(self) -> Self {
+        Self {
+            text: self.text.trim().to_string(),
+            attachments: self.attachments,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.text.trim().is_empty() && self.attachments.is_empty()
+    }
+
+    pub fn has_attachments(&self) -> bool {
+        !self.attachments.is_empty()
+    }
+}
+
+impl From<String> for SubmittedInput {
+    fn from(text: String) -> Self {
+        Self::text_only(text)
+    }
+}
+
+impl From<&str> for SubmittedInput {
+    fn from(text: &str) -> Self {
+        Self::text_only(text)
+    }
+}
+
+impl Deref for SubmittedInput {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.text
+    }
+}
+
+impl PartialEq<&str> for SubmittedInput {
+    fn eq(&self, other: &&str) -> bool {
+        self.text == *other
+    }
+}
+
+impl PartialEq<&str> for &SubmittedInput {
+    fn eq(&self, other: &&str) -> bool {
+        self.text == *other
+    }
+}
+
+impl PartialEq<String> for SubmittedInput {
+    fn eq(&self, other: &String) -> bool {
+        self.text == *other
+    }
+}
+
+impl PartialEq<&String> for SubmittedInput {
+    fn eq(&self, other: &&String) -> bool {
+        self.text == **other
+    }
+}
 
 pub enum InlineCommand {
     AppendLine {
@@ -84,6 +164,7 @@ pub enum InlineCommand {
     SetCursorVisible(bool),
     SetInputEnabled(bool),
     SetInput(String),
+    RestoreInputDraft(SubmittedInput),
     ApplySuggestedPrompt(String),
     SetInlinePromptSuggestion {
         suggestion: String,
@@ -111,9 +192,9 @@ pub enum InlineCommand {
 
 #[derive(Debug, Clone)]
 pub enum InlineEvent {
-    Submit(String),
-    QueueSubmit(String),
-    Steer(String),
+    Submit(SubmittedInput),
+    QueueSubmit(SubmittedInput),
+    Steer(SubmittedInput),
     ProcessLatestQueued,
     /// Edit the newest queued input (pop into input buffer)
     EditQueue,
@@ -307,6 +388,10 @@ impl InlineHandle {
 
     pub fn set_input(&self, content: String) {
         self.send_command(InlineCommand::SetInput(content));
+    }
+
+    pub fn restore_input_draft(&self, input: SubmittedInput) {
+        self.send_command(InlineCommand::RestoreInputDraft(input));
     }
 
     pub fn apply_suggested_prompt(&self, content: String) {

--- a/vtcode-ui/src/tui/core_tui/types/protocol.rs
+++ b/vtcode-ui/src/tui/core_tui/types/protocol.rs
@@ -163,6 +163,7 @@ pub enum InlineCommand {
     },
     SetCursorVisible(bool),
     SetInputEnabled(bool),
+    SetImageInputEnabled(bool),
     SetInput(String),
     RestoreInputDraft(SubmittedInput),
     ApplySuggestedPrompt(String),
@@ -384,6 +385,10 @@ impl InlineHandle {
 
     pub fn set_input_enabled(&self, enabled: bool) {
         self.send_command(InlineCommand::SetInputEnabled(enabled));
+    }
+
+    pub fn set_image_input_enabled(&self, enabled: bool) {
+        self.send_command(InlineCommand::SetImageInputEnabled(enabled));
     }
 
     pub fn set_input(&self, content: String) {


### PR DESCRIPTION
# Pull Request

## Description

Adds Codex-style clipboard image paste support to the TUI and fixes several input handling regressions found while wiring it in.

This branch:

- Preserves enhanced keyboard protocol handling when entering the alternate screen, fixing `Shift+Enter` in terminals that support Kitty keyboard protocol.
- Fixes compact paste rendering so typed text after a compact pasted-context marker stays visible, and newlines render correctly.
- Carries image attachments through the TUI submission path and gates submitted image content based on model image capability.
- Adds a clipboard image reader using `arboard` and `image`, including Linux, macOS, Windows, and WSL fallback handling.
- Wires `Ctrl+V` and `Alt+V` as app-level clipboard image paste shortcuts. Text paste remains on the terminal bracketed paste path.
- Displays pasted image placeholders inline as `[Image #n]`.
- Preserves inline image placeholders through submission so the model receives text and image parts in the intended order.
- Rejects pasted or submitted images when the selected model does not support image input.
- Detects GPT-5.5 image capability correctly.
- Prevents manually deleted `[Image #n]` placeholders from submitting orphaned image attachments.
- Updates user docs for clipboard image paste and terminal paste handling.
- Adds regression coverage for keyboard input, compact paste, image paste, image capability gating, placeholder ordering, and orphaned image removal.

New dependencies:

- `arboard` for clipboard access, with `wayland-data-control`.
- `image` for encoding clipboard image data as supported image formats.
- `base64` in `vtcode-ui` for image payload handling.

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Focused regression tests, formatting, build checks, and diff validation were run locally.

- [x] Rust tests: `cargo test`
- [ ] Linting: `cargo clippy`
- [x] Formatting: `cargo fmt`
- [x] Build: `cargo check`

Commands run:

```sh
cargo fmt --check
cargo test -p vtcode-ui --locked pasted_image
cargo test -p vtcode-ui --locked orphan
cargo test -p vtcode --bin vtcode --locked inline_image_placeholder_text_stays_before_pasted_image_part
cargo check -p vtcode-ui --locked
cargo check -p vtcode --locked
git diff --check
```

**Test Configuration**:
* Rust version: `rustc 1.88.0 (6b00bc388 2025-06-23)`
* Operating system: Linux `x86_64`, kernel `7.0.14-x64v3-xanmod1-1`
* Toolchain: `1.88-x86_64-unknown-linux-gnu`

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`cargo test`)
- [ ] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the `CHANGELOG.md` if this change affects the user-facing behaviour
- [x] I have checked my code and corrected any misspellings

## Additional Context

`cargo check -p vtcode --locked` reports existing warnings in `vtcode-core` and `vtcode-acp`; this branch does not introduce new warnings in the changed paths.

Image paste is intentionally separate from terminal text paste: `Ctrl+V` and `Alt+V` paste clipboard images through VT Code, while text paste continues to use the terminal’s bracketed paste shortcut, commonly `Ctrl+Shift+V`.

<img width="449" height="118" alt="image" src="https://github.com/user-attachments/assets/2c3e54c7-6f8f-47c7-886d-e6deaee7eee2" />
