### PR TITLE
TUI UX improvements and custom-provider fixes for non-interactive commands

### DIFF
--- a/crates/codegen/vtcode-config/src/loader/manager.rs
+++ b/crates/codegen/vtcode-config/src/loader/manager.rs
@@ -507,10 +507,13 @@ impl ConfigManager {
     fn load_from_file_impl(path: impl AsRef<Path>, write_global_config_to_canonical: bool) -> Result<Self> {
         let path = path.as_ref();
         let defaults_provider = defaults::current_config_defaults();
-        let config_file_name = path
-            .file_name()
-            .and_then(|name| name.to_str().map(ToOwned::to_owned))
-            .unwrap_or_else(|| defaults_provider.config_file_name().to_string());
+        // Global layer probing always uses the canonical config file name, never
+        // the basename of the explicit override file. Deriving it from the file
+        // previously caused global layers (e.g. `~/.config/vtcode/vtcode.toml`
+        // with `[[custom_providers]]`) to be skipped whenever the override file
+        // was named something else (e.g. `night.toml`), silently dropping
+        // custom providers and other user-global settings.
+        let config_file_name = defaults_provider.config_file_name().to_string();
         let canonical_user_config_path = defaults_provider.canonical_user_config_path(&config_file_name)?;
         let mut tracked_user_config_paths = defaults_provider.home_config_paths(&config_file_name);
         if let Some(path) = &canonical_user_config_path

--- a/crates/codegen/vtcode-config/src/models/model_id/collection.rs
+++ b/crates/codegen/vtcode-config/src/models/model_id/collection.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
-use crate::core::ProviderOverrideConfig;
+use crate::core::{CustomProviderConfig, ProviderOverrideConfig};
 use crate::models::Provider;
 use hashbrown::HashSet;
 
@@ -228,5 +229,45 @@ impl ModelId {
             .into_iter()
             .filter(|model| model.provider() == provider)
             .collect()
+    }
+
+    /// Resolve a model identifier against a configuration, falling back to
+    /// [`ModelId::from_str`].
+    ///
+    /// Models declared under the active provider in `[providers.<name>]`
+    /// overrides or by a `[[custom_providers]]` profile are not part of the
+    /// static catalog, so they are represented as [`ModelId::Custom`].
+    /// Matching is scoped to the active provider to avoid mis-routing a model
+    /// ID shared across providers, mirroring the catalog and custom-provider
+    /// branches of the subagent resolution path. Local-provider pass-through
+    /// (arbitrary Ollama/llama.cpp IDs) is intentionally not handled here.
+    pub fn from_config(
+        model: &str,
+        provider: &str,
+        provider_overrides: &BTreeMap<String, ProviderOverrideConfig>,
+        custom_providers: &[CustomProviderConfig],
+    ) -> Result<Self, crate::models::ModelParseError> {
+        let trimmed = model.trim();
+        if let Ok(parsed) = Self::from_str(trimmed) {
+            return Ok(parsed);
+        }
+        let hinted_provider = provider.trim().parse::<Provider>().ok();
+        for (provider_key, override_cfg) in provider_overrides {
+            let matches_hint = match hinted_provider {
+                Some(active) => provider_key.parse::<Provider>().ok() == Some(active),
+                None => provider_key.eq_ignore_ascii_case(provider.trim()),
+            };
+            if matches_hint && override_cfg.models.iter().any(|candidate| candidate.trim() == trimmed) {
+                return Ok(ModelId::Custom(provider_key.clone(), trimmed.to_owned()));
+            }
+        }
+        for custom in custom_providers {
+            if custom.name.eq_ignore_ascii_case(provider.trim())
+                && custom.effective_models().iter().any(|candidate| candidate == trimmed)
+            {
+                return Ok(ModelId::Custom(custom.name.to_lowercase(), trimmed.to_owned()));
+            }
+        }
+        Self::from_str(trimmed)
     }
 }

--- a/crates/codegen/vtcode-config/src/models/tests.rs
+++ b/crates/codegen/vtcode-config/src/models/tests.rs
@@ -643,7 +643,9 @@ fn from_config_accepts_custom_provider_model() {
         ..crate::core::CustomProviderConfig::default()
     };
 
-    let parsed = ModelId::from_config("x-preview-f-free", "zen-free", &Default::default(), &[custom.clone()]).unwrap();
+    let parsed =
+        ModelId::from_config("x-preview-f-free", "zen-free", &Default::default(), std::slice::from_ref(&custom))
+            .unwrap();
     assert_eq!(parsed, ModelId::Custom("zen-free".to_string(), "x-preview-f-free".to_string()));
     assert_eq!(parsed.as_str(), "x-preview-f-free");
 

--- a/crates/codegen/vtcode-config/src/models/tests.rs
+++ b/crates/codegen/vtcode-config/src/models/tests.rs
@@ -628,3 +628,66 @@ fn test_all_models_have_non_empty_metadata_and_parse() {
         assert_eq!(parsed.unwrap(), model);
     }
 }
+
+#[test]
+fn from_config_accepts_custom_provider_model() {
+    let custom = crate::core::CustomProviderConfig {
+        name: "zen-free".to_string(),
+        display_name: "Zen Free".to_string(),
+        base_url: "https://opencode.ai/zen/v1".to_string(),
+        context_window: None,
+        api_key_env: "OPENCODE_API_KEY".to_string(),
+        auth: None,
+        model: "".to_string(),
+        models: vec!["deepseek-v4-flash-free".to_string(), "x-preview-f-free".to_string()],
+        ..crate::core::CustomProviderConfig::default()
+    };
+
+    let parsed = ModelId::from_config("x-preview-f-free", "zen-free", &Default::default(), &[custom.clone()]).unwrap();
+    assert_eq!(parsed, ModelId::Custom("zen-free".to_string(), "x-preview-f-free".to_string()));
+    assert_eq!(parsed.as_str(), "x-preview-f-free");
+
+    // Case-insensitive provider matching.
+    let parsed = ModelId::from_config("x-preview-f-free", "Zen-Free", &Default::default(), &[custom]).unwrap();
+    assert_eq!(parsed, ModelId::Custom("zen-free".to_string(), "x-preview-f-free".to_string()));
+}
+
+#[test]
+fn from_config_accepts_provider_override_model() {
+    let mut overrides = std::collections::BTreeMap::new();
+    overrides.insert(
+        "opencode-zen".to_string(),
+        crate::core::ProviderOverrideConfig {
+            models: vec!["my-fine-tuned-gpt".to_string()],
+            base_url: None,
+            api_key_env: None,
+        },
+    );
+
+    let parsed = ModelId::from_config("my-fine-tuned-gpt", "opencode-zen", &overrides, &[]).unwrap();
+    assert_eq!(parsed, ModelId::Custom("opencode-zen".to_string(), "my-fine-tuned-gpt".to_string()));
+}
+
+#[test]
+fn from_config_rejects_custom_model_for_unrelated_provider() {
+    let custom = crate::core::CustomProviderConfig {
+        name: "zen-free".to_string(),
+        display_name: "Zen Free".to_string(),
+        base_url: "https://opencode.ai/zen/v1".to_string(),
+        context_window: None,
+        api_key_env: "OPENCODE_API_KEY".to_string(),
+        auth: None,
+        model: "".to_string(),
+        models: vec!["x-preview-f-free".to_string()],
+        ..crate::core::CustomProviderConfig::default()
+    };
+
+    // The model exists for zen-free but not for openai: standard parsing must fail.
+    assert!(ModelId::from_config("x-preview-f-free", "openai", &Default::default(), &[custom]).is_err());
+}
+
+#[test]
+fn from_config_falls_through_to_catalog_for_known_models() {
+    let parsed = ModelId::from_config("gpt-5.4", "openai", &Default::default(), &[]).unwrap();
+    assert_eq!(parsed, ModelId::GPT54);
+}

