### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -1,5 +1,32 @@
 # MCP Integration Guide
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 This guide outlines how VT Code connects to external MCP (Model Context Protocol) servers, how
 allowlists control tool access, and how to troubleshoot common configuration issues. The
 configuration surface documented below maps directly to the serde structures in
@@ -159,13 +186,6 @@ This is not VT Code's HTTP ACP tools (`acp_call` / `acp_discover`). Pairing
 stays `gbr-agent pair` + `gbr-agent run`. Attach is only
 `http://127.0.0.1:8788` or `gbr-mcp` stdio. Phone is spectator + veto.
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version
-gbr-agent pair && gbr-agent run
-git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
-cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
-```
 
 ```toml
 [[mcp.providers]]
@@ -305,3 +325,10 @@ Expect the test to take a little longer on the first run while `npx` downloads t
 
 With these settings and checks in place, MCP providers and allowlists should behave predictably,
 unlocking additional context-aware tooling in VT Code.
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -144,6 +144,45 @@ configured in `[mcp]`.
 > provider lacks streaming, fall back to a stdio wrapper until the server adopts the reference
 > implementation.
 
+### Phone pairing (Build Remote Agent)
+
+VT Code can attach **Build Remote Agent** as a pairing device: the iOS/Android
+app spectates (and can inject into) this desktop session through the free MIT
+`gbr-agent`. Phone and PC never open ports to each other.
+
+Website: https://grokbuildremote.com/ · Agent:
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT) · Protocol
+`gbr/1` (agent **v0.6.0+**). Independent product. Not affiliated with xAI or
+SpaceX.
+
+This is not VT Code's HTTP ACP tools (`acp_call` / `acp_discover`). Pairing
+stays `gbr-agent pair` + `gbr-agent run`. Attach is only
+`http://127.0.0.1:8788` or `gbr-mcp` stdio. Phone is spectator + veto.
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version
+gbr-agent pair && gbr-agent run
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+```
+
+```toml
+[[mcp.providers]]
+name = "gbr"
+enabled = true
+command = "node"
+args = ["GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+```
+
+Replace `args` with the absolute path to `bin/gbr-mcp.js`. Never put mailbox
+keys in `vtcode.toml` or `.mcp.json`.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
 ## Security and validation
 
 VT Code exposes additional security gates through the `[mcp.security]` table. Enable authentication


### PR DESCRIPTION
## What

Optional **Build Remote Agent** pairing device so a phone can spectate this desktop agent.

Protocol stays `gbr/1` (not a fourth pair protocol):

1. Install `gbr-agent` v0.6.0+ from https://grokbuildremote.com/
2. `gbr-agent pair` — browser QR **and** printed 8-char code
3. Phone scans or types the code
4. `gbr-agent run` (leave running)
5. Attach only `http://127.0.0.1:8788` or `gbr-mcp` stdio

Phone is spectator + veto. Orchestration stays on this agent.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.**

Agent source (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents

## Files

Docs / MCP snippet only. No product-runtime change. No mailbox keys.

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version    # need v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```
