### PR TITLE
fix(llm): serialize f32 sampling params without binary tails

### DIFF
--- a/crates/codegen/vtcode-core/src/core/agent/runner/execute.rs
+++ b/crates/codegen/vtcode-core/src/core/agent/runner/execute.rs
@@ -612,7 +612,7 @@ impl AgentRunner {
                 {
                     None
                 } else {
-                    Some(0.7)
+                    Some(self.config().agent.temperature)
                 };
 
                 let (request_messages, previous_response_id) = prepare_responses_request_messages(

--- a/crates/codegen/vtcode-llm/src/providers/base.rs
+++ b/crates/codegen/vtcode-llm/src/providers/base.rs
@@ -140,7 +140,7 @@ pub mod request_builder {
         }
 
         if let Some(temp) = temperature {
-            body["temperature"] = serde_json::json!(temp);
+            body["temperature"] = serde_json::json!(crate::providers::common::sampling_param_f64(temp));
         }
 
         if let Some(val) = tools {

--- a/crates/codegen/vtcode-llm/src/providers/common.rs
+++ b/crates/codegen/vtcode-llm/src/providers/common.rs
@@ -60,10 +60,22 @@ pub(crate) fn extract_header(headers: &reqwest::header::HeaderMap, names: &[&str
         .find_map(|name| headers.get(*name).and_then(|value| value.to_str().ok()).map(ToOwned::to_owned))
 }
 
+/// Widens an f32 sampling parameter to f64 through its shortest round-trip
+/// decimal form. Direct `f32 as f64` promotion keeps the binary tail
+/// (`0.7f32` → `0.699999988079071`), which strict backends reject as invalid
+/// precision; routing the value through its shortest repr keeps the wire form
+/// compact (`0.7`) without losing round-trip fidelity.
+pub(crate) fn sampling_param_f64(value: f32) -> f64 {
+    if !value.is_finite() {
+        return f64::from(value);
+    }
+    format!("{value}").parse().unwrap_or_else(|_| f64::from(value))
+}
+
 /// Converts a float parameter (temperature, top_p, …) into a JSON number,
 /// rejecting NaN and infinity with an `LLMError::InvalidRequest`.
 pub(crate) fn float_to_json_number(value: f32) -> Result<serde_json::Number, LLMError> {
-    serde_json::Number::from_f64(f64::from(value)).ok_or_else(|| LLMError::InvalidRequest {
+    serde_json::Number::from_f64(sampling_param_f64(value)).ok_or_else(|| LLMError::InvalidRequest {
         message: "invalid numeric parameter value (NaN or infinity)".to_string(),
         metadata: None,
     })
@@ -1368,9 +1380,9 @@ pub fn make_anthropic_thinking_config(config: &vtcode_config::core::AnthropicCon
 mod tests {
     use super::{
         PROVIDER_ERROR_BODY_MAX_BYTES, assistant_interleaved_history_text, extract_reasoning_text_from_detail_values,
-        extract_reasoning_text_from_serialized_details, is_interleaved_thinking_model, is_minimax_m2_model,
-        normalize_reasoning_detail_object, parse_chat_request_openai_format, parse_response_openai_format,
-        parse_usage_openai_format, read_provider_error_body,
+        extract_reasoning_text_from_serialized_details, float_to_json_number, is_interleaved_thinking_model,
+        is_minimax_m2_model, normalize_reasoning_detail_object, parse_chat_request_openai_format,
+        parse_response_openai_format, parse_usage_openai_format, read_provider_error_body, sampling_param_f64,
     };
     use crate::provider::{AssistantPhase, Message};
     use serde_json::{Value, json};
@@ -1620,5 +1632,35 @@ mod tests {
     fn parse_usage_openai_format_handles_missing_usage() {
         let response = json!({"choices": []});
         assert!(parse_usage_openai_format(&response, true).is_none());
+    }
+
+    #[test]
+    fn float_to_json_number_keeps_shortest_f32_wire_form() {
+        let number = float_to_json_number(0.7).expect("finite value");
+        assert_eq!(number.to_string(), "0.7");
+        assert_ne!(number.to_string(), "0.699999988079071");
+
+        let payload = json!({ "temperature": number });
+        assert_eq!(serde_json::to_string(&payload).unwrap(), r#"{"temperature":0.7}"#);
+    }
+
+    #[test]
+    fn float_to_json_number_round_trips_f32_values() {
+        for raw in [0.5_f32, 0.25, 0.1, 1.0, 2.0, -0.75, 0.123_456_79] {
+            let number = float_to_json_number(raw).expect("finite value");
+            let wire: f64 = number.to_string().parse().expect("wire form parses");
+            assert_eq!(wire as f32, raw, "wire form of {raw} must round-trip");
+        }
+    }
+
+    #[test]
+    fn float_to_json_number_rejects_non_finite() {
+        assert!(float_to_json_number(f32::NAN).is_err());
+        assert!(float_to_json_number(f32::INFINITY).is_err());
+        assert_eq!(
+            sampling_param_f64(0.7_f32).to_bits(),
+            0.7_f64.to_bits(),
+            "widened value must equal the f64 literal"
+        );
     }
 }

--- a/crates/codegen/vtcode-llm/src/providers/huggingface.rs
+++ b/crates/codegen/vtcode-llm/src/providers/huggingface.rs
@@ -282,11 +282,11 @@ impl HuggingFaceProvider {
         }
 
         if let Some(temperature) = request.temperature {
-            payload["temperature"] = json!(temperature);
+            payload["temperature"] = json!(super::common::sampling_param_f64(temperature));
         }
 
         if let Some(top_p) = request.top_p {
-            payload["top_p"] = json!(top_p);
+            payload["top_p"] = json!(super::common::sampling_param_f64(top_p));
         }
 
         if let Some(top_k) = request.top_k {
@@ -490,10 +490,10 @@ impl HuggingFaceProvider {
             payload["max_tokens"] = json!(max_tokens);
         }
         if let Some(temperature) = request.temperature {
-            payload["temperature"] = json!(temperature);
+            payload["temperature"] = json!(super::common::sampling_param_f64(temperature));
         }
         if let Some(top_p) = request.top_p {
-            payload["top_p"] = json!(top_p);
+            payload["top_p"] = json!(super::common::sampling_param_f64(top_p));
         }
         if let Some(top_k) = request.top_k {
             payload["top_k"] = json!(top_k);

--- a/crates/codegen/vtcode-llm/src/providers/merge_gateway.rs
+++ b/crates/codegen/vtcode-llm/src/providers/merge_gateway.rs
@@ -385,10 +385,10 @@ impl MergeGatewayProvider {
             payload.insert("max_tokens".to_owned(), json!(max_tokens));
         }
         if let Some(temperature) = request.temperature {
-            payload.insert("temperature".to_owned(), json!(temperature));
+            payload.insert("temperature".to_owned(), json!(super::common::sampling_param_f64(temperature)));
         }
         if let Some(top_p) = request.top_p {
-            payload.insert("top_p".to_owned(), json!(top_p));
+            payload.insert("top_p".to_owned(), json!(super::common::sampling_param_f64(top_p)));
         }
         if let Some(stop) = Self::native_stop_sequences(request) {
             payload.insert("stop".to_owned(), Value::Array(stop));

--- a/crates/codegen/vtcode-llm/src/providers/moonshot.rs
+++ b/crates/codegen/vtcode-llm/src/providers/moonshot.rs
@@ -31,13 +31,6 @@ impl OpenAiCompatSpec for MoonshotSpec {
         model.trim().to_string()
     }
 
-    fn float_number(value: f32) -> Result<serde_json::Number, LLMError> {
-        serde_json::Number::from_f64(f64::from(value)).ok_or_else(|| LLMError::InvalidRequest {
-            message: "Invalid temperature value".to_string(),
-            metadata: None,
-        })
-    }
-
     fn insert_reasoning(
         _core: &OpenAiCompatCore<Self>,
         request: &LLMRequest,

--- a/crates/codegen/vtcode-llm/src/providers/openai/provider/harmony_client.rs
+++ b/crates/codegen/vtcode-llm/src/providers/openai/provider/harmony_client.rs
@@ -370,7 +370,7 @@ impl OpenAIProvider {
         // Prepare request body for vLLM-style inference server
         let request_body = json!({
             "prompt_token_ids": tokens,
-            "temperature": temperature.unwrap_or(0.7),
+            "temperature": crate::providers::common::sampling_param_f64(temperature.unwrap_or(0.7)),
             "stop_token_ids": stop_token_ids_vec,
             // Additional parameters that might be needed
             "stream": false,

--- a/crates/codegen/vtcode-llm/src/providers/openai/request_builder.rs
+++ b/crates/codegen/vtcode-llm/src/providers/openai/request_builder.rs
@@ -383,7 +383,7 @@ pub(crate) fn build_chat_request(
         && ctx.supports_temperature
         && allows_sampling_parameters(&request.model, effective_reasoning_effort)
     {
-        openai_request["temperature"] = json!(temperature);
+        openai_request["temperature"] = Value::Number(crate::providers::common::float_to_json_number(temperature)?);
     }
 
     if ModelProvider::OpenAI.supports_service_tier(&request.model)
@@ -583,24 +583,27 @@ fn build_responses_request_from_history(
         && ctx.supports_temperature
         && allows_sampling_parameters(&request.model, effective_reasoning_effort)
     {
-        sampling_parameters["temperature"] = json!(temperature);
+        sampling_parameters["temperature"] =
+            Value::Number(crate::providers::common::float_to_json_number(temperature)?);
         has_sampling = true;
     }
 
     if let Some(top_p) = request.top_p
         && allows_sampling_parameters(&request.model, effective_reasoning_effort)
     {
-        sampling_parameters["top_p"] = json!(top_p);
+        sampling_parameters["top_p"] = Value::Number(crate::providers::common::float_to_json_number(top_p)?);
         has_sampling = true;
     }
 
     if let Some(presence_penalty) = request.presence_penalty {
-        sampling_parameters["presence_penalty"] = json!(presence_penalty);
+        sampling_parameters["presence_penalty"] =
+            Value::Number(crate::providers::common::float_to_json_number(presence_penalty)?);
         has_sampling = true;
     }
 
     if let Some(frequency_penalty) = request.frequency_penalty {
-        sampling_parameters["frequency_penalty"] = json!(frequency_penalty);
+        sampling_parameters["frequency_penalty"] =
+            Value::Number(crate::providers::common::float_to_json_number(frequency_penalty)?);
         has_sampling = true;
     }
 

--- a/crates/codegen/vtcode-llm/src/providers/openresponses/provider.rs
+++ b/crates/codegen/vtcode-llm/src/providers/openresponses/provider.rs
@@ -388,7 +388,7 @@ impl OpenResponsesProvider {
 
         let mut req = Request::new(&request.model, Vec::new());
         req.stream = stream;
-        req.temperature = request.temperature.map(|t| t as f64);
+        req.temperature = request.temperature.map(crate::providers::common::sampling_param_f64);
         req.max_output_tokens = request.max_tokens.map(|t| t as u64);
         req.previous_response_id = request
             .previous_response_id
@@ -1025,6 +1025,28 @@ mod tests {
         assert_eq!(payload.get("store").and_then(Value::as_bool), Some(false));
         let include = payload.get("include").and_then(Value::as_array).expect("include must exist");
         assert_eq!(include.len(), 2);
+    }
+
+    #[test]
+    fn native_payload_serializes_compact_temperature() {
+        let provider = test_provider("https://api.openresponses.com/v1");
+        let request = LLMRequest {
+            model: "gpt-5".to_string(),
+            messages: vec![Message::user("hello".to_string())].into(),
+            temperature: Some(0.7),
+            ..Default::default()
+        };
+
+        let payload = provider
+            .build_native_payload(&request, false)
+            .expect("native payload should serialize");
+
+        assert_eq!(payload.get("temperature").and_then(Value::as_f64), Some(0.7));
+        assert_eq!(
+            payload.get("temperature").expect("temperature present").to_string(),
+            "0.7",
+            "wire form must be compact, not the f32->f64 widening tail"
+        );
     }
 
     #[test]

--- a/crates/codegen/vtcode-llm/src/providers/openresponses/provider.rs
+++ b/crates/codegen/vtcode-llm/src/providers/openresponses/provider.rs
@@ -481,7 +481,7 @@ impl OpenResponsesProvider {
         }
 
         if let Some(temp) = request.temperature {
-            payload["temperature"] = json!(temp);
+            payload["temperature"] = json!(crate::providers::common::sampling_param_f64(temp));
         }
 
         if let Some(tools) = &request.tools {

--- a/crates/codegen/vtcode-llm/src/providers/openrouter/request_builder.rs
+++ b/crates/codegen/vtcode-llm/src/providers/openrouter/request_builder.rs
@@ -101,7 +101,8 @@ impl OpenRouterProvider {
         }
 
         if let Some(temperature) = request.temperature {
-            provider_request["temperature"] = json!(temperature);
+            provider_request["temperature"] =
+                Value::Number(crate::providers::common::float_to_json_number(temperature)?);
         }
 
         if let Some(tools) = &request.tools
@@ -189,5 +190,27 @@ mod tests {
         let messages = payload["messages"].as_array().expect("messages should be present");
 
         assert_eq!(messages[0]["content"], json!("<think>trace</think>done"));
+    }
+
+    #[test]
+    fn openrouter_payload_serializes_compact_temperature() {
+        let provider = OpenRouterProvider::new("test-key".to_string());
+        let request = LLMRequest {
+            model: "openai/gpt-5".to_string(),
+            messages: vec![Message::user("hello".to_string())].into(),
+            temperature: Some(0.7),
+            ..Default::default()
+        };
+
+        let payload = provider
+            .convert_to_openrouter_format(&request)
+            .expect("payload should serialize");
+
+        assert_eq!(payload["temperature"].as_f64(), Some(0.7));
+        assert_eq!(
+            payload.get("temperature").expect("temperature present").to_string(),
+            "0.7",
+            "wire form must be compact, not the f32->f64 widening tail"
+        );
     }
 }

--- a/docs/config/CONFIG_FIELD_REFERENCE.md
+++ b/docs/config/CONFIG_FIELD_REFERENCE.md
@@ -162,7 +162,7 @@ picker also refreshes from Merge's authenticated paginated `/v1/models` catalog.
 | `agent.small_model.use_for_web_summary` | `boolean` | no | `true` | Enable small model for web content summarization |
 | `agent.system_prompt_budget_warning` | `boolean` | no | `true` | Warn when the composed system prompt exceeds `max_system_prompt_tokens`. |
 | `agent.system_prompt_mode` | `string` | no | `"default"` | System prompt mode controlling prompt verbosity and token overhead. Options target lean base prompts: minimal (~150-250 tokens), lightweight/default (~250-350 tokens), specialized (~350-500 tokens) before dynamic runtime addenda. |
-| `agent.temperature` | `number` | no | `0.699999988079071` | Temperature for main LLM responses (0.0-1.0) Lower values = more deterministic, higher values = more creative Recommended: 0.7 for balanced creativity and consistency Range: 0.0 (deterministic) to 1.0 (maximum randomness) |
+| `agent.temperature` | `number` | no | `0.7` | Temperature for main LLM responses (0.0-1.0) Lower values = more deterministic, higher values = more creative Recommended: 0.7 for balanced creativity and consistency Range: 0.0 (deterministic) to 1.0 (maximum randomness) |
 | `agent.temporal_context_use_utc` | `boolean` | no | `false` | Use UTC instead of local time for temporal context in system prompts |
 | `agent.theme` | `string` | no | `"ciapre"` | UI theme identifier controlling ANSI styling |
 | `agent.todo_planning_mode` | `boolean` | no | `true` | Enable TODO planning helper mode for structured task management |


### PR DESCRIPTION
# Pull Request

## Description

Strict JSON backends behind gateways rejected our requests with:

    {"error":{"message":"[1210] The temperature parameter is illegal.
    ：限制小数点[2]位"}}   <- "limit: 2 decimal places"

**Root cause.** Sampling parameters are stored as `f32` (`LLMRequest.temperature`).
Every payload-building path widened them to `f64` before JSON encoding - either via
`serde_json::Number::from_f64(f64::from(v))`, its duplicate override in Moonshot,
or raw `json!(temp)` interpolation (serde_json 1.0.x `Number::from_f32` performs
`f as f64` internally). Direct promotion keeps the binary tail:
`0.7f32 -> 0.699999988079071`, which strict backends reject.

**Fix.** New shared helper `providers::common::sampling_param_f64()` widens f32
through its shortest round-trip decimal form, so the wire value stays compact
(`0.7`) without losing fidelity. All payload paths now route through it:

- `openai_compat` core (all compat-spec providers: opencode-zen/go, evolink,
  stepfun, qwen, nvidia, zai, ...) via the fixed `float_to_json_number()`
- native OpenAI chat + Responses API builder (temperature, top_p, penalties)
- OpenRouter request builder
- Merge Gateway, HuggingFace (both paths), base helper, harmony/vLLM client
- OpenResponses native payload (typed `Option<f64>` field)
- Moonshot duplicate override removed (inherits the fix)

Additionally, the main chat loop no longer hardcodes `Some(0.7)` - it reads the
existing `agent.temperature` config field (default unchanged at 0.7, so behavior
is identical out of the box).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

5 new unit tests:

- `float_to_json_number_keeps_shortest_f32_wire_form` - asserts exact wire form
  `{"temperature":0.7}` and rejects the old tail representation
- `float_to_json_number_round_trips_f32_values` - 7 values survive wire->f64->f32
- `float_to_json_number_rejects_non_finite` - NaN/Inf still rejected; widening is
  bit-exact vs the f64 literal
- `openrouter_payload_serializes_compact_temperature`,
  `native_payload_serializes_compact_temperature` - provider-level wire checks

- [x] Rust tests: `cargo test -p vtcode-llm --lib` - 807 passed (1 pre-existing
      failure in `process_env::copilot_exception...`, reproduces on clean `main`)
- [x] Linting: `cargo clippy -p vtcode-llm -p vtcode-core --lib --tests` - clean
      for all touched files
- [x] Formatting: `cargo fmt --check`
- [x] Build: `cargo check`

**Test Configuration**:
* Rust version: stable (edition 2024, MSRV 1.88)
* Operating system: Linux
* Toolchain: rustc 1.93 / clippy 1.93

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`cargo test`)
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the `CHANGELOG.md` if this change affects the user-facing behavior (git-cliff generates from conventional commits)
- [x] I have checked my code and corrected any misspellings

## Additional Context

- No new dependencies; `Cargo.lock` untouched (`--locked` safe).
- The documented default for `agent.temperature` previously showed the tail
  value (`0.699999988079071`) - corrected to `0.7`.
- `CHANGELOG.md` is generated by git-cliff from these conventional commits.
