### PR TITLE
fix: accept plural models slash command

### DIFF
--- a/crates/codegen/vtcode-skills/src/command_skills.rs
+++ b/crates/codegen/vtcode-skills/src/command_skills.rs
@@ -172,7 +172,15 @@ const COMMAND_SKILL_SPECS: &[CommandSkillSpec] = &[
         "/memory",
         "configuration"
     ),
-    built_in_command_spec!("model", "Launch the interactive model picker", "/model", "configuration"),
+    CommandSkillSpec {
+        slash_name: "model",
+        skill_name: "cmd-model",
+        description: "Launch the interactive model picker",
+        usage: "/model (alias: /models)",
+        category: "configuration",
+        aliases: &["models"],
+        backend: CommandSkillBackend::BuiltInCommand { executor: BuiltInCommandExecutor::SlashAlias },
+    },
     built_in_command_spec!(
         "mode",
         "Switch the active agent mode (usage: /mode [build|auto|duck|plan])",
@@ -502,6 +510,13 @@ mod tests {
         let status = find_command_skill_by_slash_name("status").expect("status spec");
         assert!(status.is_built_in());
         assert_eq!(status.skill_name, "cmd-status");
+    }
+
+    #[test]
+    fn models_alias_opens_the_model_picker() {
+        let model = find_command_skill_by_slash_name("models").expect("models alias");
+        assert_eq!(model.slash_name, "model");
+        assert!(model.is_built_in());
     }
 
     #[test]


### PR DESCRIPTION
# Pull Request

## Description

Accept `/models` as an alias for the existing `/model` interactive model picker. Issue #723 reports that users invoking `/models` receive no model list; the command was not registered, so dispatch stopped before opening the picker. No additional dependencies are required.

Fixes #723

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added a regression test for the alias lookup and ran the complete `vtcode-skills` library test suite. Formatting was also checked.

- [x] Rust tests: `cargo test -p vtcode-skills --lib` (128 passed)
- [ ] Linting: `cargo clippy`
- [x] Formatting: `cargo fmt --all -- --check`
- [ ] Build: `cargo build`

**Test Configuration**:
* Rust version: repository toolchain
* Operating system: macOS on Apple Silicon
* Toolchain: stable

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`cargo test`)
  - The complete `vtcode-skills` suite passes; the full workspace suite was not run.
- [ ] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the `CHANGELOG.md` if this change affects the user-facing behavior
- [x] I have checked my code and corrected any misspellings

## Additional Context

The canonical command remains `/model`; `/models` is now accepted as a compatibility alias for the spelling used in issue #723. The change is limited to command registration plus its regression test.