--- a/crates/codegen/vtcode-config/tests/loader.rs
+++ b/crates/codegen/vtcode-config/tests/loader.rs
@@ -336,6 +336,60 @@ fn use_root_config_from_file_discards_lower_precedence_layers() -> Result<()> {
 
 #[test]
 #[serial]
+fn load_from_file_merges_global_layers_regardless_of_override_basename() -> Result<()> {
+    let workspace = TempDir::new()?;
+    let workspace_root = workspace.path();
+    let config_dir = workspace_root.join(".vtcode");
+    fs::create_dir_all(&config_dir)?;
+
+    // Global user config defines a custom provider.
+    let home_config = workspace_root.join("home").join("vtcode.toml");
+    fs::create_dir_all(home_config.parent().expect("home config parent"))?;
+    fs::write(
+        &home_config,
+        r#"
+[agent]
+provider = "zen-free"
+default_model = "x-preview-f-free"
+
+[[custom_providers]]
+name = "zen-free"
+display_name = "Zen Free"
+base_url = "https://opencode.ai/zen/v1"
+api_key_env = "OPENCODE_API_KEY"
+model = ""
+models = ["x-preview-f-free"]
+"#,
+    )?;
+
+    // The explicit override file uses a non-canonical basename (e.g. a
+    // "night config"). Global layers must still be retained.
+    let override_config = workspace_root.join("night.toml");
+    fs::write(&override_config, "[debug]\nenable_tracing = true\n")?;
+
+    let manager = with_test_defaults(workspace_root, config_dir, vec![home_config.clone()], || {
+        ConfigManager::load_from_file(&override_config)
+    })?;
+
+    assert_eq!(
+        manager.config().agent.provider,
+        "zen-free",
+        "global provider must survive an explicit override file with a non-canonical basename"
+    );
+    assert!(
+        manager.config().custom_providers.iter().any(|p| p.name == "zen-free"),
+        "global custom providers must survive an explicit override file with a non-canonical basename"
+    );
+    assert!(
+        manager.config().debug.enable_tracing,
+        "override file settings must still apply on top of global layers"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn providers_whitelist_validation_rejects_unknown_provider() {
     let toml = r#"
 providers_whitelist = ["openai", "nonexistent-provider"]

--- a/crates/codegen/vtcode-core/src/memory/mod.rs
+++ b/crates/codegen/vtcode-core/src/memory/mod.rs
@@ -102,7 +102,7 @@ impl MemoryMonitor {
                 if parts.len() >= 2 {
                     let kb: usize = parts[1]
                         .parse()
-                        .map_err(|_| MemoryError::Parse(format!("invalid VmRSS value: {}", parts[1])))?;
+                        .map_err(|err| MemoryError::Parse(format!("invalid VmRSS value: {}: {err}", parts[1])))?;
                     return Ok(kb * 1024); // Convert KB to bytes
                 }
             }

--- a/crates/codegen/vtcode-llm/src/providers/common.rs
+++ b/crates/codegen/vtcode-llm/src/providers/common.rs
@@ -1675,6 +1675,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::float_cmp, reason = "round-trip must be bit-exact")]
     fn float_to_json_number_round_trips_f32_values() {
         for raw in [0.5_f32, 0.25, 0.1, 1.0, 2.0, -0.75, 0.123_456_79] {
             let number = float_to_json_number(raw).expect("finite value");

--- a/crates/codegen/vtcode-safety/src/sandboxing/child_spawn.rs
+++ b/crates/codegen/vtcode-safety/src/sandboxing/child_spawn.rs
@@ -239,6 +239,11 @@ pub fn setup_parent_death_signal_with_check(expected_parent_pid: nix::unistd::Pi
 
     // Re-check parent PID to catch race condition where parent exited between
     // fork and this prctl call. If parent changed, self-terminate immediately.
+    // Signal delivery here is deliberately best-effort: nothing can recover it.
+    #[allow(
+        clippy::let_underscore_must_use,
+        reason = "best-effort self-signal during pdeathsig race"
+    )]
     if nix::unistd::getppid() != expected_parent_pid {
         let _ = raise(Signal::SIGTERM);
     }

--- a/crates/codegen/vtcode-ui/src/tui/config/constants/ui.rs
+++ b/crates/codegen/vtcode-ui/src/tui/config/constants/ui.rs
@@ -154,6 +154,11 @@ pub const TUI_SHIMMER_SWEEP_DURATION_MS: u64 = 2000;
 /// Keep cursor steady for this duration after scroll events
 pub const TUI_SCROLL_CURSOR_STEADY_MS: u64 = 250;
 
+/// Minimum delay between auto-scroll steps while dragging at a transcript edge
+pub const DRAG_AUTO_SCROLL_INTERVAL_MS: u64 = 50;
+/// Rows revealed per auto-scroll step
+pub const DRAG_AUTO_SCROLL_STEP_LINES: usize = 2;
+
 // Viewport size limits to prevent pathological CPU usage with huge terminals
 // (e.g., 2000+ columns causes 100% CPU without these guards)
 // See: <https://github.com/anthropics/claude-code/issues/21567>

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/app/session/events.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/app/session/events.rs
@@ -895,7 +895,31 @@ pub(super) fn process_key_with_clipboard_image_reader(
                 session.mark_dirty();
 
                 return if session.is_running_activity() {
-                    Some(InlineEvent::Steer(submitted))
+                    match extract_slash_command_name(&submitted.text) {
+                        Some("stop") => Some(InlineEvent::Interrupt),
+                        Some("pause") => Some(InlineEvent::Pause),
+                        Some("resume") => Some(InlineEvent::Resume),
+                        other => {
+                            // Match the reference agents: Ctrl+Enter while a
+                            // turn is running joins the visible queue, so the
+                            // message hangs above the composer, renders as the
+                            // user's own bubble when dispatched, and can be
+                            // edited via Shift+← before it sends. Plain messages
+                            // are marked batchable so several queued messages
+                            // coalesce into ONE turn (batching applies to plain
+                            // Ctrl+Enter only); slash commands and plain Enter
+                            // stay one per turn so command intent is preserved.
+                            if let Some(command_name) = other {
+                                tracing::debug!(target: "vtcode_ui::keys", %command_name, "ctrl+enter queued slash command");
+                                session.push_queued_input(submitted.text.clone());
+                                Some(InlineEvent::QueueSubmit(submitted))
+                            } else {
+                                tracing::debug!(target: "vtcode_ui::keys", "ctrl+enter queued message");
+                                session.push_queued_input(submitted.text.clone());
+                                Some(InlineEvent::QueueSubmit(submitted.batchable()))
+                            }
+                        }
+                    }
                 } else {
                     Some(InlineEvent::Submit(submitted))
                 };
@@ -1477,6 +1501,12 @@ fn handle_running_slash_command_block_for_input(session: &mut Session, input: &s
     let Some(command_name) = extract_slash_command_name(input) else {
         return false;
     };
+
+    // Read-only local commands are safe to defer: falling through lets the normal
+    // queueing path run them right after the current turn instead of dropping them.
+    if matches!(command_name, "copy") {
+        return false;
+    }
 
     // Mode switches (agent selection, planning workflow) are locked while a turn
     // is processing; surface the dedicated notice for those commands.

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/app/session/impl_events.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/app/session/impl_events.rs
@@ -611,6 +611,7 @@ impl Session {
                         }
 
                         self.core.mouse_drag_target = MouseDragTarget::Transcript;
+                        self.core.cancel_drag_auto_scroll();
                         self.core.mouse_selection.start_selection(mouse_event.column, mouse_event.row);
                         self.mark_dirty();
                         self.handle_transcript_click(mouse_event);
@@ -629,6 +630,7 @@ impl Session {
                             }
                             MouseDragTarget::Transcript => {
                                 self.core.mouse_selection.update_selection(mouse_event.column, mouse_event.row);
+                                self.core.update_drag_auto_scroll(mouse_event.column, mouse_event.row);
                                 self.mark_dirty();
                             }
                             MouseDragTarget::ModalText => {
@@ -662,6 +664,7 @@ impl Session {
                             }
                             MouseDragTarget::Transcript => {
                                 self.core.mouse_selection.finish_selection(mouse_event.column, mouse_event.row);
+                                self.core.cancel_drag_auto_scroll();
                                 self.mark_dirty();
                             }
                             MouseDragTarget::ModalText => {

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session.rs
@@ -88,7 +88,7 @@ use self::modal::{ModalState, WizardModalState};
 pub use self::action::{Action, BindingStore, parse_key_binding};
 use self::config::AppearanceConfig;
 pub(crate) use self::input::status_requires_shimmer;
-use self::mouse_selection::MouseSelectionState;
+use self::mouse_selection::{DragAutoScroll, DragAutoScrollDirection, MouseSelectionState};
 use self::queue::QueueOverlay;
 use self::scroll::ScrollManager;
 pub(crate) use self::spinner::pulse_spinner_frame_for_phase;
@@ -224,8 +224,9 @@ pub struct Session {
     placeholder_style: Option<InlineTextStyle>,
     pub(crate) input_status_left: Option<String>,
     pub(crate) input_status_right: Option<String>,
-    /// Transient "copied" confirmation shown in the input status row.
+    /// Transient "copied"/"copy failed" confirmation shown in the input status row.
     copy_notification_until: Option<Instant>,
+    copy_notification_failed: bool,
     input_compact_mode: bool,
 
     // --- UI State ---
@@ -317,6 +318,7 @@ pub struct Session {
     // --- Mouse Text Selection ---
     pub(crate) mouse_selection: MouseSelectionState,
     pub(crate) mouse_drag_target: MouseDragTarget,
+    pub(crate) drag_auto_scroll: Option<DragAutoScroll>,
     pub(crate) fullscreen: FullscreenSessionState,
 
     // --- Performance Caching ---

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/editing.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/editing.rs
@@ -235,6 +235,19 @@ impl Session {
 
     /// Delete the character before the cursor (backspace)
     pub(crate) fn delete_char(&mut self) {
+        // One Backspace right after a collapsed multi-line paste removes the
+        // whole inserted block instead of peeling single characters. When the
+        // user has an active selection, the selection must win (it removes
+        // exactly what the user highlighted).
+        if let Some(range) = self.input_manager.compact_paste_range()
+            && range.end > range.start
+            && self.input_manager.selection_range().is_none()
+            && self.input_manager.cursor() == range.end
+        {
+            self.input_manager.replace_range(range.start, range.end, "");
+            self.refresh_input_edit_state();
+            return;
+        }
         self.input_manager.backspace();
         self.refresh_input_edit_state();
     }

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/editing.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/editing.rs
@@ -244,9 +244,12 @@ impl Session {
             && self.input_manager.selection_range().is_none()
             && self.input_manager.cursor() == range.end
         {
-            self.input_manager.replace_range(range.start, range.end, "");
-            self.refresh_input_edit_state();
-            return;
+            let content = self.input_manager.content();
+            if content.is_char_boundary(range.start) && content.is_char_boundary(range.end) {
+                self.input_manager.replace_range(range.start, range.end, "");
+                self.refresh_input_edit_state();
+                return;
+            }
         }
         self.input_manager.backspace();
         self.refresh_input_edit_state();

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/impl_events.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/impl_events.rs
@@ -339,6 +339,7 @@ impl Session {
                     }
 
                     self.mouse_drag_target = MouseDragTarget::Transcript;
+                    self.cancel_drag_auto_scroll();
                     self.mouse_selection.start_selection(mouse_event.column, mouse_event.row);
                     self.mark_dirty();
                     self.handle_transcript_click(mouse_event);
@@ -356,6 +357,7 @@ impl Session {
                         }
                         MouseDragTarget::Transcript => {
                             self.mouse_selection.update_selection(mouse_event.column, mouse_event.row);
+                            self.update_drag_auto_scroll(mouse_event.column, mouse_event.row);
                             self.mark_visual_dirty();
                         }
                         MouseDragTarget::ModalText => {
@@ -388,10 +390,12 @@ impl Session {
                         }
                         MouseDragTarget::Transcript => {
                             self.mouse_selection.finish_selection(mouse_event.column, mouse_event.row);
+                            self.cancel_drag_auto_scroll();
                             self.mark_dirty();
                         }
                         MouseDragTarget::ModalText => {
                             self.mouse_selection.finish_selection(mouse_event.column, mouse_event.row);
+                            self.cancel_drag_auto_scroll();
                             self.mark_dirty();
                         }
                         MouseDragTarget::None => {}

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/impl_init.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/impl_init.rs
@@ -96,6 +96,8 @@ impl Session {
             input_status_left: None,
             input_status_right: None,
             copy_notification_until: None,
+            copy_notification_failed: false,
+            drag_auto_scroll: None,
             input_compact_mode: false,
 
             // --- UI State ---

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/impl_scroll.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/impl_scroll.rs
@@ -1,8 +1,126 @@
+use std::time::{Duration, Instant};
+
 use super::*;
 
 impl Session {
     pub(crate) fn scroll_offset(&self) -> usize {
         self.scroll_manager.offset()
+    }
+
+    /// Tracks pointer edges during a transcript drag so `step_drag_auto_scroll`
+    /// can keep revealing content while the mouse rests at the top/bottom edge.
+    pub(crate) fn update_drag_auto_scroll(&mut self, column: u16, row: u16) {
+        let Some(area) = self.transcript_area else {
+            self.drag_auto_scroll = None;
+            return;
+        };
+        if area.height == 0 {
+            self.drag_auto_scroll = None;
+            return;
+        }
+        let last_row = area.y.saturating_add(area.height.saturating_sub(1));
+        // With a single visible row both edges coincide; only a pointer strictly
+        // outside the area is meaningful, so it cannot always collapse to "Up".
+        let direction = if row < area.y {
+            Some(DragAutoScrollDirection::Up)
+        } else if row > last_row {
+            Some(DragAutoScrollDirection::Down)
+        } else if area.height > 1 && row <= area.y {
+            Some(DragAutoScrollDirection::Up)
+        } else if area.height > 1 && row >= last_row {
+            Some(DragAutoScrollDirection::Down)
+        } else {
+            None
+        };
+
+        let Some(direction) = direction else {
+            if self.drag_auto_scroll.take().is_some() {
+                tracing::debug!(target: "vtcode_ui::scroll", row, "drag auto-scroll disarmed: pointer left edge");
+            }
+            return;
+        };
+
+        let clamped_row = row.clamp(area.y, last_row);
+        let clamped_column = column.clamp(area.x, area.x.saturating_add(area.width.saturating_sub(1)));
+        // Keep the original step timer when the edge stays the same, otherwise
+        // slow drags along the edge would reset the interval and never step.
+        self.drag_auto_scroll =
+            if let Some(existing) = self.drag_auto_scroll.filter(|scroll| scroll.direction == direction) {
+                Some(DragAutoScroll {
+                    direction,
+                    column: clamped_column,
+                    row: clamped_row,
+                    last_step: existing.last_step,
+                })
+            } else {
+                tracing::debug!(
+                    target: "vtcode_ui::scroll",
+                    ?direction,
+                    pointer_row = row,
+                    area_top = area.y,
+                    area_last_row = last_row,
+                    "drag auto-scroll armed"
+                );
+                Some(DragAutoScroll {
+                    direction,
+                    column: clamped_column,
+                    row: clamped_row,
+                    last_step: Instant::now(),
+                })
+            };
+    }
+    pub(crate) fn cancel_drag_auto_scroll(&mut self) {
+        self.drag_auto_scroll = None;
+    }
+
+    /// Reveals one batch of rows toward the dragged edge and extends the active
+    /// selection onto the newly visible content. Called from the tick handler so
+    /// scrolling continues while the pointer holds still at an edge.
+    pub(crate) fn step_drag_auto_scroll(&mut self) {
+        let Some(scroll) = self.drag_auto_scroll else {
+            return;
+        };
+        // A zero-height transcript cannot scroll; drop the pending auto-scroll
+        // state (mirrors the guard in update_drag_auto_scroll).
+        if self.transcript_area.is_some_and(|area| area.height == 0) {
+            self.drag_auto_scroll = None;
+            return;
+        }
+        if scroll.last_step.elapsed() < Duration::from_millis(ui::DRAG_AUTO_SCROLL_INTERVAL_MS) {
+            return;
+        }
+        self.ensure_scroll_metrics();
+        let previous_offset = self.scroll_manager.offset();
+        match scroll.direction {
+            DragAutoScrollDirection::Down => self.scroll_manager.scroll_up(ui::DRAG_AUTO_SCROLL_STEP_LINES),
+            DragAutoScrollDirection::Up => self.scroll_manager.scroll_down(ui::DRAG_AUTO_SCROLL_STEP_LINES),
+        }
+        let offset_delta = self.scroll_manager.offset() as i64 - previous_offset as i64;
+
+        let Some(scroll) = self.drag_auto_scroll.as_mut() else {
+            return;
+        };
+        scroll.last_step = Instant::now();
+        if offset_delta == 0 {
+            // The dragged edge has no more content to reveal; stop nudging until
+            // the pointer moves to a different edge.
+            let direction = scroll.direction;
+            tracing::debug!(target: "vtcode_ui::scroll", ?direction, "drag auto-scroll disarmed: no more content");
+            self.drag_auto_scroll = None;
+            return;
+        }
+
+        let direction = scroll.direction;
+        tracing::debug!(
+            target: "vtcode_ui::scroll",
+            ?direction,
+            offset_delta,
+            "drag auto-scroll stepped"
+        );
+        self.mouse_selection.adjust_for_scroll(offset_delta as i32);
+        self.mouse_selection.update_selection(scroll.column, scroll.row);
+        self.user_scrolled = true;
+        self.mark_dirty();
     }
 
     pub(crate) fn scroll_to_top(&mut self) {

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -582,8 +582,11 @@ impl InputManager {
             // At start: swap first two chars
             chars.swap(0, 1);
             let new_content: String = chars.into_iter().collect();
+            // Move to just after the char now at index 0 (byte-correct for
+            // multi-byte UTF-8; cursor + 1 would panic on non-ASCII).
+            let new_cursor = new_content.chars().next().map_or(0, |c| c.len_utf8());
             self.set_content(new_content);
-            self.set_cursor(cursor + 1);
+            self.set_cursor(new_cursor);
         } else if char_pos >= chars.len() {
             // At end: swap last two chars
             let last = chars.len() - 1;
@@ -591,11 +594,17 @@ impl InputManager {
             let new_content: String = chars.into_iter().collect();
             self.set_content(new_content);
         } else {
-            // In middle: swap char at cursor with char before
+            // In middle: swap char at cursor with char before. The byte length
+            // of the string is unchanged, so the cursor stays at the boundary
+            // of the (now-swapped) character at char_pos.
             chars.swap(char_pos - 1, char_pos);
             let new_content: String = chars.into_iter().collect();
+            let new_cursor = new_content
+                .char_indices()
+                .nth(char_pos)
+                .map_or(new_content.len(), |(idx, c)| idx + c.len_utf8());
             self.set_content(new_content);
-            self.set_cursor(cursor + 1);
+            self.set_cursor(new_cursor);
         }
     }
 
@@ -648,9 +657,14 @@ impl InputManager {
         let curr_word: String = chars[word_start..word_end].iter().collect();
         let between: String = chars[prev_end..word_start].iter().collect();
 
-        // Reconstruct
-        let new_content =
-            format!("{}{}{}{}{}", &content[..prev_start], curr_word, between, prev_word, &content[word_end..]);
+        // Reconstruct purely from char slices; slicing the raw string with
+        // char indices would panic on non-ASCII content.
+        let mut new_content = String::new();
+        new_content.extend(chars[..prev_start].iter());
+        new_content.push_str(&curr_word);
+        new_content.push_str(&between);
+        new_content.push_str(&prev_word);
+        new_content.extend(chars[word_end..].iter());
 
         self.set_content(new_content);
         self.set_cursor(cursor);
@@ -709,7 +723,11 @@ impl InputManager {
         let word: String = chars[word_start..word_end].iter().collect();
         let transformed = transform(&word);
 
-        let new_content = format!("{}{}{}", &content[..word_start], transformed, &content[word_end..]);
+        // char indices must be translated to byte offsets before slicing the
+        // UTF-8 string; slicing with char indices panics on non-ASCII content.
+        let byte_start = chars[..word_start].iter().map(|c| c.len_utf8()).sum::<usize>();
+        let byte_end = byte_start + chars[word_start..word_end].iter().map(|c| c.len_utf8()).sum::<usize>();
+        let new_content = format!("{}{}{}", &content[..byte_start], transformed, &content[byte_end..]);
 
         self.set_content(new_content);
         self.set_cursor(cursor);

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -316,9 +316,11 @@ impl InputManager {
         let Some(text) = self.selected_text() else {
             return false;
         };
-        MouseSelectionState::copy_to_clipboard(&text);
+        let copied = MouseSelectionState::copy_to_clipboard(&text);
+        // Mark attempted even on failure: render-driven copies call this every frame
+        // while selection_needs_copy() is true, and a false flag would retry forever.
         self.selection_copied = true;
-        true
+        copied
     }
 
     pub fn selection_needs_copy(&self) -> bool {

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -540,6 +540,8 @@ impl InputManager {
         let prefix_len = self.cursor();
         let before_len = self.content().len();
         self.textarea.delete_next_word();
+        // Refresh before reading the new length: content() serves the cache.
+        self.refresh_content_cache();
         // Deleting a forward span preserves everything before the cursor, so
         // the removed span is exactly [cursor, cursor + shrink). Track it like
         // the other mutators so compact_paste_range stays aligned.
@@ -547,7 +549,6 @@ impl InputManager {
         if after_len < before_len {
             self.track_compact_paste_replace(prefix_len, prefix_len + (before_len - after_len), 0);
         }
-        self.refresh_content_cache();
     }
 
     pub fn delete_whitespace_around_cursor(&mut self) {

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/input_manager.rs
@@ -537,7 +537,16 @@ impl InputManager {
         if self.delete_selection() {
             return;
         }
+        let prefix_len = self.cursor();
+        let before_len = self.content().len();
         self.textarea.delete_next_word();
+        // Deleting a forward span preserves everything before the cursor, so
+        // the removed span is exactly [cursor, cursor + shrink). Track it like
+        // the other mutators so compact_paste_range stays aligned.
+        let after_len = self.content().len();
+        if after_len < before_len {
+            self.track_compact_paste_replace(prefix_len, prefix_len + (before_len - after_len), 0);
+        }
         self.refresh_content_cache();
     }
 

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/mouse_selection.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/mouse_selection.rs
@@ -377,16 +377,19 @@ fn spawn_clipboard_command(mut cmd: std::process::Command, text: &str) -> bool {
     // longer than this budget regardless of helper behavior.
     const WAIT_BUDGET: Duration = Duration::from_millis(300);
     const POLL_INTERVAL: Duration = Duration::from_millis(10);
+    // After the helper exits, its writer report is usually already delivered;
+    // this grace window only covers the rare in-flight race.
+    const WRITE_REPORT_GRACE: Duration = Duration::from_millis(25);
 
     let program = cmd.get_program().to_string_lossy().into_owned();
     let Ok(mut child) = cmd.stdin(Stdio::piped()).stdout(Stdio::null()).stderr(Stdio::null()).spawn() else {
         trace_clipboard(&format!("'{program}' unavailable: spawn failed"));
         return false;
     };
-    // std::process::Child is neither Send nor Sync, so move only the stdin pipe
-    // (plus a copy of the text) into the detached writer thread; the child
-    // itself is polled from this thread. The writer is never joined so a
-    // blocked write_all cannot stall the UI thread.
+    // The writer is detached and never joined so a blocked write_all cannot
+    // stall the UI thread; only the stdin pipe (plus a copy of the text) moves
+    // into it. `child` stays on this thread for try_wait polling and is handed
+    // to a detached reaper if the budget expires.
     let mut stdin = child.stdin.take();
     let text_owned = text.to_owned();
     let (write_tx, write_rx) = std::sync::mpsc::channel();
@@ -408,6 +411,22 @@ fn spawn_clipboard_command(mut cmd: std::process::Command, text: &str) -> bool {
         }
         match child.try_wait() {
             Ok(Some(status)) => {
+                // The helper has exited, so the writer will finish promptly;
+                // give its report a short grace window, otherwise a write
+                // failing concurrently with a clean exit would count as ok.
+                let flush_deadline = Instant::now() + WRITE_REPORT_GRACE;
+                while write_error.is_none() {
+                    match write_rx.try_recv() {
+                        Ok(report) => write_error = report,
+                        Err(std::sync::mpsc::TryRecvError::Empty) => {
+                            if Instant::now() >= flush_deadline {
+                                break;
+                            }
+                            std::thread::sleep(POLL_INTERVAL);
+                        }
+                        Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+                    }
+                }
                 let ok = status.success() && write_error.is_none();
                 if !ok {
                     if let Some(err) = write_error {
@@ -428,12 +447,22 @@ fn spawn_clipboard_command(mut cmd: std::process::Command, text: &str) -> bool {
                         "'{program}' still running after {WAIT_BUDGET:?}; input {}",
                         if ok { "accepted" } else { "failed" }
                     ));
+                    // Fork-and-hold helpers legitimately outlive the copy call;
+                    // reap from a detached thread so no zombie accumulates.
+                    let _ = std::thread::spawn(move || {
+                        let mut child = child;
+                        let _ = child.wait();
+                    });
                     return ok;
                 }
                 std::thread::sleep(POLL_INTERVAL);
             }
             Err(err) => {
                 trace_clipboard(&format!("'{program}' wait failed: {err}"));
+                let _ = std::thread::spawn(move || {
+                    let mut child = child;
+                    let _ = child.wait();
+                });
                 return false;
             }
         }

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/mouse_selection.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/mouse_selection.rs
@@ -1,5 +1,5 @@
 use ratatui::buffer::Buffer;
-use ratatui::crossterm::{clipboard::CopyToClipboard, execute};
+use ratatui::crossterm::{Command, clipboard::CopyToClipboard};
 use ratatui::layout::Rect;
 use std::io::Write;
 #[cfg(test)]
@@ -10,6 +10,24 @@ use std::time::{Duration, Instant};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(450);
+
+/// Edge direction for auto-scroll while dragging a transcript selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DragAutoScrollDirection {
+    Up,
+    Down,
+}
+
+/// Pending edge auto-scroll for an in-progress transcript drag.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DragAutoScroll {
+    pub(crate) direction: DragAutoScrollDirection,
+    /// Pointer position clamped into the transcript area so the selection end
+    /// keeps extending onto newly revealed rows.
+    pub(crate) column: u16,
+    pub(crate) row: u16,
+    pub(crate) last_step: Instant,
+}
 
 /// Tracks mouse-driven text selection state for the TUI transcript.
 #[derive(Debug, Default)]
@@ -276,21 +294,30 @@ impl MouseSelectionState {
 
     /// Copy the selected text to the system clipboard.
     ///
-    /// Tries native OS clipboard utilities first (`pbcopy` on macOS, `xclip`/`xsel`
-    /// on Linux, `clip.exe` on Windows/WSL) for maximum compatibility, then falls
-    /// back to the OSC 52 escape sequence.
-    pub fn copy_to_clipboard(text: &str) {
+    /// Tries native OS clipboard utilities first (`pbcopy` on macOS, `xclip`/`xsel`/`wl-copy`
+    /// on Linux, `clip.exe` on Windows/WSL) for maximum compatibility, then falls back to the
+    /// OSC 52 escape sequence. Returns whether any strategy reported success.
+    ///
+    /// OSC 52 delivery is best-effort: terminals never acknowledge the sequence, so a clean
+    /// stderr write counts as success even if the terminal silently drops it (unsupported,
+    /// disabled, or swallowed by a multiplexer). Every strategy attempt emits a
+    /// `tracing::debug!` event; enable `RUST_LOG=vtcode_ui=debug` when diagnosing.
+    pub fn copy_to_clipboard(text: &str) -> bool {
         if text.is_empty() {
-            return;
+            trace_clipboard("nothing to copy: empty text");
+            return false;
         }
 
         if Self::copy_via_native(text) {
-            return;
+            return true;
         }
 
-        // Fallback: OSC 52 escape sequence
-        let _ = execute!(std::io::stderr(), CopyToClipboard::to_clipboard_from(text.as_bytes()));
-        let _ = std::io::stderr().flush();
+        let copied = copy_via_osc52(text, inside_tmux());
+        trace_clipboard(&format!(
+            "native candidates exhausted; osc52 fallback result={copied} text_bytes={}",
+            text.len()
+        ));
+        copied
     }
 
     /// Attempt to copy text using native OS clipboard utilities.
@@ -306,7 +333,7 @@ impl MouseSelectionState {
         let candidates: &[&str] = if cfg!(target_os = "macos") {
             &["pbcopy"]
         } else if cfg!(target_os = "linux") {
-            &["xclip", "xsel"]
+            &["xclip", "xsel", "wl-copy"]
         } else if cfg!(target_os = "windows") {
             &["clip.exe"]
         } else {
@@ -325,28 +352,156 @@ impl MouseSelectionState {
                 _ => {}
             }
             if spawn_clipboard_command(cmd, text) {
+                trace_clipboard(&format!("native '{program}' succeeded ({} bytes)", text.len()));
                 return true;
             }
         }
+        trace_clipboard("all native clipboard candidates failed or missing");
         false
     }
+}
+
+/// Emits clipboard strategy diagnostics for support/debugging sessions.
+fn trace_clipboard(message: &str) {
+    tracing::debug!(target: "vtcode_ui::clipboard", "{message}");
 }
 
 fn spawn_clipboard_command(mut cmd: std::process::Command, text: &str) -> bool {
     use std::process::Stdio;
 
+    // Helpers such as xclip/wl-copy normally exit right away, but some builds
+    // fork-and-hold while serving the selection, and a helper that never reads
+    // stdin could block a synchronous write_all forever once the pipe buffer
+    // fills (>= 64KB). The input is therefore written on a detached writer
+    // thread and the result is read via try_recv, so the UI thread never blocks
+    // longer than this budget regardless of helper behavior.
+    const WAIT_BUDGET: Duration = Duration::from_millis(300);
+    const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+    let program = cmd.get_program().to_string_lossy().into_owned();
     let Ok(mut child) = cmd.stdin(Stdio::piped()).stdout(Stdio::null()).stderr(Stdio::null()).spawn() else {
+        trace_clipboard(&format!("'{program}' unavailable: spawn failed"));
         return false;
     };
-    if let Some(stdin) = child.stdin.as_mut() {
-        let _ = stdin.write_all(text.as_bytes());
+    // std::process::Child is neither Send nor Sync, so move only the stdin pipe
+    // (plus a copy of the text) into the detached writer thread; the child
+    // itself is polled from this thread. The writer is never joined so a
+    // blocked write_all cannot stall the UI thread.
+    let mut stdin = child.stdin.take();
+    let text_owned = text.to_owned();
+    let (write_tx, write_rx) = std::sync::mpsc::channel();
+    let _ = std::thread::spawn(move || {
+        let result = match stdin.as_mut() {
+            Some(pipe) => pipe.write_all(text_owned.as_bytes()).err(),
+            None => None,
+        };
+        drop(stdin.take());
+        let _ = write_tx.send(result);
+    });
+    // Tracks the first observed write failure; None until the writer reports or
+    // a status/deadline path makes a decision.
+    let mut write_error = None;
+    let deadline = Instant::now() + WAIT_BUDGET;
+    loop {
+        if let Ok(report) = write_rx.try_recv() {
+            write_error = report;
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let ok = status.success() && write_error.is_none();
+                if !ok {
+                    if let Some(err) = write_error {
+                        trace_clipboard(&format!("'{program}' stdin write failed: {err}; status={status}"));
+                    } else {
+                        trace_clipboard(&format!("'{program}' failed: status={status}"));
+                    }
+                }
+                return ok;
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    // The writer may still be blocked; do NOT join it (that
+                    // would hang the UI thread). Input was at least accepted
+                    // into the pipe unless a write failure was already reported.
+                    let ok = write_error.is_none();
+                    trace_clipboard(&format!(
+                        "'{program}' still running after {WAIT_BUDGET:?}; input {}",
+                        if ok { "accepted" } else { "failed" }
+                    ));
+                    return ok;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(err) => {
+                trace_clipboard(&format!("'{program}' wait failed: {err}"));
+                return false;
+            }
+        }
     }
-    drop(child.stdin.take());
-    child.wait().is_ok()
+}
+
+/// Whether the session runs inside tmux; OSC 52 must then be DCS-wrapped or tmux
+/// consumes it without ever reaching the outer terminal.
+fn inside_tmux() -> bool {
+    std::env::var_os("TMUX").is_some_and(|value| !value.is_empty())
+}
+
+/// Wrap an escape sequence in tmux's DCS passthrough so tmux forwards it verbatim to
+/// the outer terminal. Every ESC inside the payload must be doubled.
+fn wrap_tmux_passthrough(sequence: &str) -> String {
+    format!("\x1bPtmux;\x1b{}\x1b\\", sequence.replace('\x1b', "\x1b\x1b"))
+}
+
+/// Build the OSC 52 payload for `text`, wrapped for tmux when requested.
+fn build_osc52_payload(text: &str, inside_tmux: bool) -> Option<String> {
+    let mut sequence = String::new();
+    CopyToClipboard::to_clipboard_from(text.as_bytes())
+        .write_ansi(&mut sequence)
+        .ok()?;
+    Some(if inside_tmux {
+        wrap_tmux_passthrough(&sequence)
+    } else {
+        sequence
+    })
+}
+
+/// Emit the OSC 52 clipboard sequence on stderr. Delivery cannot be confirmed —
+/// terminals never acknowledge it — so success means "written without IO error".
+fn copy_via_osc52(text: &str, inside_tmux: bool) -> bool {
+    #[cfg(test)]
+    if let Some(forced) = osc52_write_override() {
+        return forced;
+    }
+
+    let Some(payload) = build_osc52_payload(text, inside_tmux) else {
+        return false;
+    };
+
+    let mut stderr = std::io::stderr();
+    let written = stderr.write_all(payload.as_bytes()).is_ok() && stderr.flush().is_ok();
+    trace_clipboard(&format!("osc52 written={written} payload_bytes={} tmux_passthrough={inside_tmux}", payload.len()));
+    written
 }
 
 #[cfg(test)]
 static CLIPBOARD_COMMAND_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+
+#[cfg(test)]
+static OSC52_WRITE_OVERRIDE: OnceLock<Mutex<Option<bool>>> = OnceLock::new();
+
+#[cfg(test)]
+pub(crate) fn set_osc52_write_override(result: Option<bool>) {
+    let lock = OSC52_WRITE_OVERRIDE.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = lock.lock() {
+        *guard = result;
+    }
+}
+
+#[cfg(test)]
+fn osc52_write_override() -> Option<bool> {
+    let lock = OSC52_WRITE_OVERRIDE.get_or_init(|| Mutex::new(None));
+    lock.lock().ok().and_then(|guard| *guard)
+}
 
 #[cfg(test)]
 pub(crate) fn set_clipboard_command_override(path: Option<PathBuf>) {
@@ -512,5 +667,84 @@ mod tests {
         assert!(!selection.register_click(3, 7, now));
         assert!(selection.register_click(3, 7, now + Duration::from_millis(250)));
         assert!(!selection.register_click(4, 7, now + Duration::from_millis(250)));
+    }
+
+    #[test]
+    fn spawn_clipboard_command_requires_success_exit_status() {
+        let failing = {
+            let mut cmd = std::process::Command::new("sh");
+            cmd.arg("-c").arg("exit 1");
+            cmd
+        };
+        assert!(!spawn_clipboard_command(failing, "hello"));
+
+        let succeeding = {
+            let mut cmd = std::process::Command::new("sh");
+            cmd.arg("-c").arg("cat > /dev/null");
+            cmd
+        };
+        assert!(spawn_clipboard_command(succeeding, "hello"));
+    }
+
+    #[test]
+    fn spawn_clipboard_command_treats_hanging_helper_as_success() {
+        // A helper that holds stdin open and never exits must not block the
+        // UI thread forever: the bounded wait accepts the already-written
+        // input and returns without hanging.
+        let hanging = {
+            let mut cmd = std::process::Command::new("sh");
+            cmd.arg("-c").arg("cat > /dev/null & sleep 10");
+            cmd
+        };
+        let start = Instant::now();
+        assert!(spawn_clipboard_command(hanging, "hello"));
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "bounded wait must return promptly, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn spawn_clipboard_command_large_write_to_non_reading_helper_returns_promptly() {
+        // A helper that never reads stdin would block a synchronous write_all
+        // forever once the 64KB pipe buffer fills. The detached writer must not
+        // stall the caller: the bounded poll returns without joining it.
+        let non_reading = {
+            let mut cmd = std::process::Command::new("sh");
+            cmd.arg("-c").arg("sleep 10");
+            cmd
+        };
+        let big: String = "x".repeat(128 * 1024);
+        let start = Instant::now();
+        let result = spawn_clipboard_command(non_reading, &big);
+        assert!(start.elapsed() < Duration::from_secs(2), "must not block on the writer, took {:?}", start.elapsed());
+        // No write failure was observed within the budget, so the input is
+        // treated as accepted even though the helper never reads.
+        assert!(result);
+    }
+
+    #[test]
+    fn build_osc52_payload_emits_base64_clipboard_sequence() {
+        let payload = build_osc52_payload("hi", false).expect("osc52 payload");
+        assert!(payload.starts_with("\x1b]52;c;"), "unexpected payload: {payload:?}");
+        assert!(payload.ends_with("\x1b\\"));
+        assert!(payload.contains("aGk="));
+    }
+
+    #[test]
+    fn build_osc52_payload_wraps_in_tmux_passthrough() {
+        let plain = build_osc52_payload("hi", false).expect("plain payload");
+        let wrapped = build_osc52_payload("hi", true).expect("wrapped payload");
+
+        // DCS introducer + doubled-ESC payload + ST terminator.
+        assert_eq!(wrapped, format!("\x1bPtmux;\x1b{}\x1b\\", plain.replace('\x1b', "\x1b\x1b")));
+        assert!(wrapped.starts_with("\x1bPtmux;\x1b\x1b\x1b]52;c;"));
+        assert!(wrapped.ends_with("\x1b\x1b\\\x1b\\"));
+    }
+
+    #[test]
+    fn wrap_tmux_passthrough_doubles_every_escape() {
+        assert_eq!(wrap_tmux_passthrough("\x1ba\x1bb"), "\x1bPtmux;\x1b\x1b\x1ba\x1b\x1bb\x1b\\");
     }
 }

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/queue.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/queue.rs
@@ -33,6 +33,8 @@ impl Session {
             return Vec::new();
         }
 
+        const VISIBLE_ITEMS: usize = 5;
+
         let max_width = width as usize;
         let mut lines = Vec::new();
         let mut prefix_style = self.styles.accent_style();
@@ -43,16 +45,28 @@ impl Session {
         let prefix_width = UnicodeWidthStr::width(prefix);
         let available = max_width.saturating_sub(prefix_width);
 
-        for entry in self.queued_inputs.iter().rev().take(2) {
-            let trimmed = truncate_to_width(entry, available);
-            let spans = vec![
-                Span::styled(prefix.to_owned(), prefix_style),
-                Span::styled(trimmed, message_style),
-            ];
+        // The queue is strict FIFO (first queued = first dispatched), so the
+        // overlay renders in insertion order: oldest on top, newest directly
+        // above the input field. The oldest will be sent first. Multi-line
+        // items must be flattened so a raw newline/carriage-return cannot
+        // break the layout.
+        for entry in self.queued_inputs.iter().take(VISIBLE_ITEMS) {
+            let flattened = entry.replace(['\r', '\n'], " ⏎ ");
+            let trimmed = truncate_to_width(&flattened, available);
+            let mut spans = Vec::with_capacity(2);
+            // Skip the prefix when it does not fit (tiny terminal width).
+            if available > 0 {
+                spans.push(Span::styled(prefix.to_owned(), prefix_style));
+            }
+            spans.push(Span::styled(trimmed, message_style));
             lines.push(Line::from(spans));
         }
 
         let muted_style = self.styles.default_style().add_modifier(Modifier::DIM);
+        let hidden = self.queued_inputs.len().saturating_sub(VISIBLE_ITEMS);
+        if hidden > 0 {
+            lines.push(Line::from(vec![Span::styled(format!("+{hidden} more queued"), muted_style)]));
+        }
         lines.push(Line::from(vec![Span::styled(
             super::terminal_capabilities::queued_input_edit_hint().to_string(),
             muted_style,

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/state.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/state.rs
@@ -29,6 +29,7 @@ use crate::tui::options::FullscreenInteractionSettings;
 
 const COPY_NOTIFICATION_DURATION: Duration = Duration::from_secs(5);
 const COPY_NOTIFICATION_TEXT: &str = "Copied to clipboard";
+const COPY_FAILURE_NOTIFICATION_TEXT: &str = "Copy failed";
 const ACTION_REQUIRED_STATUS_TEXT: &str = "Action required";
 const APPROVAL_REQUIRED_STATUS_TEXT: &str = "Approval required";
 const INPUT_REQUIRED_STATUS_TEXT: &str = "Input required";
@@ -48,12 +49,18 @@ impl Session {
     }
 
     pub(crate) fn copy_input_selection_to_clipboard(&mut self) -> bool {
+        if self.input_manager.selected_text().is_none() {
+            return false;
+        }
+
+        // Swallow the key even on hard failure so Ctrl+C never degrades into an
+        // interrupt while the user is trying to copy a selection.
         if self.input_manager.copy_selected_text_to_clipboard() {
             self.show_copy_notification();
-            true
         } else {
-            false
+            self.show_copy_failure_notification();
         }
+        true
     }
 
     pub(crate) fn copy_text_to_clipboard(&mut self, text: &str) {
@@ -61,8 +68,11 @@ impl Session {
             return;
         }
 
-        MouseSelectionState::copy_to_clipboard(text);
-        self.show_copy_notification();
+        if MouseSelectionState::copy_to_clipboard(text) {
+            self.show_copy_notification();
+        } else {
+            self.show_copy_failure_notification();
+        }
     }
 
     pub(crate) fn clear_suggested_prompt_state(&mut self) {
@@ -301,14 +311,26 @@ impl Session {
     }
 
     pub(crate) fn show_copy_notification(&mut self) {
+        self.show_copy_result_notification(false);
+    }
+
+    pub(crate) fn show_copy_failure_notification(&mut self) {
+        self.show_copy_result_notification(true);
+    }
+
+    fn show_copy_result_notification(&mut self, failed: bool) {
         self.copy_notification_until = Some(Instant::now() + COPY_NOTIFICATION_DURATION);
+        self.copy_notification_failed = failed;
         self.needs_redraw = true;
     }
 
     pub(crate) fn copy_notification_text(&self) -> Option<&'static str> {
-        self.copy_notification_until
-            .filter(|until| Instant::now() < *until)
-            .map(|_| COPY_NOTIFICATION_TEXT)
+        self.copy_notification_until.filter(|until| Instant::now() < *until)?;
+        Some(if self.copy_notification_failed {
+            COPY_FAILURE_NOTIFICATION_TEXT
+        } else {
+            COPY_NOTIFICATION_TEXT
+        })
     }
 
     fn overlay_attention_status_text(&self) -> Option<&'static str> {

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/state.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/state.rs
@@ -271,6 +271,7 @@ impl Session {
     /// Advance animation state on tick and request redraw when a frame changes.
     pub(crate) fn handle_tick(&mut self) {
         let motion_reduced = self.appearance.motion_reduced();
+        self.step_drag_auto_scroll();
         let mut animation_updated = false;
         if !motion_reduced && self.thinking_spinner.is_active && self.thinking_spinner.update() {
             animation_updated = true;

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/terminal_capabilities.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/terminal_capabilities.rs
@@ -270,8 +270,10 @@ mod tests {
     #[test]
     fn queued_input_edit_binding_switches_for_tmux() {
         let _guard = TERMINAL_ENV_TEST_LOCK.lock().expect("terminal env test lock");
-        clear_var("TMUX");
-        clear_var("TERM");
+        // Shadow instead of clearing: clearing falls back to the host environment,
+        // which leaks when the suite itself runs inside tmux.
+        remove_var("TMUX");
+        remove_var("TERM");
         set_var("TERM", "xterm-256color");
         assert!(!queued_input_edit_uses_shift_left());
 

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests.rs
@@ -1,5 +1,6 @@
 mod clipboard;
 mod diff_overlay;
+mod drag_autoscroll;
 mod file_palette;
 mod header_status;
 mod helpers;

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/clipboard.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/clipboard.rs
@@ -182,3 +182,132 @@ fn selecting_input_text_auto_copies_and_keeps_selection() {
     let clipboard_contents = fs::read_to_string(&clipboard_file).expect("read copied input text");
     assert_eq!(clipboard_contents, "world");
 }
+
+#[test]
+fn transcript_copy_failure_surfaces_copy_failed_status() {
+    use crate::tui::core_tui::session::mouse_selection::{
+        clipboard_command_override, set_clipboard_command_override, set_osc52_write_override,
+    };
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+
+    let _guard = CLIPBOARD_TEST_LOCK.lock().expect("clipboard test lock should not be poisoned");
+
+    struct OverrideGuard;
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            set_clipboard_command_override(None);
+            set_osc52_write_override(None);
+        }
+    }
+    let _overrides = OverrideGuard;
+
+    let temp_dir = std::env::temp_dir().join(format!(
+        "vtcode-clipboard-fail-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after UNIX_EPOCH")
+            .as_nanos()
+    ));
+    fs::create_dir_all(&temp_dir).expect("create temp dir for clipboard script");
+    struct TempDirGuard(PathBuf);
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+    let _temp_guard = TempDirGuard(temp_dir.clone());
+
+    let script_path = temp_dir.join("xclip");
+    fs::write(&script_path, "#!/bin/sh\nexit 1\n").expect("write failing clipboard command");
+    let mut permissions = fs::metadata(&script_path)
+        .expect("read failing clipboard metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script_path, permissions).expect("make failing clipboard executable");
+
+    set_clipboard_command_override(Some(script_path.clone()));
+    set_osc52_write_override(Some(false));
+
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.copy_text_to_clipboard("hello");
+
+    let rendered_status = session
+        .render_input_status_line(VIEW_WIDTH)
+        .expect("input status line")
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+    assert!(
+        rendered_status.contains("Copy failed"),
+        "failed copy should surface a failure notice, got: {rendered_status}"
+    );
+}
+
+#[test]
+fn input_copy_failure_is_swallowed_without_interrupt_and_never_retries() {
+    use crate::tui::core_tui::session::mouse_selection::{
+        clipboard_command_override, set_clipboard_command_override, set_osc52_write_override,
+    };
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+
+    let _guard = CLIPBOARD_TEST_LOCK.lock().expect("clipboard test lock should not be poisoned");
+
+    struct OverrideGuard;
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            set_clipboard_command_override(None);
+            set_osc52_write_override(None);
+        }
+    }
+    let _overrides = OverrideGuard;
+
+    let temp_dir = std::env::temp_dir().join(format!(
+        "vtcode-clipboard-fail-input-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after UNIX_EPOCH")
+            .as_nanos()
+    ));
+    fs::create_dir_all(&temp_dir).expect("create temp dir for clipboard script");
+    struct TempDirGuard(PathBuf);
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+    let _temp_guard = TempDirGuard(temp_dir.clone());
+
+    let script_path = temp_dir.join("xclip");
+    fs::write(&script_path, "#!/bin/sh\nexit 1\n").expect("write failing clipboard command");
+    let mut permissions = fs::metadata(&script_path)
+        .expect("read failing clipboard metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script_path, permissions).expect("make failing clipboard executable");
+
+    set_clipboard_command_override(Some(script_path.clone()));
+    set_osc52_write_override(Some(false));
+
+    let mut session = app_session_with_input("hello world", "hello world".len());
+    for _ in 0..5 {
+        let result = session.process_key(KeyEvent::new(KeyCode::Left, KeyModifiers::SHIFT));
+        assert!(result.is_none());
+    }
+
+    let _ = rendered_app_session_lines(&mut session, VIEW_ROWS);
+    assert!(
+        !session.core.input_manager.selection_needs_copy(),
+        "a failed auto-copy must not re-arm or every frame would retry it"
+    );
+
+    let result = session.process_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+    assert!(result.is_none(), "Ctrl+C over a selection must stay a copy attempt even when copying fails");
+
+    let rendered = rendered_app_session_lines(&mut session, VIEW_ROWS);
+    assert!(rendered.iter().any(|line| line.contains("Copy failed")));
+}

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/drag_autoscroll.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/drag_autoscroll.rs
@@ -1,0 +1,145 @@
+#![cfg(unix)]
+#![allow(
+    missing_docs,
+    reason = "Intentional compatibility, platform, or test-only suppression."
+)]
+use std::time::{Duration, Instant};
+
+use super::super::*;
+use super::helpers::*;
+
+const STEP_BACKDATE: Duration = Duration::from_millis(200);
+
+fn content_session() -> Session {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    for i in 0..80 {
+        session.push_line(InlineMessageKind::Agent, vec![make_segment(&format!("line {i}"))]);
+    }
+    session
+}
+
+fn mouse_event(kind: MouseEventKind, column: u16, row: u16) -> CrosstermEvent {
+    CrosstermEvent::Mouse(MouseEvent { kind, column, row, modifiers: KeyModifiers::NONE })
+}
+
+#[test]
+fn drag_at_bottom_edge_reveals_newer_content_and_disarms_at_end() {
+    let mut session = content_session();
+    let (transcript_area, _rendered) = rendered_transcript_lines(&mut session, VIEW_ROWS);
+    let last_row = transcript_area.y + transcript_area.height.saturating_sub(1);
+    let mid_row = transcript_area.y + 3;
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    session.handle_event(
+        mouse_event(MouseEventKind::Down(MouseButton::Left), transcript_area.x + 2, mid_row),
+        &tx,
+        None,
+    );
+
+    session.handle_event(
+        mouse_event(MouseEventKind::Drag(MouseButton::Left), transcript_area.x + 2, mid_row),
+        &tx,
+        None,
+    );
+    assert!(session.drag_auto_scroll.is_none(), "dragging mid-transcript must not arm edge auto-scroll");
+
+    session.handle_event(
+        mouse_event(MouseEventKind::Drag(MouseButton::Left), transcript_area.x + 2, last_row),
+        &tx,
+        None,
+    );
+    assert_eq!(session.drag_auto_scroll.map(|scroll| scroll.direction), Some(DragAutoScrollDirection::Down));
+
+    // Scroll away from the newest content so there is room to reveal downward.
+    session.scroll_to_top();
+    let before = session.scroll_manager.offset();
+    assert!(before > 0, "test needs scrollback above the viewport");
+
+    // Within the interval a tick must not step.
+    session.step_drag_auto_scroll();
+    assert_eq!(session.scroll_manager.offset(), before);
+
+    session.drag_auto_scroll.as_mut().expect("auto-scroll armed").last_step =
+        Instant::now().checked_sub(STEP_BACKDATE).expect("test timestamp before epoch");
+    session.step_drag_auto_scroll();
+    assert!(session.scroll_manager.offset() < before, "bottom-edge auto-scroll must reveal newer content");
+
+    // Exhaust the remaining scrollback: the edge state must disarm itself.
+    while session.drag_auto_scroll.is_some() {
+        session.drag_auto_scroll.as_mut().expect("armed").last_step =
+            Instant::now().checked_sub(STEP_BACKDATE).expect("test timestamp before epoch");
+        session.step_drag_auto_scroll();
+    }
+    assert_eq!(session.scroll_manager.offset(), 0);
+}
+
+#[test]
+fn drag_at_top_edge_reveals_older_content_and_release_cancels() {
+    let mut session = content_session();
+    let (transcript_area, _rendered) = rendered_transcript_lines(&mut session, VIEW_ROWS);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    session.handle_event(
+        mouse_event(MouseEventKind::Down(MouseButton::Left), transcript_area.x + 2, transcript_area.y + 5),
+        &tx,
+        None,
+    );
+    session.handle_event(
+        mouse_event(MouseEventKind::Drag(MouseButton::Left), transcript_area.x + 2, transcript_area.y),
+        &tx,
+        None,
+    );
+    assert_eq!(session.drag_auto_scroll.map(|scroll| scroll.direction), Some(DragAutoScrollDirection::Up));
+
+    session.scroll_to_bottom();
+    let before = session.scroll_manager.offset();
+
+    session.drag_auto_scroll.as_mut().expect("auto-scroll armed").last_step =
+        Instant::now().checked_sub(STEP_BACKDATE).expect("test timestamp before epoch");
+    session.step_drag_auto_scroll();
+    assert!(session.scroll_manager.offset() > before, "top-edge auto-scroll must reveal older content");
+
+    session.handle_event(
+        mouse_event(MouseEventKind::Up(MouseButton::Left), transcript_area.x + 2, transcript_area.y),
+        &tx,
+        None,
+    );
+    assert!(session.drag_auto_scroll.is_none());
+}
+
+#[test]
+fn dragging_back_into_the_middle_disarms_edge_auto_scroll() {
+    let mut session = content_session();
+    let (transcript_area, _rendered) = rendered_transcript_lines(&mut session, VIEW_ROWS);
+    let last_row = transcript_area.y + transcript_area.height.saturating_sub(1);
+    let mid_row = transcript_area.y + 3;
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    session.handle_event(
+        mouse_event(MouseEventKind::Down(MouseButton::Left), transcript_area.x + 2, mid_row),
+        &tx,
+        None,
+    );
+    session.handle_event(
+        mouse_event(MouseEventKind::Drag(MouseButton::Left), transcript_area.x + 2, last_row),
+        &tx,
+        None,
+    );
+    assert!(session.drag_auto_scroll.is_some());
+
+    session.handle_event(
+        mouse_event(MouseEventKind::Drag(MouseButton::Left), transcript_area.x + 2, mid_row),
+        &tx,
+        None,
+    );
+    assert!(session.drag_auto_scroll.is_none());
+}
+
+#[test]
+fn zero_height_transcript_area_never_arms_auto_scroll() {
+    let mut session = content_session();
+    session.transcript_area = Some(Rect::new(0, 0, 80, 0));
+
+    session.update_drag_auto_scroll(10, 0);
+    assert!(session.drag_auto_scroll.is_none(), "zero-height area must not arm auto-scroll");
+}

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/input_navigation.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/input_navigation.rs
@@ -386,6 +386,29 @@ fn ctrl_t_transposes_characters() {
 }
 
 #[test]
+fn ctrl_t_transposes_cyrillic_characters_without_panicking() {
+    // Multi-byte UTF-8 must not hit a "byte index is not a char boundary" panic.
+    let mut session = session_with_input("яб", 0);
+
+    let event = KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL);
+    let result = session.process_key(event);
+
+    assert!(result.is_none());
+    assert_eq!(session.input_manager.content(), "бя");
+}
+
+#[test]
+fn ctrl_t_transposes_cyrillic_in_middle_without_panicking() {
+    let mut session = session_with_input("абв", 2);
+
+    let event = KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL);
+    let result = session.process_key(event);
+
+    assert!(result.is_none());
+    assert_eq!(session.input_manager.content(), "бав");
+}
+
+#[test]
 fn alt_t_toggles_tool_display_mode() {
     let mut session = session_with_input("hello world", 6);
 
@@ -405,6 +428,18 @@ fn alt_u_uppercases_word() {
 
     assert!(result.is_none());
     assert_eq!(session.input_manager.content(), "HELLO world");
+}
+
+#[test]
+fn alt_u_uppercases_cyrillic_word_without_panicking() {
+    // Byte-vs-char index confusion would panic on multi-byte UTF-8.
+    let mut session = session_with_input("привет мир", 0);
+
+    let event = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::ALT);
+    let result = session.process_key(event);
+
+    assert!(result.is_none());
+    assert_eq!(session.input_manager.content(), "ПРИВЕТ мир");
 }
 
 #[test]

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/misc.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/misc.rs
@@ -405,3 +405,99 @@ fn error_block_with_cjk_label_reserves_correct_content_width() {
         );
     }
 }
+
+#[test]
+fn backspace_after_large_paste_deletes_whole_block() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.insert_char('x');
+    let pasted: String = (0..12).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    session.insert_paste_text(&pasted);
+
+    assert!(session.input_manager.compact_paste_range().is_some());
+    assert_eq!(session.input_manager.cursor(), session.input_manager.content().len());
+
+    session.delete_char();
+
+    assert_eq!(session.input_manager.content(), "x");
+    assert!(session.input_manager.compact_paste_range().is_none());
+}
+
+#[test]
+fn backspace_after_paste_still_deletes_typed_chars_one_by_one() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    let pasted: String = (0..12).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    session.insert_paste_text(&pasted);
+
+    session.insert_char('!');
+    session.insert_char('?');
+    assert!(session.input_manager.content().ends_with("!?"));
+
+    session.delete_char();
+    assert!(session.input_manager.content().ends_with("!"));
+    assert!(session.input_manager.compact_paste_range().is_some());
+
+    session.delete_char();
+    assert!(session.input_manager.content().ends_with(&pasted));
+}
+
+#[test]
+fn backspace_with_active_selection_deletes_selection_not_whole_paste() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    let pasted: String = (0..12).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    session.insert_paste_text(&pasted);
+
+    let content_len = session.input_manager.content().len();
+    // Select the last two characters (e.g. "10" of "line 10") so the active
+    // selection ends exactly at the collapsed paste end.
+    session.input_manager.set_cursor_with_selection(content_len - 2);
+    assert!(session.input_manager.selection_range().is_some());
+
+    session.delete_char();
+
+    // The selection wins over the collapse: only the two selected chars are
+    // removed, not the entire pasted block.
+    assert_eq!(session.input_manager.content().len(), content_len - 2);
+    assert!(!session.input_manager.content().ends_with("10"));
+    assert!(session.input_manager.content().contains("line 0"));
+}
+
+#[test]
+fn backspace_after_paste_deletes_whole_block_when_no_selection() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.insert_char('x');
+    let pasted: String = (0..12).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    session.insert_paste_text(&pasted);
+
+    assert!(session.input_manager.compact_paste_range().is_some());
+    assert_eq!(session.input_manager.cursor(), session.input_manager.content().len());
+    assert!(session.input_manager.selection_range().is_none());
+
+    session.delete_char();
+
+    assert_eq!(session.input_manager.content(), "x");
+    assert!(session.input_manager.compact_paste_range().is_none());
+}
+
+#[test]
+fn alt_backspace_deletes_previous_word() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.input_manager.set_content("hello world".to_string());
+    session.input_manager.set_cursor(session.input_manager.content().len());
+
+    let result = session.process_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT));
+
+    assert!(result.is_none());
+    assert_eq!(session.input_manager.content(), "hello ");
+}
+
+#[test]
+fn alt_backspace_deletes_previous_cyrillic_word() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.input_manager.set_content("привет мир".to_string());
+    session.input_manager.set_cursor(session.input_manager.content().len());
+
+    let result = session.process_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT));
+
+    assert!(result.is_none());
+    assert_eq!(session.input_manager.content(), "привет ");
+}

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/misc.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/misc.rs
@@ -479,6 +479,56 @@ fn backspace_after_paste_deletes_whole_block_when_no_selection() {
 }
 
 #[test]
+fn delete_word_forward_before_paste_keeps_block_delete_aligned() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.insert_char('x');
+    session.insert_char(' ');
+    let pasted: String = (0..12).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    session.insert_paste_text(&pasted);
+
+    let range = session.input_manager.compact_paste_range().expect("collapsed paste range");
+    assert_eq!(range.start, 2);
+
+    // Delete the typed word sitting before the collapsed block.
+    session.input_manager.set_cursor(0);
+    session.input_manager.delete_word_forward();
+
+    // The range must shift by the removed bytes, not go stale.
+    let shifted = session
+        .input_manager
+        .compact_paste_range()
+        .expect("range survives edits entirely before it");
+    assert_eq!(shifted.start, 1);
+    assert_eq!(shifted.end, range.end - 1);
+
+    // The block-delete invariant holds: cursor at the new end coincides with
+    // the shifted range end, so Backspace removes the whole block.
+    session.input_manager.set_cursor(session.input_manager.content().len());
+    session.delete_char();
+
+    assert_eq!(session.input_manager.content(), " ");
+    assert!(session.input_manager.compact_paste_range().is_none());
+}
+
+#[test]
+fn delete_word_forward_overlapping_paste_clears_compact_range() {
+    let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
+    session.insert_char('x');
+    session.insert_char(' ');
+    let pasted: String = (0..12).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+    session.insert_paste_text(&pasted);
+
+    let range = session.input_manager.compact_paste_range().expect("collapsed paste range");
+
+    // Cursor inside the collapsed block: an overlapping delete invalidates it
+    // so a later Backspace never removes user-typed bytes.
+    session.input_manager.set_cursor(range.start + 1);
+    session.input_manager.delete_word_forward();
+
+    assert!(session.input_manager.compact_paste_range().is_none());
+}
+
+#[test]
 fn alt_backspace_deletes_previous_word() {
     let mut session = Session::new(InlineTheme::default(), None, VIEW_ROWS);
     session.input_manager.set_content("hello world".to_string());

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/session/tests/queue_inputs.rs
@@ -4,6 +4,7 @@
 )]
 use super::super::*;
 use super::helpers::*;
+use crate::tui::core_tui::app::types::InlineEvent as AppInlineEvent;
 use crate::tui::core_tui::types::{ContentPart, SubmittedInput};
 
 #[test]
@@ -529,6 +530,45 @@ fn busy_control_enter_steers_active_run() {
 
     let event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL));
     assert!(matches!(event, Some(InlineEvent::Steer(value)) if value == "keep searching in docs/"));
+}
+
+#[test]
+fn app_busy_control_enter_queues_batchable_submission() {
+    let mut session = AppSession::new(InlineTheme::default(), None, VIEW_ROWS);
+    set_app_session_busy_status(&mut session);
+    session.core.set_input("batch me".to_string());
+
+    let event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL));
+    assert!(
+        matches!(&event, Some(AppInlineEvent::QueueSubmit(value)) if value.text == "batch me" && value.batchable),
+        "expected batchable QueueSubmit, got: {event:?}"
+    );
+}
+
+#[test]
+fn app_busy_plain_enter_queues_non_batchable_submission() {
+    let mut session = AppSession::new(InlineTheme::default(), None, VIEW_ROWS);
+    set_app_session_busy_status(&mut session);
+    session.core.set_input("one turn".to_string());
+
+    let event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert!(
+        matches!(&event, Some(AppInlineEvent::QueueSubmit(value)) if value.text == "one turn" && !value.batchable),
+        "expected non-batchable QueueSubmit, got: {event:?}"
+    );
+}
+
+#[test]
+fn app_busy_control_enter_queues_slash_command_as_non_batchable() {
+    let mut session = AppSession::new(InlineTheme::default(), None, VIEW_ROWS);
+    set_app_session_busy_status(&mut session);
+    session.core.set_input("/model gpt-4o".to_string());
+
+    let event = session.process_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL));
+    assert!(
+        matches!(&event, Some(AppInlineEvent::QueueSubmit(value)) if value.text == "/model gpt-4o" && !value.batchable),
+        "expected non-batchable QueueSubmit for a slash command, got: {event:?}"
+    );
 }
 
 #[test]

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/types/protocol.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/types/protocol.rs
@@ -16,21 +16,32 @@ pub use vtcode_commons::ui_protocol::InlineMessageKind;
 pub struct SubmittedInput {
     pub text: String,
     pub attachments: Vec<ContentPart>,
+    /// Whether this submission may be merged with other queued text-only
+    /// submissions of the same agent into a single model turn. Ctrl+Enter sets
+    /// this; a plain Enter queued while busy must stay a one-per-turn dispatch.
+    pub batchable: bool,
 }
 
 impl SubmittedInput {
     pub fn new(text: impl Into<String>, attachments: Vec<ContentPart>) -> Self {
-        Self { text: text.into(), attachments }
+        Self { text: text.into(), attachments, batchable: false }
     }
 
     fn text_only(text: impl Into<String>) -> Self {
         Self::new(text, Vec::new())
     }
 
+    /// Mark this submission as eligible for queue batching (Ctrl+Enter).
+    pub fn batchable(mut self) -> Self {
+        self.batchable = true;
+        self
+    }
+
     pub fn trim_text(self) -> Self {
         Self {
             text: self.text.trim().to_string(),
             attachments: self.attachments,
+            batchable: self.batchable,
         }
     }
 

--- a/crates/codegen/vtcode-ui/src/tui/core_tui/widgets/transcript.rs
+++ b/crates/codegen/vtcode-ui/src/tui/core_tui/widgets/transcript.rs
@@ -308,6 +308,61 @@ mod tests {
     }
 
     #[test]
+    fn render_queue_overlay_orders_items_fifo_oldest_on_top() {
+        let area = Rect::new(0, 0, 30, 8);
+        let inner = Rect::new(1, 1, 28, 6);
+        let mut buf = Buffer::empty(area);
+        let mut session = Session::new(InlineTheme::default(), None, 12);
+        session.push_line(InlineMessageKind::Agent, vec![segment("alpha")]);
+        session.push_queued_input("first".to_string());
+        session.push_queued_input("second".to_string());
+        session.push_queued_input("third".to_string());
+
+        TranscriptWidget::new(&mut session).render(area, &mut buf);
+
+        // The queue is strict FIFO, so the overlay shows the oldest message at
+        // the top and the newest directly above the input field.
+        let overlay_rows: Vec<String> = (inner.y..inner.bottom())
+            .map(|row| row_text(&buf, inner, row))
+            .map(|text| text.trim().to_string())
+            .filter(|text| !text.is_empty())
+            .collect();
+        let first_row = overlay_rows.iter().position(|row| row.contains("first"));
+        let second_row = overlay_rows.iter().position(|row| row.contains("second"));
+        let third_row = overlay_rows.iter().position(|row| row.contains("third"));
+        assert!(
+            first_row.is_some() && second_row.is_some() && third_row.is_some(),
+            "all three queued items must be visible in the overlay, got: {overlay_rows:?}"
+        );
+        assert!(
+            first_row.unwrap() < second_row.unwrap() && second_row.unwrap() < third_row.unwrap(),
+            "expected FIFO order first < second < third, got: {overlay_rows:?}"
+        );
+    }
+
+    #[test]
+    fn render_queue_overlay_flattens_multiline_entries() {
+        let area = Rect::new(0, 0, 40, 8);
+        let inner = Rect::new(1, 1, 38, 6);
+        let mut buf = Buffer::empty(area);
+        let mut session = Session::new(InlineTheme::default(), None, 12);
+        session.push_line(InlineMessageKind::Agent, vec![segment("alpha")]);
+        session.push_queued_input("line one\nline two".to_string());
+
+        TranscriptWidget::new(&mut session).render(area, &mut buf);
+
+        let overlay_text: String = (inner.y..inner.bottom()).map(|row| row_text(&buf, inner, row)).collect();
+        assert!(
+            overlay_text.contains("line one") && overlay_text.contains("line two"),
+            "both lines of the queued entry must be visible, got: {overlay_text:?}"
+        );
+        assert!(
+            overlay_text.contains("⏎"),
+            "newlines must be flattened into a visible separator, got: {overlay_text:?}"
+        );
+    }
+
+    #[test]
     fn render_clears_stale_queue_overlay_rows_when_queue_is_removed() {
         let area = Rect::new(0, 0, 20, 6);
         let inner = Rect::new(1, 1, 18, 4);

--- a/crates/common/vtcode-commons/src/vtcode_paths.rs
+++ b/crates/common/vtcode-commons/src/vtcode_paths.rs
@@ -28,7 +28,14 @@ struct NativeRoots {
 }
 
 fn native_roots(
-    #[cfg_attr(not(any(target_os = "macos", target_os = "windows")), allow(unused_variables))] home_dir: &Path,
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "windows")),
+        allow(
+            unused_variables,
+            reason = "home_dir is only consumed by macOS/Windows root resolution"
+        )
+    )]
+    home_dir: &Path,
 ) -> Result<NativeRoots> {
     #[cfg(target_os = "macos")]
     {

--- a/docs/user-guide/interactive-mode.md
+++ b/docs/user-guide/interactive-mode.md
@@ -32,7 +32,7 @@ The VT Code terminal UI includes an interactive mode that combines keyboard-firs
 | `Esc` + `Esc`                               | Open the rewind picker for checkpoint restore or summarize actions.             | Idle context only (while no task/PTY is running).                                                                                         |
 | `Enter`                                     | Queue the current input.                                                        | Plain input box only.                                                                                                                     |
 | `Tab`                                       | Accept the visible inline suggestion; on an empty idle composer, cycle primary agents; otherwise queue the current input. | Plain input box only. Disabled while a turn is processing (shows a notice). |
-| `Ctrl+Enter`                                | Process now or steer now.                                                       | Idle: runs the current draft, or the newest queued message if the draft is empty. Active: steers the current turn with the current draft. |
+| `Ctrl+Enter`                                | Queue the current draft (batchable).                                              | Idle: submits the current draft immediately (or the newest queued message if the draft is empty). Active: joins the visible queue; consecutive text-only messages are batched into one turn. `/stop`, `/pause`, and `/resume` are handled immediately instead of being queued. |
 | `Shift+Tab` or `Alt+M`                      | Cycle primary agents.                                                           | Switches between available main-session agents. Disabled while a turn is processing (shows a notice). |
 
 ### Multiline Input
@@ -102,6 +102,8 @@ Press `Alt+O` to open the fullscreen transcript review surface. It builds a plai
 
 - `ui.fullscreen.mouse_capture = false` keeps fullscreen rendering but returns click-and-drag selection to the terminal. This also disables in-app wheel scrolling, click-to-expand, click-to-position, and link activation.
 - `ui.fullscreen.copy_on_select = false` disables automatic clipboard copy after an in-app text selection. Manual copy shortcuts still work.
+- Copying prefers native clipboard helpers (`pbcopy` on macOS, `xclip`/`xsel`/`wl-copy` on Linux, `clip.exe` on Windows) and falls back to the OSC 52 escape sequence. When no strategy succeeds, the input status row shows a `Copy failed` notice instead of a false success.
+- Dragging a selection to the top or bottom edge of the transcript auto-scrolls it, extending the selection onto newly revealed lines.
 - `ui.fullscreen.scroll_speed` multiplies mouse-wheel scrolling without affecting `PgUp`/`PgDn`.
 - Inside tmux, enable mouse support with `set -g mouse on` if you want wheel scrolling and other mouse actions to reach VT Code.
 - Avoid fullscreen rendering in `tmux -CC` sessions. iTerm2's control-mode integration does not handle alternate-screen mouse capture reliably.
@@ -158,10 +160,11 @@ VT Code supports an optional Vim-style prompt editor.
 
 ## Active Run Steering
 
-When a task is already running, VT Code keeps the active turn alive and lets you steer it:
+When a task is already running, VT Code keeps the active turn alive and lets you queue or steer input:
 
-- `Enter` and `Tab` queue the current input for later processing.
-- `Ctrl+Enter` sends the current draft to the active run as steering text.
+- `Enter` and `Tab` queue the current input for later processing; queued messages dispatch one per turn in FIFO order.
+- `Ctrl+Enter` queues the current draft as a *batchable* message. Consecutive text-only Ctrl+Enter messages queued while a turn runs are joined into a single combined prompt for the next turn. Slash commands other than `/stop`, `/pause`, and `/resume` are queued non-batchable so their intent is preserved; `/stop`, `/pause`, and `/resume` take effect immediately instead of being queued.
+- Queued inputs appear in an overlay above the composer in FIFO order (oldest on top, newest directly above the input). `Shift+Left` (tmux) or `Alt+Up` pops the newest queued message back into the composer for editing. Up to five messages are shown, plus a `+N more queued` line when more are pending.
 - `/pause` pauses the active run at the next model/tool/approval boundary.
 - `/resume` resumes a paused run while it is active. When idle, `/resume` still opens archived sessions.
 - `/stop` still cancels the active run immediately.

--- a/src/agent/runloop/unified/inline_events/context.rs
+++ b/src/agent/runloop/unified/inline_events/context.rs
@@ -133,6 +133,9 @@ impl<'a> InlineEventContext<'a> {
                     self.modal.restore_input_draft(input);
                     InlineLoopAction::Continue
                 } else {
+                    // The TUI echoes accepted steering inputs immediately; the
+                    // queued intent is consumed via the steering channel and
+                    // applied when the current turn completes.
                     self.input_processor().passive()
                 }
             }

--- a/src/agent/runloop/unified/inline_events/driver.rs
+++ b/src/agent/runloop/unified/inline_events/driver.rs
@@ -128,8 +128,46 @@ impl<'a> InlineEventLoop<'a> {
             return Ok(action);
         }
 
+        // Consume every already-buffered event BEFORE taking a submission.
+        // Otherwise each queued message dispatched as its own turn because
+        // buffered events trickled in one per interaction cycle and the queue
+        // never held more than a single item at a boundary. Queue-affecting
+        // events return Continue so the drain keeps folding them into the
+        // queue; the first real action (direct submit, exit, …) dispatches
+        // immediately and stops the drain. A transient processing error is
+        // recorded but does not abandon the remaining buffered events; it is
+        // surfaced only after the drain finishes.
+        let mut drain_error = None;
+        while let Ok(event) = session.events.try_recv() {
+            match self.process_buffered_event(event).await {
+                Ok(InlineLoopAction::Continue) => {}
+                Ok(action) => {
+                    if let Some(err) = drain_error {
+                        tracing::error!(error = %err, "inline event processing failed earlier in the drain; dispatching action anyway");
+                    }
+                    return Ok(action);
+                }
+                Err(err) => {
+                    if drain_error.is_none() {
+                        tracing::warn!(error = %err, "inline event processing failed; draining remaining buffered events");
+                    }
+                    drain_error.get_or_insert(err);
+                }
+            }
+        }
+        if let Some(err) = drain_error {
+            return Err(err);
+        }
+
         if let Some(action) = self.take_queued_submission() {
             return Ok(action);
+        }
+
+        // If the TUI event stream has been dropped the session cannot produce
+        // further input; polling would spin a 100% CPU busy-loop because
+        // next_event() resolves to None instantly on a closed channel. Exit.
+        if session.events.is_closed() {
+            return Ok(InlineLoopAction::Exit(vtcode_core::hooks::SessionEndReason::Exit));
         }
 
         let maybe_event = tokio::select! {
@@ -166,6 +204,10 @@ impl<'a> InlineEventLoop<'a> {
             return Ok(InlineLoopAction::Continue);
         };
 
+        self.process_buffered_event(event).await
+    }
+
+    async fn process_buffered_event(&mut self, event: InlineEvent) -> Result<InlineLoopAction> {
         if let InlineEvent::Submit(ref input) = event {
             if !input.is_empty() {
                 self.emit_interjected(InterjectionSource::Direct, Self::count_images(input));
@@ -248,7 +290,7 @@ impl<'a> InlineEventLoop<'a> {
     }
 
     fn take_queued_submission(&mut self) -> Option<InlineLoopAction> {
-        let queued = self.queue.take_next_submission()?;
+        let queued = self.queue.take_batched_submission()?;
         if queued.input.is_empty() {
             return Some(InlineLoopAction::Continue);
         }
@@ -437,7 +479,7 @@ mod tests {
     #[tokio::test]
     async fn poll_inline_loop_action_respects_idle_wake_delay() {
         let (command_tx, _command_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (_event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<InlineEvent>();
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<InlineEvent>();
         let handle = InlineHandle::new_for_tests(command_tx);
         let mut session = InlineSession { handle: handle.clone(), events: event_rx };
         let mut renderer = AnsiRenderer::with_inline_ui(handle.clone(), Default::default());
@@ -499,5 +541,70 @@ mod tests {
         .expect("poll should succeed");
 
         assert!(matches!(action, InlineLoopAction::Continue));
+        drop(event_tx);
+    }
+
+    #[tokio::test]
+    async fn poll_inline_loop_action_exits_when_event_stream_is_closed() {
+        let (command_tx, _command_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<InlineEvent>();
+        drop(event_tx); // drop the sender so the stream is closed from the start
+        let handle = InlineHandle::new_for_tests(command_tx);
+        let mut session = InlineSession { handle: handle.clone(), events: event_rx };
+        let mut renderer = AnsiRenderer::with_inline_ui(handle.clone(), Default::default());
+        let ctrl_c_state = Arc::new(CtrlCState::new());
+        let interrupts = InlineInterruptCoordinator::new(ctrl_c_state.as_ref());
+        let mut ctrl_c_notice_displayed = false;
+        let default_placeholder = None;
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_queued_input_once = false;
+        let mut model_picker_state = None;
+        let mut palette_state = None;
+        let mut config = runtime_config();
+        let mut vt_cfg = None;
+        let mut provider_client: Box<dyn uni::LLMProvider> = Box::new(DummyProvider);
+        let session_bootstrap = SessionBootstrap::default();
+        let mut startup_update_notice_rx = None;
+        let mut header_context = InlineHeaderContext::default();
+        let ctrl_c_notify = Arc::new(Notify::new());
+        let (editor_open_sender, _editor_open_receiver) =
+            crate::agent::runloop::unified::session_setup::bounded_editor_open_requests();
+
+        let resources = InlineEventLoopResources {
+            renderer: &mut renderer,
+            handle: &handle,
+            interrupts,
+            ctrl_c_notice_displayed: &mut ctrl_c_notice_displayed,
+            default_placeholder: &default_placeholder,
+            queued_inputs: &mut queued_inputs,
+            prefer_latest_queued_input_once: &mut prefer_latest_queued_input_once,
+            model_picker_state: &mut model_picker_state,
+            palette_state: &mut palette_state,
+            config: &mut config,
+            vt_cfg: &mut vt_cfg,
+            provider_client: &mut provider_client,
+            session_bootstrap: &session_bootstrap,
+            full_auto: false,
+            startup_update_notice_rx: &mut startup_update_notice_rx,
+            header_context: &mut header_context,
+            use_unicode: true,
+            conversation_history: &mut Vec::new(),
+            session_stats: &mut SessionStats::default(),
+            context_manager: &mut ContextManager::default_for_test(),
+            session_id: "test-session",
+            thread_id: "test-thread",
+            lifecycle_hooks: None,
+            harness_emitter: None,
+            editor_open_sender: &editor_open_sender,
+            idle_wake_delay: Duration::from_millis(5),
+            ctrl_c_state: &ctrl_c_state,
+            ctrl_c_notify: &ctrl_c_notify,
+        };
+
+        let action = poll_inline_loop_action(&mut session, &ctrl_c_notify, resources)
+            .await
+            .expect("poll should succeed");
+
+        assert!(matches!(action, InlineLoopAction::Exit(_)), "a closed event stream must exit rather than spin");
     }
 }

--- a/src/agent/runloop/unified/inline_events/queue.rs
+++ b/src/agent/runloop/unified/inline_events/queue.rs
@@ -6,11 +6,15 @@ use vtcode_ui::tui::app::{InlineHandle, SubmittedInput};
 pub(crate) struct QueuedInput {
     pub(crate) input: SubmittedInput,
     pub(crate) primary_agent: Option<String>,
+    /// Only Ctrl+Enter submissions are batchable; plain Enter queued while
+    /// busy must dispatch as its own turn.
+    pub(crate) batchable: bool,
 }
 
 impl QueuedInput {
     pub(crate) fn new(input: SubmittedInput, primary_agent: Option<String>) -> Self {
         Self {
+            batchable: input.batchable,
             input,
             primary_agent: primary_agent.filter(|name| !name.trim().is_empty()),
         }
@@ -41,7 +45,6 @@ impl<'a> InlineQueueState<'a> {
 
     pub(crate) fn push(&mut self, input: SubmittedInput, primary_agent: Option<String>) {
         self.queued_inputs.push_back(QueuedInput::new(input, primary_agent));
-        *self.prefer_latest_once = true;
         self.sync_handle_queue();
     }
 
@@ -54,6 +57,63 @@ impl<'a> InlineQueueState<'a> {
         };
         self.sync_handle_queue();
         result
+    }
+
+    /// Pop the next submission plus every following batchable text-only
+    /// submission for the same agent, joined into ONE combined prompt so
+    /// several queued Ctrl+Enter messages reach the model in a single turn
+    /// instead of one turn each. Non-batchable items (plain Enter, attachments,
+    /// agent changes) stop the batch and dispatch alone on their own turns.
+    pub(crate) fn take_batched_submission(&mut self) -> Option<QueuedInput> {
+        // A Ctrl+Enter "run the latest now" promotion must stay a single-turn
+        // dispatch: merging the newest item with older FIFO items would batch
+        // turns the user asked to run individually.
+        let promoted_latest = *self.prefer_latest_once;
+        let mut batch = self.take_next_submission()?;
+        // Only batchable (Ctrl+Enter) submissions coalesce, and never a
+        // submission carrying attachments — the association between an image
+        // and its message must stay intact. A plain Enter that reached the
+        // front must also dispatch alone and never absorb following items.
+        if !batch.batchable || promoted_latest || batch.input.has_attachments() {
+            tracing::debug!(
+                target: "vtcode_ui::queue",
+                batched_count = 1,
+                text_bytes = batch.input.text.len(),
+                "queue submission drained (single, non-batchable)"
+            );
+            self.sync_handle_queue();
+            return Some(batch);
+        }
+        let primary_agent = batch.primary_agent.clone();
+        let mut batched_count = 1usize;
+        const MAX_BATCH_ITEMS: usize = 32;
+        // Cap the combined prompt so a user hammering Ctrl+Enter hundreds of
+        // times cannot build one unbounded message.
+        const MAX_BATCH_BYTES: usize = 64 * 1024;
+        while batched_count < MAX_BATCH_ITEMS && batch.input.text.len() < MAX_BATCH_BYTES {
+            let Some(next) = self.queued_inputs.front() else {
+                break;
+            };
+            if !next.batchable || next.input.has_attachments() || next.primary_agent != primary_agent {
+                break;
+            }
+            let Some(next) = self.queued_inputs.pop_front() else {
+                break;
+            };
+            batched_count += 1;
+            if !batch.input.text.trim().is_empty() && !next.input.text.trim().is_empty() {
+                batch.input.text.push_str("\n\n");
+            }
+            batch.input.text.push_str(&next.input.text);
+        }
+        tracing::debug!(
+            target: "vtcode_ui::queue",
+            batched_count,
+            text_bytes = batch.input.text.len(),
+            "queue submission drained"
+        );
+        self.sync_handle_queue();
+        Some(batch)
     }
 
     pub(crate) fn prefer_latest_next(&mut self) {
@@ -86,7 +146,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn newest_submission_runs_once_then_queue_returns_to_fifo() {
+    fn pushes_drain_in_fifo_order() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let handle = InlineHandle::new_for_tests(tx);
         let mut queued_inputs = VecDeque::new();
@@ -97,9 +157,10 @@ mod tests {
         queue.push("second".into(), Some("build".to_string()));
         queue.push("third".into(), Some("review".to_string()));
 
-        assert_eq!(queue.take_next_submission().map(|queued| queued.input.text).as_deref(), Some("third"));
+        // The queue is strict FIFO: first queued runs first.
         assert_eq!(queue.take_next_submission().map(|queued| queued.input.text).as_deref(), Some("first"));
         assert_eq!(queue.take_next_submission().map(|queued| queued.input.text).as_deref(), Some("second"));
+        assert_eq!(queue.take_next_submission().map(|queued| queued.input.text).as_deref(), Some("third"));
     }
 
     #[test]
@@ -122,6 +183,168 @@ mod tests {
     }
 
     #[test]
+    fn take_batched_submission_joins_consecutive_batchable_items() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        for text in ["first", "second", "third"] {
+            queue.push(SubmittedInput::new(text, Vec::new()).batchable(), None);
+        }
+
+        // The queue is strict FIFO: queued order is preserved inside the batch.
+        let batched = queue.take_batched_submission().expect("batched submission");
+        assert_eq!(batched.input.text, "first\n\nsecond\n\nthird");
+        assert!(queue.take_batched_submission().is_none());
+    }
+
+    #[test]
+    fn take_batched_submission_stops_at_plain_enter_attachments_or_agent_change() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        queue.push("text one".into(), Some("planner".to_string()));
+        queue.push(
+            SubmittedInput::new("with image", vec![vtcode_ui::tui::app::ContentPart::image("img", "image/png")]),
+            None,
+        );
+        queue.push(SubmittedInput::new("text two", Vec::new()).batchable(), None);
+
+        // Strict FIFO: the planner-tagged plain-Enter item runs first alone,
+        // then the attachment item alone (it stops batching), then the
+        // batchable item alone because the queue behind it is already empty.
+        let planner_item = queue.take_batched_submission().expect("planner submission");
+        assert_eq!(planner_item.input.text, "text one");
+
+        let with_image = queue.take_batched_submission().expect("attachment submission");
+        assert_eq!(with_image.input.text, "with image");
+
+        let batched = queue.take_batched_submission().expect("last submission");
+        assert_eq!(batched.input.text, "text two");
+
+        assert!(queue.take_batched_submission().is_none());
+    }
+
+    #[test]
+    fn take_batched_submission_runs_plain_enter_items_as_their_own_turns() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        queue.push(SubmittedInput::new("batch me", Vec::new()).batchable(), None);
+        queue.push("plain enter one".into(), None);
+        queue.push("plain enter two".into(), None);
+
+        // Strict FIFO: the batchable item runs alone because the plain-Enter
+        // item behind it stops the batch, then each plain-Enter item runs as
+        // its own turn.
+        let first = queue.take_batched_submission().expect("first submission");
+        assert_eq!(first.input.text, "batch me");
+
+        let second = queue.take_batched_submission().expect("second submission");
+        assert_eq!(second.input.text, "plain enter one");
+
+        let third = queue.take_batched_submission().expect("third submission");
+        assert_eq!(third.input.text, "plain enter two");
+
+        assert!(queue.take_batched_submission().is_none());
+    }
+
+    #[test]
+    fn take_batched_submission_keeps_attachment_head_single() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        queue.push(
+            SubmittedInput::new("see image", vec![vtcode_ui::tui::app::ContentPart::image("img", "image/png")]),
+            None,
+        );
+        queue.push(SubmittedInput::new("follow-up", Vec::new()).batchable(), None);
+
+        // The attachment-carrying head must dispatch alone so the image stays
+        // associated with its message; the following batchable item may then
+        // run alone (nothing else behind it).
+        let first = queue.take_batched_submission().expect("attachment head");
+        assert_eq!(first.input.text, "see image");
+        assert!(first.input.has_attachments());
+
+        let second = queue.take_batched_submission().expect("follow-up");
+        assert_eq!(second.input.text, "follow-up");
+        assert!(queue.take_batched_submission().is_none());
+    }
+
+    #[test]
+    fn take_batched_submission_does_not_merge_after_prefer_latest_promotion() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        queue.push(SubmittedInput::new("first", Vec::new()).batchable(), None);
+        queue.push(SubmittedInput::new("second", Vec::new()).batchable(), None);
+        queue.push(SubmittedInput::new("third", Vec::new()).batchable(), None);
+
+        // Ctrl+Enter with empty input while idle promotes the newest item to
+        // run alone NOW; it must not absorb the older items into one batch.
+        queue.prefer_latest_next();
+        let promoted = queue.take_batched_submission().expect("promoted submission");
+        assert_eq!(promoted.input.text, "third");
+
+        // Remaining queue drains in strict FIFO inside one batch.
+        let batch = queue.take_batched_submission().expect("remaining batch");
+        assert_eq!(batch.input.text, "first\n\nsecond");
+        assert!(queue.take_batched_submission().is_none());
+    }
+
+    #[test]
+    fn take_batched_submission_skips_separator_for_whitespace_items() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        queue.push(SubmittedInput::new("first", Vec::new()).batchable(), None);
+        queue.push(SubmittedInput::new("   ", Vec::new()).batchable(), None);
+        queue.push(SubmittedInput::new("third", Vec::new()).batchable(), None);
+
+        let batch = queue.take_batched_submission().expect("batch");
+        // The whitespace-only item is still its own message: no separator is
+        // injected for it, but it must remain distinct from "third".
+        assert_eq!(batch.input.text, "first   \n\nthird");
+    }
+
+    #[test]
+    fn take_batched_submission_caps_batch_size() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = InlineHandle::new_for_tests(tx);
+        let mut queued_inputs = VecDeque::new();
+        let mut prefer_latest_once = false;
+        let mut queue = InlineQueueState::new(&handle, &mut queued_inputs, &mut prefer_latest_once);
+
+        // 100 batchable items must not become one unbounded prompt.
+        for i in 0..100 {
+            queue.push(SubmittedInput::new(format!("msg {i}"), Vec::new()).batchable(), None);
+        }
+
+        let batch = queue.take_batched_submission().expect("batch");
+        let item_count = batch.input.text.split("\n\n").count();
+        assert!(item_count <= 32, "batch must be capped, got {item_count} items");
+        assert!(queue.take_batched_submission().is_some(), "leftover items must still drain");
+    }
+
+    #[test]
     fn queued_input_keeps_primary_agent_captured_at_queue_time() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let handle = InlineHandle::new_for_tests(tx);
@@ -132,13 +355,13 @@ mod tests {
         queue.push("first".into(), Some("planner".to_string()));
         queue.push("second".into(), Some("builder".to_string()));
 
-        let latest = queue.take_next_submission().expect("latest queued input");
-        assert_eq!(latest.input.text, "second");
-        assert_eq!(latest.primary_agent.as_deref(), Some("builder"));
-
         let first = queue.take_next_submission().expect("first queued input");
         assert_eq!(first.input.text, "first");
         assert_eq!(first.primary_agent.as_deref(), Some("planner"));
+
+        let latest = queue.take_next_submission().expect("second queued input");
+        assert_eq!(latest.input.text, "second");
+        assert_eq!(latest.primary_agent.as_deref(), Some("builder"));
     }
 
     #[test]

--- a/src/agent/runloop/unified/inline_events/queue.rs
+++ b/src/agent/runloop/unified/inline_events/queue.rs
@@ -90,18 +90,25 @@ impl<'a> InlineQueueState<'a> {
         // Cap the combined prompt so a user hammering Ctrl+Enter hundreds of
         // times cannot build one unbounded message.
         const MAX_BATCH_BYTES: usize = 64 * 1024;
-        while batched_count < MAX_BATCH_ITEMS && batch.input.text.len() < MAX_BATCH_BYTES {
+        while batched_count < MAX_BATCH_ITEMS {
             let Some(next) = self.queued_inputs.front() else {
                 break;
             };
             if !next.batchable || next.input.has_attachments() || next.primary_agent != primary_agent {
                 break;
             }
+            // Cap the COMBINED prompt: merging `next` must not exceed the
+            // budget, otherwise one large queued message could overshoot it.
+            let needs_separator = !batch.input.text.trim().is_empty() && !next.input.text.trim().is_empty();
+            let merged_len = batch.input.text.len() + usize::from(needs_separator) * 2 + next.input.text.len();
+            if merged_len > MAX_BATCH_BYTES {
+                break;
+            }
             let Some(next) = self.queued_inputs.pop_front() else {
                 break;
             };
             batched_count += 1;
-            if !batch.input.text.trim().is_empty() && !next.input.text.trim().is_empty() {
+            if needs_separator {
                 batch.input.text.push_str("\n\n");
             }
             batch.input.text.push_str(&next.input.text);

--- a/src/agent/runloop/unified/turn/session/slash_commands/control.rs
+++ b/src/agent/runloop/unified/turn/session/slash_commands/control.rs
@@ -140,9 +140,12 @@ pub(crate) async fn handle_copy_latest_assistant_reply(ctx: SlashCommandContext<
     });
 
     if let Some(reply) = latest_reply {
-        vtcode_ui::tui::core::MouseSelectionState::copy_to_clipboard(&reply);
-        ctx.renderer
-            .line(MessageStyle::Info, "Copied latest assistant reply to clipboard.")?;
+        if vtcode_ui::tui::core::MouseSelectionState::copy_to_clipboard(&reply) {
+            ctx.renderer
+                .line(MessageStyle::Info, "Copied latest assistant reply to clipboard.")?;
+        } else {
+            ctx.renderer.line(MessageStyle::Warning, "Failed to copy to clipboard.")?;
+        }
     } else {
         ctx.renderer
             .line(MessageStyle::Warning, "No complete assistant reply found to copy yet.")?;

--- a/src/cli/auto.rs
+++ b/src/cli/auto.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -70,10 +69,16 @@ pub async fn handle_auto_task_command(
         return Ok(());
     }
 
-    let model_id = ModelId::from_str(&run_config.model).with_context(|| {
+    let model_id = ModelId::from_config(
+        &run_config.model,
+        &run_config.provider,
+        &run_vt_cfg.provider_overrides,
+        &run_vt_cfg.custom_providers,
+    )
+    .with_context(|| {
         format!(
             "Model '{}' is not recognized for autonomous execution. Update vtcode.toml to a \
-             supported identifier.",
+                     supported identifier.",
             run_config.model
         )
     })?;

--- a/src/cli/benchmark/run.rs
+++ b/src/cli/benchmark/run.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result, anyhow, bail};
-use std::str::FromStr;
 use vtcode_core::config::VTCodeConfig;
 use vtcode_core::config::models::ModelId;
 use vtcode_core::config::types::AgentConfig as CoreAgentConfig;
@@ -50,7 +49,13 @@ pub async fn handle_benchmark_command(
         }
     }
 
-    let model_id = ModelId::from_str(&config.model).with_context(|| {
+    let model_id = ModelId::from_config(
+        &config.model,
+        &config.provider,
+        &vt_cfg.provider_overrides,
+        &vt_cfg.custom_providers,
+    )
+    .with_context(|| {
         format!(
             "Model '{}' is not recognized for benchmark execution. Update vtcode.toml to a supported identifier.",
             config.model

--- a/src/cli/exec/eval.rs
+++ b/src/cli/exec/eval.rs
@@ -8,7 +8,6 @@
 use crate::startup::require_full_auto_workspace_trust;
 use anyhow::{Context, Result, bail};
 use std::path::Path;
-use std::str::FromStr;
 use std::time::Instant;
 use vtcode_core::cli::input_hardening::validate_agent_safe_text;
 use vtcode_core::config::VTCodeConfig;
@@ -110,7 +109,12 @@ async fn run_eval_task(
         return eval_error(&eval_task.id, start, format!("Prompt validation failed: {e}"));
     }
 
-    let model_id = match ModelId::from_str(&config.model) {
+    let model_id = match ModelId::from_config(
+        &config.model,
+        &config.provider,
+        &vt_cfg.provider_overrides,
+        &vt_cfg.custom_providers,
+    ) {
         Ok(id) => id,
         Err(e) => return eval_error(&eval_task.id, start, format!("Model not recognized: {e}")),
     };

--- a/src/cli/exec/prep.rs
+++ b/src/cli/exec/prep.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result, bail};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use vtcode_core::cli::args::{ExecResumeArgs, ExecSubcommand};
 use vtcode_core::cli::input_hardening::validate_agent_safe_text;
 use vtcode_core::config::VTCodeConfig;
@@ -167,7 +166,13 @@ pub(super) async fn prepare_exec_run(
         bail!("Automation is disabled in configuration. Enable [automation.full_auto] to continue.");
     }
 
-    let model_id = ModelId::from_str(&run_config.model).with_context(|| {
+    let model_id = ModelId::from_config(
+        &run_config.model,
+        &run_config.provider,
+        &run_vt_cfg.provider_overrides,
+        &run_vt_cfg.custom_providers,
+    )
+    .with_context(|| {
         format!(
             "Model '{}' is not recognized for exec command. Update vtcode.toml to a supported identifier.",
             run_config.model

--- a/src/process_hardening.rs
+++ b/src/process_hardening.rs
@@ -18,7 +18,7 @@ use nix::sys::resource::{RLIM_INFINITY, Resource, getrlimit, setrlimit};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn prctl_set_dumpable() -> std::io::Result<()> {
-    prctl::set_dumpable(false).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")))
+    prctl::set_dumpable(false).map_err(|e| std::io::Error::other(format!("{e}")))
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Description

Two independent lines of work on one branch: (A) interactive TUI quality-of-life
improvements, and (B) fixes that make custom providers usable in non-interactive
commands (`exec`, `--auto`, `benchmark`, `exec eval`) — parity with what already
worked interactively.

### B. Custom-provider fixes (motivation & context)

**Explicit config files dropped global layers.** Both `--config <file>` and
`VTCODE_CONFIG_PATH` are documented as an explicit layer that *retains* global
layers (see `docs/config/CONFIGURATION_PRECEDENCE.md`). In practice the loader
derived the global config filename from the override file's basename: passing
`/tmp/night.toml` probed for `~/.config/vtcode/night.toml`, found nothing, and
silently dropped every global setting — including `[[custom_providers]]`:

```
VTCODE_CONFIG_PATH=/tmp/night.toml vtcode exec ...
# Error: Unknown provider 'zen-free'
```

Global layer probing now always uses the canonical config file name; the explicit
file only replaces the workspace-file layer, matching the documented behavior.

**Non-interactive commands rejected custom-provider models.** `exec`/`auto`/
`benchmark`/`eval` gated the model through `ModelId::from_str` alone, rejecting
any identifier outside the static catalog even when declared for the active
provider, while the same model worked fine in interactive sessions:

```
vtcode exec --provider zen-free --model x-preview-f-free "hi"
# Error: Invalid model identifier: 'x-preview-f-free'. Supported models: [...]
```

New `ModelId::from_config` resolves the static catalog first, then does
provider-scoped lookups in `[providers.<name>].models` and
`[[custom_providers]].models` (as `ModelId::Custom`), mirroring the existing
subagent resolution path (`subagents/model.rs`). All four CLI paths now use it;
catalog IDs resolve exactly as before.

### A. Interactive UX

- **Clipboard robustness**: native helper failures are surfaced instead of
  swallowed; stdin writes are bounded so a stuck `xclip`/`wl-copy` can never
  stall the UI thread; timed-out fork-and-hold helpers are reaped on a detached
  thread (no zombie processes); a short grace drain after helper exit prevents a
  concurrent write failure from being reported as success.
- **Ctrl+Enter queue batching**: consecutive queued Ctrl+Enter messages for the
  same agent coalesce into one combined prompt per turn instead of one turn each.
  Plain Enter, attachments, agent switches and promote-latest break the batch;
  caps at 32 items / 64 KB combined prompt (checked against the combined size).
- **Editing & selection**: transcript auto-scroll while drag-selecting beyond the
  viewport, UTF-8-safe editing operations (word ops/transpose respect char
  boundaries), paste-block delete (one Backspace after a collapsed multi-line
  paste removes the whole block; selection still wins). `compact_paste_range`
  stays aligned across all mutators, including word-forward delete.

No upstream issue filed yet — happy to split this PR or open issues per bug if
preferred.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] This change requires a documentation update (`docs/user-guide/interactive-mode.md` updated)

## How Has This Been Tested?

- [x] Rust tests: `cargo nextest run` (repo-preferred runner per CONTRIBUTING):
      `vtcode-ui` 891 passed · `vtcode-config` 408 passed · inline_events/exec
      suites passed; new tests cover batch caps and break conditions, clipboard
      failure paths, paste-range shift/clear invariants (regression tests verified
      to fail pre-fix), global-layer merge with non-canonical override basenames,
      and `from_config` acceptance/rejection
- [x] Linting: `cargo clippy --all-targets` clean under `-D warnings`
      (incl. two lint fixes: `cloned_ref_to_slice_refs`, pre-existing
      `float_cmp` in an f32 round-trip test)
- [x] Formatting: `cargo fmt --all`
- [x] Build: `cargo build`

**Test Configuration**:
* Rust version: 1.93.0 (254b59607 2026-01-19)
* Operating system: Linux x86_64
* Toolchain: stable, `--locked`

Manual verification of the original repro: with a global
`[[custom_providers]] zen-free` profile and a minimal `/tmp/night.toml` override,
`VTCODE_CONFIG_PATH=/tmp/night.toml vtcode exec --json --provider zen-free
--model x-preview-f-free "hi"` now reaches planning (`thread.started →
turn.started`) instead of failing with `Unknown provider 'zen-free'`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code (3 iterative review passes over the branch diff)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)
- [x] CHANGELOG.md — auto-generated via git-cliff from Conventional Commits; all commits follow the spec

## Additional Context

- Commit subjects kept ≤72 chars where newly authored; the four earlier UI commits
  were pushed previously and are included as-is.
- Full local suite has several environment-sensitive failures (pty/persistent-memory/
  hooks) that reproduce identically on clean `upstream/main` on this machine — they
  pass in isolation and are unrelated to these changes.
