### PR TITLE
fix(config): keep --config / VTCODE_CONFIG_PATH active for the whole session

### DIFF
--- a/crates/codegen/vtcode-config/src/lib.rs
+++ b/crates/codegen/vtcode-config/src/lib.rs
@@ -120,8 +120,8 @@ pub use loader::layers::{
 };
 pub use loader::{
     ConfigBuilder, ConfigManager, ConfigWatcher, FeaturesConfig, SimpleConfigWatcher, SyntaxHighlightingConfig,
-    VTCodeConfig, WorkspaceConfig, fingerprint_str, fingerprint_toml_value, merge_toml_values,
-    merge_toml_values_with_origins,
+    VTCodeConfig, WorkspaceConfig, explicit_config_path, fingerprint_str, fingerprint_toml_value, merge_toml_values,
+    merge_toml_values_with_origins, set_explicit_config_path,
 };
 pub use mcp::{
     McpAllowListConfig, McpAllowListRules, McpClientConfig, McpHttpServerConfig, McpLifecycleConfig, McpProviderConfig,

--- a/crates/codegen/vtcode-config/src/loader/manager.rs
+++ b/crates/codegen/vtcode-config/src/loader/manager.rs
@@ -259,6 +259,17 @@ impl ConfigManager {
         let _ = workspace;
     }
 
+    /// Invalidate every cached workspace configuration.
+    ///
+    /// Used when a session-scoped override changes or is cleared: the cache is
+    /// keyed by canonical workspace only, so an override-loaded manager for any
+    /// workspace must not leak into later default loads. This is a rare event
+    /// (startup and tests), so a full sweep is cheap and safe.
+    pub fn invalidate_all_workspace_cache() {
+        #[cfg(not(test))]
+        with_cache_mut(|map| map.clear());
+    }
+
     /// Load configuration from a specific workspace
     ///
     /// When the session has an explicit config-file override (captured at

--- a/crates/codegen/vtcode-config/src/loader/manager.rs
+++ b/crates/codegen/vtcode-config/src/loader/manager.rs
@@ -12,6 +12,7 @@ use crate::loader::config::VTCodeConfig;
 use crate::loader::layers::{
     ConfigLayerEntry, ConfigLayerMetadata, ConfigLayerSource, ConfigLayerStack, LayerDisabledReason,
 };
+use crate::loader::session_override;
 use vtcode_commons::VtCodePaths;
 use vtcode_commons::canonicalize;
 
@@ -50,7 +51,7 @@ fn cache_remove(workspace: &Path) {
     });
 }
 
