### PR TITLE
fix(gemini): strip examples from function schemas

### DIFF
--- a/crates/codegen/vtcode-llm/src/providers/gemini/sanitize.rs
+++ b/crates/codegen/vtcode-llm/src/providers/gemini/sanitize.rs
@@ -43,6 +43,7 @@ fn sanitize_function_parameters_impl(parameters: Value, inside_properties_map: b
                 "not",
                 "contentMediaType",
                 "contentEncoding",
+                "examples",
             ];
 
             let alias_description_property = inside_properties_map && should_alias_description_property(&map);

--- a/crates/codegen/vtcode-llm/src/providers/gemini/tests.rs
+++ b/crates/codegen/vtcode-llm/src/providers/gemini/tests.rs
@@ -691,6 +691,24 @@ fn sanitize_function_parameters_removes_additional_properties() {
 }
 
 #[test]
+fn sanitize_function_parameters_removes_examples() {
+    let parameters = json!({
+        "type": "object",
+        "examples": [{ "path": "src/lib.rs" }],
+        "properties": {
+            "path": {
+                "type": "string",
+                "examples": ["src/lib.rs"]
+            }
+        }
+    });
+
+    let sanitized = sanitize_function_parameters(parameters);
+    assert!(sanitized.get("examples").is_none());
+    assert!(sanitized["properties"]["path"].get("examples").is_none());
+}
+
+#[test]
 fn sanitize_function_parameters_removes_exclusive_min_max() {
     // Test case for the bug: exclusiveMaximum and exclusiveMinimum in nested properties
     let parameters = json!({


### PR DESCRIPTION
## Summary
- remove the unsupported `examples` keyword from Gemini function parameter schemas
- add regression coverage for root and nested property examples

## Root cause
Gemini rejects `examples` in `function_declarations[].parameters`, causing ACP requests from Zed to fail with HTTP 400.

## Validation
- `cargo test -p vtcode-llm sanitize_function_parameters_removes_examples`