### PR TITLE
Migrate PTY screen backend from vt100 to rio-vt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
  "cpufeatures 0.2.17",
 ]
@@ -82,7 +82,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -429,7 +429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -463,7 +463,7 @@ dependencies = [
  "async-signal",
  "async-task",
  "blocking",
- "cfg-if",
+ "cfg-if 1.0.4",
  "event-listener",
  "futures-lite",
  "rustix",
@@ -489,7 +489,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "atomic-waker",
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-core",
  "futures-io",
  "rustix",
@@ -695,7 +695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
  "object 0.37.3",
@@ -945,6 +945,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "byteorder"
@@ -1017,6 +1031,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -1039,7 +1059,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -1234,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -1326,6 +1346,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "corcovado"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bb434a9c882d7615547c604a758ac0d7be142b3cc42c2b58339491d319e3bd"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "libc",
+ "miow 0.5.0",
+ "net2",
+ "slab",
+ "tracing",
+ "windows 0.42.0",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,7 +1414,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1514,8 +1553,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "curve25519-dalek"
@@ -1523,7 +1568,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -1760,7 +1805,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "dirs-sys-next",
 ]
 
@@ -1904,7 +1949,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1991,7 +2036,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "home",
  "windows-sys 0.59.0",
 ]
@@ -2167,7 +2212,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -2304,6 +2349,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,7 +2495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "log",
  "rustversion",
@@ -2468,7 +2529,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi",
@@ -2481,7 +2542,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -2495,7 +2556,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
@@ -2594,7 +2655,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "zerocopy",
 ]
@@ -2708,7 +2769,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "windows-link 0.2.1",
 ]
@@ -2720,7 +2781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "902f40dea4993d99db66732fddd9143e92657f1d47a642395f92b339b1375659"
 dependencies = [
  "arc-swap",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-channel",
  "flate2",
  "futures-channel",
@@ -3261,6 +3322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,7 +3392,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys",
@@ -3381,7 +3451,7 @@ version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "wasm-bindgen",
 ]
@@ -3526,7 +3596,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link 0.2.1",
 ]
 
@@ -3639,7 +3709,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "generator",
  "scoped-tls",
  "tracing",
@@ -3715,7 +3785,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rayon",
 ]
 
@@ -3800,6 +3870,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3904,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "net2"
+version = "0.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,7 +3927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.1.1",
  "libc",
 ]
@@ -3840,7 +3939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
@@ -3853,7 +3952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "libc",
 ]
@@ -4240,7 +4339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "openssl-macros",
@@ -4411,7 +4510,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -4534,7 +4633,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4544,7 +4653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -4553,7 +4662,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -4564,7 +4673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4575,6 +4684,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4692,7 +4810,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -5187,7 +5305,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossterm",
  "instability",
  "ratatui-core",
@@ -5271,7 +5389,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
- "cfg-if",
+ "cfg-if 1.0.4",
  "interpolate_name",
  "itertools 0.14.0",
  "libc",
@@ -5577,11 +5695,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rio-grapheme-width"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4dcff875ccd52c2b3da56061350469674f4f292cbae02538009f64f48cc3d8"
+dependencies = [
+ "phf 0.13.1",
+ "ucd-trie",
+]
+
+[[package]]
+name = "rio-graphics"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc1807607df800b542b9980aaf20a8732b7168172df24e3d811d18ec4d7addb"
+dependencies = [
+ "rustc-hash 2.1.2",
+ "tracing",
+]
+
+[[package]]
+name = "rio-vt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee35d73ac2bc2628caa2bc677b9a83ec14541e9a189e204aeeb9a452ddc4cf0"
+dependencies = [
+ "base64",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "corcovado",
+ "cursor-icon",
+ "flate2",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "regex",
+ "regex-automata",
+ "rio-grapheme-width",
+ "rio-graphics",
+ "rustc-hash 2.1.2",
+ "serde",
+ "simdutf",
+ "smallvec",
+ "teletypewriter",
+ "tracing",
+ "unicode-width-16",
+ "url",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6102,7 +6271,7 @@ version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -6138,7 +6307,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -6149,7 +6318,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -6160,7 +6329,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
@@ -6276,6 +6445,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
+]
+
+[[package]]
+name = "simdutf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f542752c7335a9174e7bb81112c3ca1415a7a6b6ec2c3e840aca347a30f9141"
+dependencies = [
+ "bitflags 2.13.0",
+ "cc",
 ]
 
 [[package]]