-fn canonicalize_workspace_root(path: &Path) -> PathBuf {
+pub(crate) fn canonicalize_workspace_root(path: &Path) -> PathBuf {
     canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
@@ -124,15 +125,49 @@ pub struct ConfigManager {
 impl ConfigManager {
     /// Load configuration from the default locations rooted at the current directory.
     pub fn load() -> Result<Self> {
-        if let Ok(config_path) = std::env::var("VTCODE_CONFIG_PATH") {
-            let trimmed = config_path.trim();
-            if !trimmed.is_empty() {
-                return Self::load_from_file_impl(trimmed, true)
-                    .with_context(|| format!("Failed to load configuration from VTCODE_CONFIG_PATH={trimmed}"));
-            }
+        if let Some(override_path) = session_override::explicit_config_path() {
+            return Self::load_for_session(std::env::current_dir()?, &override_path).with_context(|| {
+                format!("Failed to load configuration from explicit path {}", override_path.display())
+            });
         }
 
         Self::load_from_workspace(std::env::current_dir()?)
+    }
+
+    /// Load configuration for an interactive session with an explicit config file.
+    ///
+    /// The explicit file takes the highest file-layer precedence (the same
+    /// position a workspace root `vtcode.toml` would occupy), while the
+    /// system/user global layers are still loaded underneath it. Unlike
+    /// [`Self::load_from_file`], the manager's `workspace_root` remains the
+    /// session workspace (not the explicit file's parent directory), so
+    /// workspace-relative config writes and project-level paths keep
+    /// resolving against the workspace.
+    pub fn load_for_session(workspace: impl AsRef<Path>, explicit_path: impl AsRef<Path>) -> Result<Self> {
+        let workspace = workspace.as_ref();
+        let explicit_path = explicit_path.as_ref();
+        #[cfg(not(test))]
+        let canonical_workspace = canonicalize_workspace_root(workspace);
+
+        #[cfg(not(test))]
+        if let Some(cached) = cache_get(&canonical_workspace) {
+            return Ok(cached.as_ref().clone());
+        }
+
+        let mut manager = Self::load_from_file_impl(explicit_path, false).with_context(|| {
+            format!(
+                "Failed to load explicit session config file {} (from --config / VTCODE_CONFIG_PATH)",
+                explicit_path.display()
+            )
+        })?;
+        // The session workspace, not the explicit file's parent, anchors
+        // workspace-relative config resolution for the rest of the session.
+        manager.workspace_root = Some(canonicalize_workspace_root(workspace));
+
+        #[cfg(not(test))]
+        cache_insert(canonical_workspace, Arc::new(manager.clone()));
+
+        Ok(manager)
     }
 
     /// Load only the system and user configuration layers.
@@ -225,7 +260,16 @@ impl ConfigManager {
     }
 
     /// Load configuration from a specific workspace
+    ///
+    /// When the session has an explicit config-file override (captured at
+    /// startup via [`session_override::set_explicit_config_path`]), the
+    /// override file takes precedence and is loaded as the highest file
+    /// layer above the default global layers.
     pub fn load_from_workspace(workspace: impl AsRef<Path>) -> Result<Self> {
+        if let Some(override_path) = session_override::explicit_config_path() {
+            return Self::load_for_session(workspace, override_path);
+        }
+
         let workspace = workspace.as_ref();
         #[cfg(not(test))]
         let canonical_workspace = canonicalize_workspace_root(workspace);
@@ -616,6 +660,25 @@ impl ConfigManager {
     /// Get the active workspace root for this manager.
     pub fn workspace_root(&self) -> Option<&Path> {
         self.workspace_root.as_deref()
+    }
+
+    /// Resolve the workspace-level config file this manager reads from, i.e.
+    /// the highest enabled `Workspace` layer.
+    ///
+    /// With a session-explicit config file (`--config` / `VTCODE_CONFIG_PATH`)
+    /// that layer is the override file itself, so config writes land where the
+    /// session actually reads from. Falls back to `<workspace>/<config_file_name>`
+    /// when no workspace layer is present.
+    pub fn preferred_workspace_config_path(&self, workspace: &Path) -> PathBuf {
+        self.layer_stack
+            .layers()
+            .iter()
+            .rev()
+            .find_map(|layer| match &layer.source {
+                ConfigLayerSource::Workspace { file } if layer.is_enabled() => Some(file.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| workspace.join(&self.config_file_name))
     }
 
     /// Get the config filename used by this manager (usually `vtcode.toml`).

--- a/crates/codegen/vtcode-config/src/loader/mod.rs
+++ b/crates/codegen/vtcode-config/src/loader/mod.rs
@@ -8,6 +8,7 @@ mod config;
 mod fingerprint;
 mod manager;
 mod merge;
+pub(crate) mod session_override;
 mod syntax_highlighting;
 
 #[cfg(test)]
@@ -18,5 +19,6 @@ pub use config::{FeaturesConfig, ProviderConfig, VTCodeConfig, WorkspaceConfig};
 pub use fingerprint::{fingerprint_str, fingerprint_toml_value};
 pub use manager::{ConfigManager, ConfigPhaseTiming};
 pub use merge::{merge_toml_values, merge_toml_values_with_origins};
+pub use session_override::{explicit_config_path, set_explicit_config_path};
 pub use syntax_highlighting::SyntaxHighlightingConfig;
 pub use watch::{ConfigWatcher, SimpleConfigWatcher};

--- a/crates/codegen/vtcode-config/src/loader/session_override.rs
+++ b/crates/codegen/vtcode-config/src/loader/session_override.rs
@@ -1,0 +1,74 @@
+//! Process-wide explicit config-file override for a session.
+//!
+//! When the user launches vtcode with `--config PATH` or
+//! `VTCODE_CONFIG_PATH`, every later configuration reload must honor that
+//! explicit file instead of silently drifting back to the default layer
+//! hierarchy. The resolved path is captured once during startup and stored
+//! here as a session snapshot, so runtime reloads via
+//! [`ConfigManager::load_from_workspace`] stay deterministic.
+//!
+//! Runtime reloads must re-read the environment; the snapshot keeps reloads
+//! deterministic and matches `--config` behavior.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+use super::manager::ConfigManager;
+
+static EXPLICIT_CONFIG_PATH: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+
+fn cell() -> &'static Mutex<Option<PathBuf>> {
+    EXPLICIT_CONFIG_PATH.get_or_init(|| Mutex::new(None))
+}
+
+/// Capture the session's explicit config-file override.
+///
+/// Called during startup after the CLI/env path has been resolved to an
+/// absolute file path. Passing `None` clears the override and invalidates the
+/// workspace config cache so subsequent loads return to the default layer
+/// hierarchy instead of a stale override-loaded manager.
+///
+/// This is process-global and intended to be set once per process at startup;
+/// changing it mid-session is supported for tests and reloads, but consumers
+/// must not race concurrent calls.
+pub fn set_explicit_config_path(path: Option<PathBuf>) {
+    {
+        let mut guard = cell().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = path;
+    }
+    // A cleared or changed override must not leave a stale manager in the
+    // workspace cache: the cache key is the canonical workspace only, so an
+    // override-loaded manager would otherwise leak into later default loads.
+    if let Ok(cwd) = std::env::current_dir() {
+        ConfigManager::invalidate_workspace_cache(cwd);
+    }
+}
+
+/// Return the session's explicit config-file override, if one was captured.
+pub fn explicit_config_path() -> Option<PathBuf> {
+    let guard = cell().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.clone()
+}
+
+/// RAII helper for tests: set an override and restore the previous value on drop.
+#[cfg(test)]
+pub(crate) struct ExplicitConfigPathGuard {
+    previous: Option<PathBuf>,
+}
+
+#[cfg(test)]
+impl ExplicitConfigPathGuard {
+    pub(crate) fn set(path: Option<PathBuf>) -> Self {
+        let previous = explicit_config_path();
+        set_explicit_config_path(path);
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ExplicitConfigPathGuard {
+    fn drop(&mut self) {
+        set_explicit_config_path(self.previous.take());
+    }
+}

--- a/crates/codegen/vtcode-config/src/loader/session_override.rs
+++ b/crates/codegen/vtcode-config/src/loader/session_override.rs
@@ -7,8 +7,9 @@
 //! here as a session snapshot, so runtime reloads via
 //! [`ConfigManager::load_from_workspace`] stay deterministic.
 //!
-//! Runtime reloads must re-read the environment; the snapshot keeps reloads
-//! deterministic and matches `--config` behavior.
+//! Reloads reuse this stored snapshot rather than re-reading the
+//! environment, which keeps them deterministic and matches `--config`
+//! semantics.
 
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -39,10 +40,9 @@ pub fn set_explicit_config_path(path: Option<PathBuf>) {
     }
     // A cleared or changed override must not leave a stale manager in the
     // workspace cache: the cache key is the canonical workspace only, so an
-    // override-loaded manager would otherwise leak into later default loads.
-    if let Ok(cwd) = std::env::current_dir() {
-        ConfigManager::invalidate_workspace_cache(cwd);
-    }
+    // override-loaded manager would otherwise leak into later default loads
+    // for any workspace. Invalidate every entry.
+    ConfigManager::invalidate_all_workspace_cache();
 }
 
 /// Return the session's explicit config-file override, if one was captured.

--- a/crates/codegen/vtcode-config/src/loader/tests.rs
+++ b/crates/codegen/vtcode-config/src/loader/tests.rs
@@ -945,3 +945,127 @@ fn test_config_loader_phase_timing_recorded() {
             || timing.validation_us > 0
     );
 }
+
+#[test]
+#[serial]
+fn explicit_session_override_loads_requested_file_as_workspace_layer() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace dir");
+    let workspace_config = workspace.join("vtcode.toml");
+    fs::write(&workspace_config, "agent.provider = \"anthropic\"\n").expect("workspace config");
+
+    let override_path = temp.path().join("custom-night.toml");
+    fs::write(&override_path, "agent.provider = \"openai\"\n").expect("override config");
+
+    let _guard = session_override::ExplicitConfigPathGuard::set(Some(override_path.clone()));
+
+    let manager = ConfigManager::load_from_workspace(&workspace).expect("load with override");
+    assert_eq!(manager.config().agent.provider, "openai");
+    assert_eq!(manager.config_path(), Some(override_path.as_path()));
+    let workspace_files = manager
+        .layer_stack()
+        .layers()
+        .iter()
+        .filter_map(|layer| match &layer.source {
+            ConfigLayerSource::Workspace { file } => Some(file.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        workspace_files.iter().any(|file| file == &override_path),
+        "override file must appear as the Workspace layer: {workspace_files:?}"
+    );
+    assert_eq!(
+        manager.workspace_root(),
+        Some(canonicalize(&workspace).expect("canonical workspace").as_path()),
+        "session workspace_root must remain the workspace, not the override file's parent"
+    );
+}
+
+#[test]
+#[serial]
+fn explicit_session_override_without_override_falls_back_to_defaults() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let workspace = temp.path();
+    let workspace_config = workspace.join("vtcode.toml");
+    fs::write(&workspace_config, "agent.provider = \"anthropic\"\n").expect("workspace config");
+
+    let _guard = session_override::ExplicitConfigPathGuard::set(None);
+
+    let manager = ConfigManager::load_from_workspace(workspace).expect("load without override");
+    assert_eq!(manager.config().agent.provider, "anthropic");
+}
+
+#[test]
+#[serial]
+fn explicit_session_override_save_config_writes_override_file() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace dir");
+    let workspace_config = workspace.join("vtcode.toml");
+    fs::write(&workspace_config, "agent.provider = \"anthropic\"\n").expect("workspace config");
+
+    let override_path = temp.path().join("custom-night.toml");
+    fs::write(&override_path, "agent.provider = \"openai\"\n").expect("override config");
+
+    let _guard = session_override::ExplicitConfigPathGuard::set(Some(override_path.clone()));
+
+    let mut manager = ConfigManager::load_from_workspace(&workspace).expect("load with override");
+    let mut modified = manager.config().clone();
+    modified.ui.display_mode = crate::UiDisplayMode::Full;
+    manager.save_config(&modified).expect("save with override");
+
+    let saved = fs::read_to_string(&override_path).expect("read saved override file");
+    assert!(saved.contains("display_mode = \"full\""), "override file must receive the save. Got:\n{saved}");
+    let workspace_saved = fs::read_to_string(&workspace_config).expect("read workspace config");
+    assert_eq!(
+        workspace_saved, "agent.provider = \"anthropic\"\n",
+        "workspace config must stay untouched when an explicit override is active"
+    );
+}
+
+#[test]
+#[serial]
+fn explicit_session_override_survives_cache_invalidation() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let workspace = temp.path();
+
+    let override_path = temp.path().join("custom-night.toml");
+    fs::write(&override_path, "agent.provider = \"openai\"\n").expect("override config");
+
+    let _guard = session_override::ExplicitConfigPathGuard::set(Some(override_path.clone()));
+
+    let first = ConfigManager::load_from_workspace(workspace).expect("first load");
+    assert_eq!(first.config().agent.provider, "openai");
+
+    fs::write(&override_path, "agent.provider = \"anthropic\"\n").expect("rewrite override config");
+    ConfigManager::invalidate_workspace_cache(workspace);
+
+    let second = ConfigManager::load_from_workspace(workspace).expect("reload after invalidate");
+    assert_eq!(
+        second.config().agent.provider,
+        "anthropic",
+        "reload must re-read the override file after cache invalidation"
+    );
+}
+
+#[test]
+#[serial]
+fn explicit_session_override_file_with_use_root_config_drops_lower_layers() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace dir");
+    let workspace_config = workspace.join("vtcode.toml");
+    fs::write(&workspace_config, "agent.provider = \"anthropic\"\n").expect("workspace config");
+
+    let override_path = temp.path().join("custom-night.toml");
+    fs::write(&override_path, "agent.provider = \"openai\"\n\n[workspace]\nuse_root_config = true\n")
+        .expect("override config");
+
+    let _guard = session_override::ExplicitConfigPathGuard::set(Some(override_path));
+
+    let manager = ConfigManager::load_from_workspace(&workspace).expect("load with override");
+    assert_eq!(manager.config().agent.provider, "openai");
+    assert!(manager.config().workspace.use_root_config, "use_root_config from the override file must be honored");
+}

--- a/crates/codegen/vtcode-config/src/loader/watch.rs
+++ b/crates/codegen/vtcode-config/src/loader/watch.rs
@@ -95,9 +95,18 @@ impl ConfigWatcher {
             .current_config
             .lock()
             .map_err(|e| anyhow!("config watcher state lock poisoned: {e}"))?;
-        // Fail-safe: on reload errors keep the last known config instead of
-        // dropping it to `None`, which would cascade into a session reset
-        // (e.g. when the explicit override file was deleted mid-session).
+        // Fail-fast on the initial load: when no configuration was ever
+        // loaded and the reload fails, surface the error instead of silently
+        // starting with `None` (e.g. a broken explicit override file).
+        if current.is_none() {
+            if let Err(err) = reloaded {
+                return Err(err);
+            }
+        }
+        // Fail-safe: on subsequent reload errors keep the last known config
+        // instead of dropping it to `None`, which would cascade into a
+        // session reset (e.g. when the explicit override file was deleted
+        // mid-session).
         if let Ok(config) = reloaded {
             *current = Some(config);
         }
@@ -182,13 +191,13 @@ impl SimpleConfigWatcher {
     #[must_use]
     pub fn new_with_user_config_paths(workspace_path: PathBuf) -> Self {
         let mut watcher = Self::new(workspace_path.clone());
+        // Register the session-explicit override file before the best-effort
+        // manager load so a malformed or temporarily unreadable explicit file
+        // remains watched and observable for later correction.
+        if let Some(override_path) = super::session_override::explicit_config_path() {
+            watcher.add_watch_path(override_path);
+        }
         if let Ok(manager) = ConfigManager::load_from_workspace(&workspace_path) {
-            if let Some(explicit_path) = manager.config_path() {
-                // With a session-explicit config file the loaded manager's
-                // Workspace layer is that file; watch it so live reload
-                // observes edits to the actual config source.
-                watcher.add_watch_path(explicit_path.to_path_buf());
-            }
             for path in manager.user_config_paths() {
                 watcher.add_watch_path(path);
             }

--- a/crates/codegen/vtcode-config/src/loader/watch.rs
+++ b/crates/codegen/vtcode-config/src/loader/watch.rs
@@ -81,15 +81,26 @@ impl ConfigWatcher {
     /// Returns an error when internal watcher state cannot be updated.
     pub async fn load_config(&mut self) -> Result<()> {
         ConfigManager::invalidate_workspace_cache(&self.workspace_path);
-        let config = ConfigManager::load_from_workspace(&self.workspace_path)
-            .ok()
-            .map(|manager| manager.config().clone());
+        let reloaded = ConfigManager::load_from_workspace(&self.workspace_path).map(|manager| manager.config().clone());
+
+        if let Err(err) = &reloaded {
+            let override_path = super::session_override::explicit_config_path();
+            tracing::warn!(
+                path = %override_path.as_deref().map(|p| p.display().to_string()).unwrap_or_default(),
+                "Failed to reload config; keeping the last known configuration: {err:#}"
+            );
+        }
 
         let mut current = self
             .current_config
             .lock()
             .map_err(|e| anyhow!("config watcher state lock poisoned: {e}"))?;
-        *current = config;
+        // Fail-safe: on reload errors keep the last known config instead of
+        // dropping it to `None`, which would cascade into a session reset
+        // (e.g. when the explicit override file was deleted mid-session).
+        if let Ok(config) = reloaded {
+            *current = Some(config);
+        }
         drop(current);
 
         let mut last_load = self
@@ -143,6 +154,7 @@ pub struct SimpleConfigWatcher {
     last_modified_times: HashMap<PathBuf, Option<SystemTime>>,
     debounce_duration: Duration,
     last_reload_attempt: Option<Instant>,
+    last_known_config: Option<VTCodeConfig>,
 }
 
 impl SimpleConfigWatcher {
@@ -157,6 +169,7 @@ impl SimpleConfigWatcher {
             last_modified_times: HashMap::new(),
             debounce_duration: Duration::from_millis(1000),
             last_reload_attempt: None,
+            last_known_config: None,
         }
     }
 
@@ -170,6 +183,12 @@ impl SimpleConfigWatcher {
     pub fn new_with_user_config_paths(workspace_path: PathBuf) -> Self {
         let mut watcher = Self::new(workspace_path.clone());
         if let Ok(manager) = ConfigManager::load_from_workspace(&workspace_path) {
+            if let Some(explicit_path) = manager.config_path() {
+                // With a session-explicit config file the loaded manager's
+                // Workspace layer is that file; watch it so live reload
+                // observes edits to the actual config source.
+                watcher.add_watch_path(explicit_path.to_path_buf());
+            }
             for path in manager.user_config_paths() {
                 watcher.add_watch_path(path);
             }
@@ -259,9 +278,24 @@ impl SimpleConfigWatcher {
 
     pub fn load_config(&mut self) -> Option<VTCodeConfig> {
         ConfigManager::invalidate_workspace_cache(&self.workspace_path);
-        let config = ConfigManager::load_from_workspace(&self.workspace_path)
+        let reloaded = ConfigManager::load_from_workspace(&self.workspace_path)
             .ok()
             .map(|manager| manager.config().clone());
+
+        if reloaded.is_none() {
+            let override_path = super::session_override::explicit_config_path();
+            tracing::warn!(
+                path = %override_path.as_deref().map(|p| p.display().to_string()).unwrap_or_default(),
+                "Failed to reload config; keeping the last known configuration"
+            );
+        }
+
+        // Fail-safe: on reload errors keep the last known config so the
+        // session does not silently lose its effective configuration (e.g.
+        // when the explicit override file was deleted mid-session).
+        if let Some(config) = reloaded {
+            self.last_known_config = Some(config.clone());
+        }
 
         self.last_load_time = Instant::now();
         self.last_modified_times.clear();
@@ -269,7 +303,7 @@ impl SimpleConfigWatcher {
             self.last_modified_times.insert(target.clone(), latest_modified(&target));
         }
 
-        config
+        self.last_known_config.clone()
     }
 
     pub fn set_check_interval(&mut self, seconds: u64) {

--- a/crates/codegen/vtcode-core/src/config/api.rs
+++ b/crates/codegen/vtcode-core/src/config/api.rs
@@ -230,8 +230,11 @@ fn merged_version(layers: &[vtcode_config::loader::layers::ConfigLayerEntry]) ->
 fn resolve_target_path(manager: &ConfigManager, workspace: &Path, target: &ConfigWriteTarget) -> Result<PathBuf> {
     match target {
         ConfigWriteTarget::Workspace => {
-            let root = manager.workspace_root().unwrap_or(workspace).to_path_buf();
-            Ok(root.join(manager.config_file_name()))
+            // Prefer the highest enabled Workspace layer of the loaded
+            // manager: with a session-explicit config file (`--config` /
+            // `VTCODE_CONFIG_PATH`) that layer is the override file itself,
+            // so writes land where the session actually reads from.
+            Ok(manager.preferred_workspace_config_path(workspace))
         }
         ConfigWriteTarget::User => {
             let provider = defaults::current_config_defaults();

--- a/docs/config/CONFIGURATION_PRECEDENCE.md
+++ b/docs/config/CONFIGURATION_PRECEDENCE.md
@@ -18,6 +18,21 @@ When the CLI starts it builds a **layer stack** and merges all present layers fr
 
 Tables are deep-merged recursively. Scalars and arrays are replaced by the higher-precedence layer.
 
+### Explicit config file (session override)
+
+When an explicit config file is present (`--config path` or `VTCODE_CONFIG_PATH`),
+the resolved path is captured once at startup as the **session config override**.
+Every later configuration reload during that session — slash-command persistence,
+the settings palette, live-reload watchers, and `ConfigService` reads/writes —
+reads from and writes to the same explicit file instead of drifting back to the
+default workspace `vtcode.toml`. Relative paths and `~` are resolved identically
+for both the CLI flag and the environment variable. `--config key=value`
+overrides and `--model`/`--provider` remain runtime layers above all files.
+
+Scope note: global-only operations (for example `vtcode mcp login` / `mcp logout`)
+always operate on the canonical user configuration and intentionally ignore the
+explicit session override.
+
 ### Inline CLI overrides
 
 Inspired by [OpenAI Codex CLI](https://github.com/openai/codex), VT Code now accepts

--- a/docs/guides/user-data-directories.md
+++ b/docs/guides/user-data-directories.md
@@ -72,7 +72,12 @@ vtcode --config agent.provider=ollama
 
 Inline key/value overrides are applied above file-based layers. The
 `VTCODE_CONFIG_PATH` environment variable selects the same explicit-file layer
-when a command-line path is not supplied.
+when a command-line path is not supplied. Relative paths and `~` are resolved
+identically for both forms. The resolved file is captured as a session override:
+configuration reloads and config writes made during that session (settings
+palette, slash-command persistence, live reload) target the same explicit file.
+Global-only operations such as `vtcode mcp login` always use the canonical user
+config file and ignore the session override.
 
 ## Configuration precedence
 

--- a/docs/guides/user-data-directories.md
+++ b/docs/guides/user-data-directories.md
@@ -74,10 +74,10 @@ Inline key/value overrides are applied above file-based layers. The
 `VTCODE_CONFIG_PATH` environment variable selects the same explicit-file layer
 when a command-line path is not supplied. Relative paths and `~` are resolved
 identically for both forms. The resolved file is captured as a session override:
-configuration reloads and config writes made during that session (settings
-palette, slash-command persistence, live reload) target the same explicit file.
-Global-only operations such as `vtcode mcp login` always use the canonical user
-config file and ignore the session override.
+configuration reloads and session config writes made during that session
+(settings palette, slash-command persistence, live reload) target the same
+explicit file. Global-only operations such as `vtcode mcp login` always use the
+canonical user config file and ignore the session override.
 
 ## Configuration precedence
 

--- a/src/agent/runloop/unified/settings_interactive/mod.rs
+++ b/src/agent/runloop/unified/settings_interactive/mod.rs
@@ -369,7 +369,7 @@ mod tests {
         struct OverrideGuard;
 
         impl OverrideGuard {
-            fn set(path: Option<std::path::PathBuf>) -> Self {
+            fn set(path: Option<PathBuf>) -> Self {
                 set_explicit_config_path(path);
                 Self
             }

--- a/src/agent/runloop/unified/settings_interactive/mod.rs
+++ b/src/agent/runloop/unified/settings_interactive/mod.rs
@@ -283,6 +283,7 @@ fn describe_array_change(path: &str, added: bool) -> String {
 mod tests {
     use super::*;
     use crate::agent::runloop::unified::config_section_headings::normalize_config_path;
+    use serial_test::serial;
     use vtcode_commons::canonicalize;
 
     #[test]
@@ -358,6 +359,46 @@ mod tests {
         assert_eq!(state.draft.ui.tool_display_mode, vtcode_core::config::ToolDisplayMode::Compact);
         let persisted = std::fs::read_to_string(&source_path).expect("persisted config");
         assert!(persisted.contains("tool_display_mode = \"compact\""));
+    }
+
+    #[test]
+    #[serial]
+    fn settings_palette_uses_explicit_session_override_as_source() {
+        use vtcode_config::loader::set_explicit_config_path;
+
+        struct OverrideGuard;
+
+        impl OverrideGuard {
+            fn set(path: Option<std::path::PathBuf>) -> Self {
+                set_explicit_config_path(path);
+                Self
+            }
+        }
+
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                set_explicit_config_path(None);
+            }
+        }
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace dir");
+        std::fs::write(workspace.join("vtcode.toml"), "agent.provider = \"anthropic\"\n").expect("workspace config");
+
+        let override_path = temp.path().join("custom-night.toml");
+        std::fs::write(&override_path, "agent.provider = \"openai\"\n").expect("override config");
+
+        let _guard = OverrideGuard::set(Some(override_path.clone()));
+        let state = create_settings_palette_state(&workspace, &None);
+
+        let state = state.expect("settings state with override");
+        assert_eq!(
+            canonicalize(&state.source_path).expect("canonical source path"),
+            canonicalize(&override_path).expect("canonical override path"),
+            "settings palette must treat the explicit override file as its source"
+        );
+        assert_eq!(state.draft.agent.provider, "openai");
     }
 
     #[test]

--- a/src/agent/runloop/unified/turn/session/slash_commands/config_toml.rs
+++ b/src/agent/runloop/unified/turn/session/slash_commands/config_toml.rs
@@ -5,7 +5,6 @@ use anyhow::{Context, Result};
 use toml::Value as TomlValue;
 use vtcode_commons::VtCodePaths;
 use vtcode_core::config::loader::ConfigManager;
-use vtcode_core::config::loader::layers::ConfigLayerSource;
 
 pub(super) fn ensure_child_table<'a>(
     table: &'a mut toml::map::Map<String, TomlValue>,
@@ -104,14 +103,5 @@ fn parse_toml_value(path: &Path, content: &str) -> Result<TomlValue> {
 }
 
 pub(super) fn preferred_workspace_config_path(manager: &ConfigManager, workspace: &Path) -> PathBuf {
-    manager
-        .layer_stack()
-        .layers()
-        .iter()
-        .rev()
-        .find_map(|layer| match &layer.source {
-            ConfigLayerSource::Workspace { file } if layer.is_enabled() => Some(file.clone()),
-            _ => None,
-        })
-        .unwrap_or_else(|| workspace.join(manager.config_file_name()))
+    manager.preferred_workspace_config_path(workspace)
 }

--- a/src/startup/config_loading.rs
+++ b/src/startup/config_loading.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 use vtcode_core::cli::args::Cli;
-use vtcode_core::config::loader::{ConfigBuilder, VTCodeConfig};
+use vtcode_core::config::loader::{ConfigBuilder, VTCodeConfig, set_explicit_config_path};
 use vtcode_core::utils::validation::validate_path_exists;
 
 use super::first_run::maybe_run_first_run_setup;
@@ -37,10 +37,18 @@ pub(super) async fn load_startup_config(args: &Cli) -> Result<LoadedStartupConfi
     let config_path_override = cli_config_path_override.or(env_config_path_override);
 
     let mut builder = ConfigBuilder::new().workspace(workspace.clone());
-    if let Some(path_override) = config_path_override {
-        let resolved_path = resolve_config_path(&workspace, &path_override);
-        builder = builder.config_file(resolved_path);
-    }
+    let resolved_explicit_path = match config_path_override {
+        Some(path_override) => {
+            let resolved_path = resolve_config_path(&workspace, &path_override);
+            builder = builder.config_file(resolved_path.clone());
+            Some(resolved_path)
+        }
+        None => None,
+    };
+    // Unconditionally synchronize the session override so a previous
+    // `load_startup_config` in the same process (e.g. a test or a reload)
+    // cannot leak a stale explicit path into this load.
+    set_explicit_config_path(resolved_explicit_path.clone());
 
     if !inline_config_overrides.is_empty() {
         builder = builder.cli_overrides(&inline_config_overrides);
@@ -114,10 +122,29 @@ mod tests {
     use super::*;
     use clap::Parser;
     use tempfile::TempDir;
+    use vtcode_config::loader::explicit_config_path;
     use vtcode_core::cli::args::Cli;
+
+    /// RAII guard for the process-global session override so a panicking test
+    /// cannot leak a stale explicit path into sibling tests.
+    struct SessionOverrideGuard;
+
+    impl SessionOverrideGuard {
+        fn reset() -> Self {
+            set_explicit_config_path(None);
+            Self
+        }
+    }
+
+    impl Drop for SessionOverrideGuard {
+        fn drop(&mut self) {
+            set_explicit_config_path(None);
+        }
+    }
 
     #[tokio::test]
     async fn cli_config_path_override_loads_requested_file() {
+        let _guard = SessionOverrideGuard::reset();
         let temp_dir = TempDir::new().expect("temp dir");
         let workspace = temp_dir.path().join("workspace");
         std::fs::create_dir(&workspace).expect("workspace dir");
@@ -144,6 +171,40 @@ enable_tracing = true
         let loaded = load_startup_config(&args).await.expect("startup config should load");
 
         assert!(loaded.config.debug.enable_tracing);
+    }
+
+    #[tokio::test]
+    async fn env_config_path_override_loads_requested_file_and_captures_session_override() {
+        use vtcode_commons::env_lock;
+
+        let _guard = SessionOverrideGuard::reset();
+        let env_guard = env_lock::lock();
+        let previous = std::env::var_os("VTCODE_CONFIG_PATH");
+
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = temp_dir.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace dir");
+        std::fs::create_dir_all(workspace.join(".vtcode")).expect("workspace dot dir");
+
+        let config_path = temp_dir.path().join("custom-env-config.toml");
+        std::fs::write(&config_path, "[debug]\nenable_tracing = true\n").expect("custom env config");
+
+        env_guard.set_var("VTCODE_CONFIG_PATH", config_path.to_str().expect("config path"));
+
+        let args = Cli::parse_from(["vtcode", "--workspace", workspace.to_str().expect("workspace path")]);
+
+        let loaded = load_startup_config(&args).await;
+        let session_override = explicit_config_path();
+
+        env_guard.restore_var("VTCODE_CONFIG_PATH", previous);
+
+        let loaded = loaded.expect("startup config should load from VTCODE_CONFIG_PATH");
+        assert!(loaded.config.debug.enable_tracing);
+        assert_eq!(
+            session_override.and_then(|path| vtcode_commons::canonicalize(path).ok()),
+            vtcode_commons::canonicalize(&config_path).ok(),
+            "startup must capture the resolved env path as the session override"
+        );
     }
 
     #[test]

--- a/src/startup/config_loading.rs
+++ b/src/startup/config_loading.rs
@@ -121,6 +121,7 @@ fn has_top_level_config_key(config: &toml::Value, key: &str) -> bool {
 mod tests {
     use super::*;
     use clap::Parser;
+    use serial_test::serial;
     use tempfile::TempDir;
     use vtcode_config::loader::explicit_config_path;
     use vtcode_core::cli::args::Cli;
@@ -143,6 +144,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn cli_config_path_override_loads_requested_file() {
         let _guard = SessionOverrideGuard::reset();
         let temp_dir = TempDir::new().expect("temp dir");
@@ -174,6 +176,7 @@ enable_tracing = true
     }
 
     #[tokio::test]
+    #[serial]
     async fn env_config_path_override_loads_requested_file_and_captures_session_override() {
         use vtcode_commons::env_lock;
 

--- a/src/startup/first_run.rs
+++ b/src/startup/first_run.rs
@@ -63,6 +63,13 @@ enum SetupMode {
 }
 
 fn is_fresh_workspace(workspace: &Path) -> bool {
+    let explicit_override = vtcode_config::loader::explicit_config_path();
+    if let Some(path) = explicit_override {
+        // A session-explicit config file is the workspace's config source:
+        // when it exists the workspace is not fresh, regardless of whether
+        // the default `vtcode.toml` paths exist.
+        return !path.exists();
+    }
     let config_path = workspace.join("vtcode.toml");
     let dot_dir = workspace.join(".vtcode");
     !config_path.exists() && !dot_dir.exists()
@@ -173,7 +180,7 @@ async fn run_first_run_setup(workspace: &Path, config: &mut VTCodeConfig, mode: 
     config.agent.api_key_env = provider.default_api_key_env().to_owned();
     apply_selection(config, &provider_key, &model, &lightweight_model, reasoning, persistent_memory);
 
-    let config_path = workspace.join("vtcode.toml");
+    let config_path = vtcode_config::loader::explicit_config_path().unwrap_or_else(|| workspace.join("vtcode.toml"));
     ConfigManager::save_config_to_path(&config_path, config)
         .with_context(|| format!("Failed to write initial configuration to {}", config_path.display()))?;
 

--- a/src/startup/first_run.rs
+++ b/src/startup/first_run.rs
@@ -172,7 +172,8 @@ async fn run_first_run_setup(workspace: &Path, config: &mut VTCodeConfig, mode: 
         }
     };
 
-    renderer.line(MessageStyle::Status, "Saving your configuration to vtcode.toml ...")?;
+    let config_path = vtcode_config::loader::explicit_config_path().unwrap_or_else(|| workspace.join("vtcode.toml"));
+    renderer.line(MessageStyle::Status, &format!("Saving your configuration to {} ...", config_path.display()))?;
 
     // Compute provider key once to avoid repeated allocations from `to_string()`.
     let provider_key = provider.to_string();
@@ -180,7 +181,6 @@ async fn run_first_run_setup(workspace: &Path, config: &mut VTCodeConfig, mode: 
     config.agent.api_key_env = provider.default_api_key_env().to_owned();
     apply_selection(config, &provider_key, &model, &lightweight_model, reasoning, persistent_memory);
 
-    let config_path = vtcode_config::loader::explicit_config_path().unwrap_or_else(|| workspace.join("vtcode.toml"));
     ConfigManager::save_config_to_path(&config_path, config)
         .with_context(|| format!("Failed to write initial configuration to {}", config_path.display()))?;
 


### PR DESCRIPTION
## Summary

An explicit config file selected via `--config PATH` or `VTCODE_CONFIG_PATH`
was only applied to the initial startup load. Every subsequent configuration
reload during the session — slash-command persistence (`/memory`, theme),
the settings palette, live-reload watchers, and `ConfigService` reads/writes —
re-loaded the default layer hierarchy and silently dropped the user's explicit
config, writing settings back to the default workspace `vtcode.toml`.

This PR captures the resolved explicit path once at startup as a session
override and routes every later config load/write through it.

## Changes

- **`vtcode-config`**: new `session_override` module (process-global snapshot);
  `ConfigManager::load_from_workspace` honors the override via the new
  `load_for_session` (keeps `workspace_root` anchored to the workspace);
  `set_explicit_config_path` invalidates the workspace cache so a cleared or
  changed override cannot leak a stale manager; new
  `preferred_workspace_config_path` resolves the highest enabled Workspace
  layer; `ConfigManager::load` delegates through the override (removes the
  old env-only precedence and the `write_global_config_to_canonical` trap).
- **`vtcode-core`**: `ConfigService::write(Workspace)` now writes to the
  session's explicit file via `preferred_workspace_config_path`.
- **Binary**: `load_startup_config` resolves `VTCODE_CONFIG_PATH` with the
  same tilde/relative resolution as `--config` and unconditionally syncs the
  override; first-run detection and the setup wizard's config write honor the
  override; settings-palette `source_path` resolves to the explicit file;
  slash-command persistence delegates to `preferred_workspace_config_path`.
- **Watchers**: track the explicit file; keep the last known config on reload
  errors instead of cascading to `None`.
- **Docs**: updated `CONFIGURATION_PRECEDENCE.md` and
  `user-data-directories.md`; global-only `vtcode mcp login`/`logout`
  intentionally ignore the override (documented).

## Tests

New tests cover: override wins as the Workspace layer over a workspace
`vtcode.toml`; `save_config` writes the override file and leaves the
workspace file untouched; override survives cache invalidation;
`use_root_config` in the override file; env-variable override capture at
startup; settings palette sourcing from the override file. Config-layer test
suites pass (`vtcode-config` 413/413, `vtcode-core` config 258/258).

## Notes

Global-only operations (`vtcode mcp login` / `mcp logout`) still operate on
the canonical user configuration by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-scoped configuration file overrides.
  * Command-line and `VTCODE_CONFIG_PATH` selections are reused for reloads and saved changes.
  * First-run setup now uses explicitly selected configuration files.
* **Bug Fixes**
  * Failed reloads preserve the last working configuration.
  * Configuration caches refresh when the active override changes.
* **Documentation**
  * Clarified configuration precedence, path resolution, reload behavior, and persistence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->