### PR TITLE
fix: primary agent runtime config overrides a configured model with "inherit"

### DIFF
--- a/vtcode-core/src/primary_agent.rs
+++ b/vtcode-core/src/primary_agent.rs
@@ -275,8 +275,17 @@ pub fn build_primary_agent_runtime_config(
     agent: &ActivePrimaryAgent,
 ) -> VTCodeConfig {
     let mut config = parent.clone();
+    // "inherit" (and empty) are sentinels meaning "use the parent's model" — mirrors
+    // resolve_subagent_model's handling in subagents/model.rs. Built-in primary agents
+    // (e.g. "auto", "build") default their `model` field to "inherit", so without this
+    // check every plain `exec` run would clobber a real, explicitly configured model
+    // (via --model or [agent].default_model) with the literal string "inherit", which
+    // then fails ModelId parsing entirely.
     if let Some(model) = agent.model.as_ref() {
-        config.agent.default_model = model.clone();
+        let trimmed = model.trim();
+        if !trimmed.is_empty() && !trimmed.eq_ignore_ascii_case("inherit") {
+            config.agent.default_model = model.clone();
+        }
     }
     if let Some(reasoning_effort) = agent.reasoning_effort {
         config.agent.reasoning_effort = reasoning_effort;
@@ -823,6 +832,34 @@ mod tests {
         assert_eq!(runtime.mcp.providers.len(), 2);
         assert_eq!(runtime.mcp.providers[0].name, "global");
         assert_eq!(runtime.mcp.providers[1].name, "local");
+    }
+
+    #[test]
+    fn build_primary_agent_runtime_config_inherits_parent_model_when_spec_says_inherit() {
+        let mut parent = VTCodeConfig::default();
+        parent.agent.default_model = "parent-model".to_string();
+
+        let mut spec = test_spec("auto");
+        spec.model = Some("inherit".to_string());
+        let active = ActivePrimaryAgent::from_spec(&spec);
+
+        let runtime = build_primary_agent_runtime_config(&parent, &active);
+
+        assert_eq!(runtime.agent.default_model, "parent-model");
+    }
+
+    #[test]
+    fn build_primary_agent_runtime_config_inherits_parent_model_when_spec_model_empty() {
+        let mut parent = VTCodeConfig::default();
+        parent.agent.default_model = "parent-model".to_string();
+
+        let mut spec = test_spec("auto");
+        spec.model = Some(String::new());
+        let active = ActivePrimaryAgent::from_spec(&spec);
+
+        let runtime = build_primary_agent_runtime_config(&parent, &active);
+
+        assert_eq!(runtime.agent.default_model, "parent-model");
     }
 
     #[test]


### PR DESCRIPTION
### Description

`vtcode exec` fails on any repo that hasn't configured its own primary agent, whenever a real model is supplied via CLI flag `-- model` or config `[agent].default_model`:

```
Error: Model 'inherit' is not recognized for exec command. Update vtcode.toml to a supported identifier.

Caused by:
    Invalid model identifier: 'inherit'. Supported models: ...
```

**Root cause**: every built-in primary agent (`auto`, `build`, `duck`, `plan`) defaults its `model` field to the sentinel string `"inherit"`, meaning "use the parent session's model." `build_primary_agent_runtime_config` in `vtcode-core/src/primary_agent.rs` copies that field into the runtime config unconditionally:

```rust
if let Some(model) = agent.model.as_ref() {
    config.agent.default_model = model.clone();
}
```

Nothing here ever resolves the `"inherit"` sentinel, so it overwrites whatever real model was configured with the literal text `"inherit"`. `cli/exec/prep.rs` then tries to parse that as a `ModelId` and fails. In practice this means: **plain `vtcode exec` cannot use a custom model at all**, on any workspace where the primary agent isn't explicitly pinned to a non-inherit model, which is the common case since `auto` (the default full-auto agent) inherits by design.

`resolve_subagent_model` in `vtcode-core/src/subagents/model.rs` already handles this correctly for subagent delegation by special-casing `"inherit"`/empty and falls back to the parent's model via `resolve_inherit_model`. `build_primary_agent_runtime_config` never got the equivalent guard. This looks like an oversight from when the primary-agent
system was split out from the subagent system, rather than an intentional difference. The two code paths describe the same sentinel with the same meaning.

This fix mirrors that existing guard: if the agent's `model` field is `"inherit"` (case-insensitive) or empty, leave the parent's `default_model` untouched instead of overwriting it.

I noticed `resolve_inherit_model` was just extended in #693 (`369cf8bc`) to handle custom/local providers via `RuntimeModelSources`. I deliberately kept this fix minimal and didn't route `build_primary_agent_runtime_config` through that same machinery.

Fixes: (no existing issue number, I can file one first if you'd prefer an issue before a PR)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Added two unit tests in `vtcode-core/src/primary_agent.rs` covering the exact regression: a primary agent spec with `model: Some("inherit")` and one with `model: Some(String::new())`, both asserting the parent's `default_model` survives instead of being overwritten.
- `cargo test -p vtcode-core`: all 28 tests in the `primary_agent` module pass, including the two new ones.
- `cargo clippy -p vtcode-core --lib` : no new warnings introduced by this change (checked by diffing against a clippy run on `main`).
- `cargo fmt --check -p vtcode-core`: clean.
- **Live reproduction, not just unit tests**: built this exact patch as a release binary and drove it with `vtcode exec --model deepseek/deepseek-v4-flash "<a real task>"` against a real cloned repo. On unpatched `main` this fails immediately with the `inherit` error before the model ever gets to make a single tool call. With the patch, the same command runs the full agent loop and produces a correct, minimal file edit. (This came up because I'm building a PR-automation
  tool that shells out to `vtcode exec` non-interactively, the bug is a hard blocker for that whole class of usage; it's not just an edge case.)

- [x] Rust tests: `cargo test`
- [x] Linting: `cargo clippy`
- [x] Formatting: `cargo fmt`
- [x] Build: `cargo build`

**Test Configuration**:
* Rust version: 1.94 (stable)
* Operating system: Windows 10 (this also affects Linux/macOS. It's a pure config-resolution logic bug)
* Toolchain: stable-x86_64-pc-windows-msvc

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [ ] Any dependent changes have been merged and published in downstream
      modules (n/a)
- [ ] I have updated the `CHANGELOG.md` (I left this alone, no feature added. It looks release-automation-generated from commit history, not hand-maintained per PR; let me know if you'd like an entry added manually)
- [x] I have checked my code and corrected any misspellings (This was **human** reviewed.)

### Additional Context

Single-file, single-commit diff for easy review:

```
vtcode-core/src/primary_agent.rs | 39 ++++++++++++++++++++++++++++++++++++++-
1 file changed, 38 insertions(+), 1 deletion(-)
```

The fix itself is 9 lines; the rest is the two new tests and a comment
explaining the sentinel.