@@ -6554,6 +6733,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "teletypewriter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665b971f857741b1feb472ad1649a4584dd2a2fce91596e8da7a6f6533274dd5"
+dependencies = [
+ "corcovado",
+ "dirs",
+ "iovec",
+ "libc",
+ "miow 0.6.1",
+ "parking_lot",
+ "signal-hook 0.4.4",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6608,7 +6804,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -6651,7 +6847,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2 0.10.9",
  "signal-hook 0.3.18",
  "siphasher",
@@ -6755,7 +6951,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -7470,6 +7666,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-width-16"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7621,17 +7823,6 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "vt100"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
-dependencies = [
- "itoa",
- "unicode-width 0.2.2",
- "vte",
-]
 
 [[package]]
 name = "vtcode"
@@ -7921,6 +8112,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rig-core",
  "ring",
+ "rio-vt",
  "roff",
  "rusqlite",
  "rustc-hash 2.1.2",
@@ -7957,7 +8149,6 @@ dependencies = [
  "unicode-width 0.2.2",
  "url",
  "uuid",
- "vt100",
  "vtcode-a2a",
  "vtcode-auth",
  "vtcode-bash-runner",
@@ -8241,16 +8432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vte"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
-dependencies = [
- "arrayvec",
- "memchr",
-]
-
-[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8308,7 +8489,7 @@ version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -8636,6 +8817,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -8841,6 +9037,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8937,6 +9148,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8949,6 +9166,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8958,6 +9181,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8985,6 +9214,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8994,6 +9229,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9009,6 +9250,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -9018,6 +9265,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,7 +7635,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-a2a"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7725,7 +7725,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-acp"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-auth"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-bash-runner"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -7800,7 +7800,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-commons"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -7838,7 +7838,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-config"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-core"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "ansi-to-tui",
  "anstream",
@@ -7981,7 +7981,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-eval"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7993,7 +7993,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-exec-events"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "chrono",
  "hashbrown 0.17.1",
@@ -8008,7 +8008,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-indexer"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "fs2",
@@ -8030,7 +8030,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-llm"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-macros"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -8086,7 +8086,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-mcp"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-memory"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "chrono",
  "lru",
@@ -8135,7 +8135,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-safety"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -8160,7 +8160,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-skills"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-ui"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "anstyle",
  "anstyle-git",
@@ -8233,7 +8233,7 @@ dependencies = [
 
 [[package]]
 name = "vtcode-utility-tool-specs"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "rmcp",
  "serde",
@@ -9131,7 +9131,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.140.2"
+version = "0.140.3"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ crossterm = "0.29"
 schemars = "1.2"
 thiserror = "2.0.18"
 unicode-width = "0.2.0"
-vt100 = "0.16"
+rio-vt = "0.5.0"
 serde_json = "1.0"
 tempfile = "3.27"
 tokio = { version = "1.52", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtcode"
-version = "0.140.2"
+version = "0.140.3"
 edition = "2024"
 rust-version = "1.93.0"
 authors = ["Vinh Nguyen <vinhnguyen2308@gmail.com>"]
@@ -105,27 +105,27 @@ tracing-opentelemetry = "0.33"
 testcontainers = "0.24"
 
 # Internal workspace crates
-vtcode-commons = { path = "crates/common/vtcode-commons", version = "0.140.2" }
-vtcode-acp = { path = "crates/codegen/vtcode-acp", version = "0.140.2" }
-vtcode-auth = { path = "crates/codegen/vtcode-auth", version = "0.140.2" }
-vtcode-config = { path = "crates/codegen/vtcode-config", version = "0.140.2" }
-vtcode-core = { path = "crates/codegen/vtcode-core", version = "0.140.2" }
-vtcode-ui = { path = "crates/codegen/vtcode-ui", version = "0.140.2" }
-vtcode-indexer = { path = "crates/codegen/vtcode-indexer", version = "0.140.2" }
-vtcode-bash-runner = { path = "crates/codegen/vtcode-bash-runner", version = "0.140.2" }
-vtcode-exec-events = { path = "crates/common/vtcode-exec-events", version = "0.140.2" }
-vtcode-safety = { path = "crates/codegen/vtcode-safety", version = "0.140.2" }
-vtcode-a2a = { path = "crates/codegen/vtcode-a2a", version = "0.140.2" }
-vtcode-mcp = { path = "crates/codegen/vtcode-mcp", version = "0.140.2" }
-vtcode-llm = { path = "crates/codegen/vtcode-llm", version = "0.140.2" }
-vtcode-skills = { path = "crates/codegen/vtcode-skills", version = "0.140.2" }
-vtcode-memory = { path = "crates/codegen/vtcode-memory", version = "0.140.2" }
-vtcode-eval = { path = "crates/codegen/vtcode-eval", version = "0.140.2" }
-vtcode-macros = { path = "crates/common/vtcode-macros", version = "0.140.2" }
-vtcode-utility-tool-specs = { path = "crates/common/vtcode-utility-tool-specs", version = "0.140.2" }
+vtcode-commons = { path = "crates/common/vtcode-commons", version = "0.140.3" }
+vtcode-acp = { path = "crates/codegen/vtcode-acp", version = "0.140.3" }
+vtcode-auth = { path = "crates/codegen/vtcode-auth", version = "0.140.3" }
+vtcode-config = { path = "crates/codegen/vtcode-config", version = "0.140.3" }
+vtcode-core = { path = "crates/codegen/vtcode-core", version = "0.140.3" }
+vtcode-ui = { path = "crates/codegen/vtcode-ui", version = "0.140.3" }
+vtcode-indexer = { path = "crates/codegen/vtcode-indexer", version = "0.140.3" }
+vtcode-bash-runner = { path = "crates/codegen/vtcode-bash-runner", version = "0.140.3" }
+vtcode-exec-events = { path = "crates/common/vtcode-exec-events", version = "0.140.3" }
+vtcode-safety = { path = "crates/codegen/vtcode-safety", version = "0.140.3" }
+vtcode-a2a = { path = "crates/codegen/vtcode-a2a", version = "0.140.3" }
+vtcode-mcp = { path = "crates/codegen/vtcode-mcp", version = "0.140.3" }
+vtcode-llm = { path = "crates/codegen/vtcode-llm", version = "0.140.3" }
+vtcode-skills = { path = "crates/codegen/vtcode-skills", version = "0.140.3" }
+vtcode-memory = { path = "crates/codegen/vtcode-memory", version = "0.140.3" }
+vtcode-eval = { path = "crates/codegen/vtcode-eval", version = "0.140.3" }
+vtcode-macros = { path = "crates/common/vtcode-macros", version = "0.140.3" }
+vtcode-utility-tool-specs = { path = "crates/common/vtcode-utility-tool-specs", version = "0.140.3" }
 
 [workspace.package]
-version = "0.140.2"
+version = "0.140.3"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -264,14 +264,14 @@ allow_attributes_without_reason = "allow"  # TODO: Phase in after suppression au
 
 
 [dependencies]
-vtcode-acp = { path = "crates/codegen/vtcode-acp", version = "0.140.2" }
-vtcode-commons = { path = "crates/common/vtcode-commons", version = "0.140.2" }
-vtcode-ui = { path = "crates/codegen/vtcode-ui", version = "0.140.2" }
-vtcode-config = { path = "crates/codegen/vtcode-config", version = "0.140.2" }
-vtcode-auth = { path = "crates/codegen/vtcode-auth", version = "0.140.2" }
-vtcode-core = { path = "crates/codegen/vtcode-core", version = "0.140.2", default-features = false }
-vtcode-memory = { path = "crates/codegen/vtcode-memory", version = "0.140.2" }
-vtcode-eval = { path = "crates/codegen/vtcode-eval", version = "0.140.2" }
+vtcode-acp = { path = "crates/codegen/vtcode-acp", version = "0.140.3" }
+vtcode-commons = { path = "crates/common/vtcode-commons", version = "0.140.3" }
+vtcode-ui = { path = "crates/codegen/vtcode-ui", version = "0.140.3" }
+vtcode-config = { path = "crates/codegen/vtcode-config", version = "0.140.3" }
+vtcode-auth = { path = "crates/codegen/vtcode-auth", version = "0.140.3" }
+vtcode-core = { path = "crates/codegen/vtcode-core", version = "0.140.3", default-features = false }
+vtcode-memory = { path = "crates/codegen/vtcode-memory", version = "0.140.3" }
+vtcode-eval = { path = "crates/codegen/vtcode-eval", version = "0.140.3" }
 anyhow = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/codegen/vtcode-core/Cargo.toml
+++ b/crates/codegen/vtcode-core/Cargo.toml
@@ -48,7 +48,7 @@ async-stream = "0.3"
 base64 = { workspace = true }
 glob = "0.3"
 ignore = { workspace = true }
-vt100 = { workspace = true }
+rio-vt = { workspace = true }
 thiserror = { workspace = true }
 dialoguer = { workspace = true }
 regex = { workspace = true }

--- a/crates/codegen/vtcode-core/src/tools/pty/screen_backend.rs
+++ b/crates/codegen/vtcode-core/src/tools/pty/screen_backend.rs
@@ -1,13 +1,18 @@
 use portable_pty::PtySize;
-use vt100::Parser;
+use rio_vt::ansi::CursorShape;
+use rio_vt::crosswords::formatter::FormatOptions;
+use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+use rio_vt::event::{VoidListener, WindowId};
+use rio_vt::performer::handler::Processor;
 use vtcode_config::constants::defaults::DEFAULT_PTY_SCROLLBACK_LINES;
 
 // ---------------------------------------------------------------------------
-// PtyScreenState -- wraps vt100 terminal parser
+// PtyScreenState -- wraps the rio-vt terminal state
 // ---------------------------------------------------------------------------
 
 pub(super) struct PtyScreenState {
-    parser: Parser,
+    term: Crosswords<VoidListener>,
+    parser: Processor,
 }
 
 impl PtyScreenState {
@@ -17,21 +22,37 @@ impl PtyScreenState {
         } else {
             scrollback_lines
         };
-        let parser = Parser::new(size.rows, size.cols, scrollback);
-        Self { parser }
+        let term = Crosswords::new(
+            grid_size(size),
+            CursorShape::Block,
+            VoidListener,
+            WindowId::from(0),
+            0,
+            scrollback,
+        );
+        Self {
+            term,
+            parser: Processor::default(),
+        }
     }
 
     pub(super) fn process(&mut self, chunk: &[u8]) {
-        self.parser.process(chunk);
+        self.parser.advance(&mut self.term, chunk);
     }
 
     pub(super) fn resize(&mut self, size: PtySize) {
-        self.parser.screen_mut().set_size(size.rows, size.cols);
+        self.term.resize(grid_size(size));
     }
 
     pub(super) fn prepare_snapshot(&self) -> ScreenSnapshot {
-        ScreenSnapshot { screen_contents: self.parser.screen().contents() }
+        ScreenSnapshot {
+            screen_contents: self.term.format(FormatOptions::plain()),
+        }
     }
+}
+
+fn grid_size(size: PtySize) -> CrosswordsSize {
+    CrosswordsSize::new(size.cols.max(1) as usize, size.rows.max(1) as usize)
 }
 
 // ---------------------------------------------------------------------------
@@ -49,7 +70,12 @@ mod tests {
     use super::PtyScreenState;
 
     fn test_size() -> PtySize {
-        PtySize { rows: 4, cols: 10, pixel_width: 0, pixel_height: 0 }
+        PtySize {
+            rows: 4,
+            cols: 10,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
     }
 
     #[test]
@@ -58,7 +84,11 @@ mod tests {
         let mut state = PtyScreenState::new(size, 100);
         state.process(b"hello");
         let snapshot = state.prepare_snapshot();
-        assert!(snapshot.screen_contents.contains("hello"), "screen_contents = {:?}", snapshot.screen_contents);
+        assert!(
+            snapshot.screen_contents.contains("hello"),
+            "screen_contents = {:?}",
+            snapshot.screen_contents
+        );
     }
 
     #[test]
@@ -67,8 +97,16 @@ mod tests {
         let mut state = PtyScreenState::new(size, 100);
         state.process(b"line1\nline2");
         let snapshot = state.prepare_snapshot();
-        assert!(snapshot.screen_contents.contains("line1"), "screen_contents = {:?}", snapshot.screen_contents);
-        assert!(snapshot.screen_contents.contains("line2"), "screen_contents = {:?}", snapshot.screen_contents);
+        assert!(
+            snapshot.screen_contents.contains("line1"),
+            "screen_contents = {:?}",
+            snapshot.screen_contents
+        );
+        assert!(
+            snapshot.screen_contents.contains("line2"),
+            "screen_contents = {:?}",
+            snapshot.screen_contents
+        );
     }
 
     #[test]
@@ -77,6 +115,10 @@ mod tests {
         let mut state = PtyScreenState::new(size, 100);
         state.process(b"\x1B[1;31mcolored\x1B[0m");
         let snapshot = state.prepare_snapshot();
-        assert!(snapshot.screen_contents.contains("colored"), "screen_contents = {:?}", snapshot.screen_contents);
+        assert!(
+            snapshot.screen_contents.contains("colored"),
+            "screen_contents = {:?}",
+            snapshot.screen_contents
+        );
     }
 }

--- a/crates/codegen/xtask/Cargo.toml
+++ b/crates/codegen/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.140.2"
+version = "0.140.3"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
Swaps the PTY screen backend from vt100 to [rio-vt](https://crates.io/crates/rio-vt), Rio's terminal engine.

`PtyScreenState` used vt100 to parse PTY output and dump the screen as text for snapshots. rio-vt does the same job (feed bytes, pull a plain-text screen via `format(FormatOptions::plain())`) but is a full terminal engine, so the snapshot path also gets wide-char/grapheme handling, the sixel/Kitty/iTerm2 image protocols and scrollback, and it parses and serializes a bit faster.

The module's public API is unchanged and the three backend tests pass as-is.

Benchmark against vt100 and alacritty_terminal: https://github.com/raphamorim/rio-vt-benchmark

Background on the engine and why it was split out of Rio: https://rioterm.com/blog/2026/07/27/rio-vt-and-librio
