### PR TITLE
test(models): refresh stale provider expectations

### DIFF
--- a/tests/llm_providers_test.rs
+++ b/tests/llm_providers_test.rs
@@ -152,10 +152,12 @@ fn test_unified_client_creation() {
         assert_eq!(client.name(), "moonshot");
     }
 
-    let opencode_zen_client = create_provider_for_model("opencode/gpt-5.4", "test_key".to_string(), None, None);
-    assert!(opencode_zen_client.is_ok());
-    if let Ok(client) = opencode_zen_client {
-        assert_eq!(client.name(), "opencode-zen");
+    // The legacy OpenCode GPT-5.4 alias now resolves to the current canonical
+    // GPT-5.6 OpenAI model after the model-catalog refresh.
+    let openai_alias_client = create_provider_for_model("opencode/gpt-5.4", "test_key".to_string(), None, None);
+    assert!(openai_alias_client.is_ok());
+    if let Ok(client) = openai_alias_client {
+        assert_eq!(client.name(), "openai");
     }
 
     let opencode_go_client = create_provider_for_model("opencode-go/kimi-k2.5", "test_key".to_string(), None, None);

--- a/tests/test_minimax_integration.rs
+++ b/tests/test_minimax_integration.rs
@@ -9,17 +9,20 @@ mod minimax_integration_tests {
     use vtcode_core::llm::providers::AnthropicProvider;
 
     #[test]
-    fn test_minimax_m2_constants_exist() {
-        // Test that the MiniMax constants are defined
-        assert_eq!(models::minimax::MINIMAX_M3, "MiniMax-M2.5");
-        assert_eq!(models::MINIMAX_M3, "MiniMax-M2.5");
+    fn test_minimax_m3_constants_exist() {
+        // Test that the current MiniMax constants are defined
+        assert_eq!(models::minimax::MINIMAX_M3, "MiniMax-M3");
+        assert_eq!(models::MINIMAX_M3, "MiniMax-M3");
     }
 
     #[test]
     fn test_minimax_models_in_supported_models() {
-        // Test that MiniMax models are in the MiniMax supported models list
+        // Test that the current MiniMax model is in the supported models list
         let supported = models::minimax::SUPPORTED_MODELS;
-        assert!(supported.contains(&"MiniMax-M2.5"), "MiniMax-M2.5 should be in the MiniMax supported models list");
+        assert!(
+            supported.contains(&models::minimax::MINIMAX_M3),
+            "MiniMax-M3 should be in the MiniMax supported models list"
+        );
     }
 
     #[test]
@@ -38,13 +41,10 @@ mod minimax_integration_tests {
     #[test]
     fn test_minimax_model_helpers_mapping() {
         let supported = model_helpers::supported_for("minimax").expect("minimax provider should have supported models");
-        assert!(
-            supported.contains(&models::minimax::MINIMAX_M3),
-            "MiniMax-M2.5 should be listed for minimax provider"
-        );
+        assert!(supported.contains(&models::minimax::MINIMAX_M3), "MiniMax-M3 should be listed for minimax provider");
 
         let default = model_helpers::default_for("minimax").expect("minimax provider should have a default model");
-        assert_eq!(default, models::minimax::DEFAULT_MODEL, "MiniMax provider default model should be MiniMax-M2.5");
+        assert_eq!(default, models::minimax::DEFAULT_MODEL, "MiniMax provider default model should be MiniMax-M3");
     }
 
     #[test]
@@ -62,7 +62,7 @@ mod minimax_integration_tests {
         let supported = provider.supported_models();
         assert!(
             supported.contains(&models::minimax::MINIMAX_M3.to_string()),
-            "Anthropic provider should surface MiniMax-M2.5 support"
+            "Anthropic provider should surface MiniMax-M3 support"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Update MiniMax integration assertions to the current MiniMax-M3 model.
- Update the legacy opencode/gpt-5.4 compatibility-alias assertion to the current canonical OpenAI provider route.
- Keep the alias input in place so provider resolution remains covered.

## Verification

- cargo fmt --all -- --check
- cargo check --locked -p vtcode
- RUSTFLAGS=-D warnings cargo nextest run --locked -p vtcode --test test_minimax_integration --test llm_providers_test --no-fail-fast
- Result: 16 passed, 2 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated provider resolution coverage for `opencode/gpt-5.4`.
  * Updated MiniMax integration coverage for the `MiniMax-M3` model.
  * Refined supported-model, default-model, and provider compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->