### PR TITLE
feat(subagents): enable nested delegation via subagents.max_depth

### DIFF
--- a/crates/codegen/vtcode-core/src/core/agent/runner.rs
+++ b/crates/codegen/vtcode-core/src/core/agent/runner.rs
@@ -394,6 +394,15 @@ impl AgentRunner {
         self.loop_detector.lock().set_subagent_mode(is_subagent);
     }
 
+    /// Attach a subagent controller to this runner's tool registry so the
+    /// subagent-lifecycle tools (`agent` and its aliases) become available to
+    /// the model. Used to enable nested delegation: the attached controller
+    /// carries the child-scoped depth so the depth check in `spawn_with_spec`
+    /// still governs grandchild spawns.
+    pub fn set_subagent_controller(&self, controller: Arc<crate::subagents::SubagentController>) {
+        self.tool_registry.set_subagent_controller(controller);
+    }
+
     /// Snapshot the runner-owned conversation messages for archive persistence.
     pub fn session_messages(&self) -> Vec<crate::llm::provider::Message> {
         self.thread_handle.messages()

--- a/crates/codegen/vtcode-core/src/subagents/config.rs
+++ b/crates/codegen/vtcode-core/src/subagents/config.rs
@@ -126,6 +126,20 @@ fn apply_subagent_lightweight_profile(child: &mut VTCodeConfig) {
     child.agent.tool_documentation_mode = ToolDocumentationMode::Minimal;
 }
 
+/// Returns the subagent-internal tool names blocked from a child at the given
+/// nesting policy. When nested delegation is allowed only the background
+/// subprocess alias is blocked; otherwise every subagent-lifecycle tool is.
+///
+/// Single source of truth so the deny-list, allow-list, and wire-definition
+/// filters cannot diverge on the blocked set.
+fn blocked_child_tool_names(allow_nested_delegation: bool) -> &'static [&'static str] {
+    if allow_nested_delegation {
+        CHILD_BLOCKED_BACKGROUND_TOOL_NAMES
+    } else {
+        SUBAGENT_TOOL_NAMES
+    }
+}
+
 /// Resolves the child's allow-list. When the spec declares tools, the child
 /// allow-list is the intersection of the parent allow-list and the declared
 /// tools (with subagent-internal tools removed unless nested delegation is
@@ -136,11 +150,7 @@ fn resolve_child_allowed_tools(
     runtime: &ResolvedAgentRuntimeView,
     allow_nested_delegation: bool,
 ) -> Vec<String> {
-    let blocked: &[&str] = if allow_nested_delegation {
-        CHILD_BLOCKED_BACKGROUND_TOOL_NAMES
-    } else {
-        SUBAGENT_TOOL_NAMES
-    };
+    let blocked = blocked_child_tool_names(allow_nested_delegation);
     let allowed_tools = runtime.tools.clone().unwrap_or_default();
     if allowed_tools.is_empty() {
         return parent.permissions.allow.clone();
@@ -162,11 +172,7 @@ fn resolve_child_denied_tools(
     runtime: &ResolvedAgentRuntimeView,
     allow_nested_delegation: bool,
 ) -> Vec<String> {
-    let blocked: &[&str] = if allow_nested_delegation {
-        CHILD_BLOCKED_BACKGROUND_TOOL_NAMES
-    } else {
-        SUBAGENT_TOOL_NAMES
-    };
+    let blocked = blocked_child_tool_names(allow_nested_delegation);
     let mut denied = parent.permissions.deny.clone();
     denied.extend(runtime.disallowed_tools.clone());
     for tool in blocked {
@@ -546,11 +552,7 @@ pub fn filter_child_tools(
         .iter()
         .map(|tool| tool.to_ascii_lowercase())
         .collect::<Vec<_>>();
-    let blocked: &[&str] = if allow_nested_delegation {
-        CHILD_BLOCKED_BACKGROUND_TOOL_NAMES
-    } else {
-        SUBAGENT_TOOL_NAMES
-    };
+    let blocked = blocked_child_tool_names(allow_nested_delegation);
 
     definitions
         .into_iter()

--- a/crates/codegen/vtcode-core/src/subagents/config.rs
+++ b/crates/codegen/vtcode-core/src/subagents/config.rs
@@ -9,7 +9,8 @@ use vtcode_config::{
 };
 
 use super::constants::{
-    NON_MUTATING_TOOL_PREFIXES, SUBAGENT_MIN_BACKGROUND_MAX_TURNS, SUBAGENT_MIN_MAX_TURNS, SUBAGENT_TOOL_NAMES,
+    CHILD_BLOCKED_BACKGROUND_TOOL_NAMES, NON_MUTATING_TOOL_PREFIXES, SUBAGENT_MIN_BACKGROUND_MAX_TURNS,
+    SUBAGENT_MIN_MAX_TURNS, SUBAGENT_TOOL_NAMES,
 };
 use crate::config::VTCodeConfig;
 use crate::config::constants::tools;
@@ -77,8 +78,15 @@ pub fn build_child_config(
     spec: &SubagentSpec,
     model: &str,
     max_turns: Option<usize>,
+    allow_nested_delegation: bool,
 ) -> VTCodeConfig {
-    build_child_config_from_runtime(parent, &ResolvedAgentRuntimeView::from_spec(spec), model, max_turns)
+    build_child_config_from_runtime(
+        parent,
+        &ResolvedAgentRuntimeView::from_spec(spec),
+        model,
+        max_turns,
+        allow_nested_delegation,
+    )
 }
 
 fn build_child_config_from_runtime(
@@ -86,6 +94,7 @@ fn build_child_config_from_runtime(
     runtime: &ResolvedAgentRuntimeView,
     model: &str,
     max_turns: Option<usize>,
+    allow_nested_delegation: bool,
 ) -> VTCodeConfig {
     let mut child = parent.clone();
     child.agent.default_model = model.to_string();
@@ -98,8 +107,8 @@ fn build_child_config_from_runtime(
     apply_subagent_lightweight_profile(&mut child);
     normalize_child_max_turns_config(&mut child, max_turns);
 
-    child.permissions.allow = resolve_child_allowed_tools(parent, runtime);
-    child.permissions.deny = resolve_child_denied_tools(parent, runtime);
+    child.permissions.allow = resolve_child_allowed_tools(parent, runtime, allow_nested_delegation);
+    child.permissions.deny = resolve_child_denied_tools(parent, runtime, allow_nested_delegation);
     merge_child_hooks(&mut child, runtime.hooks.as_ref());
     // Drop parent MCP providers by default; only attach servers explicitly
     // requested by the subagent spec. This prevents multiplying MCP schema
@@ -119,27 +128,49 @@ fn apply_subagent_lightweight_profile(child: &mut VTCodeConfig) {
 
 /// Resolves the child's allow-list. When the spec declares tools, the child
 /// allow-list is the intersection of the parent allow-list and the declared
-/// tools (with subagent-internal tools removed). When the spec declares
-/// nothing, the parent allow-list is inherited unchanged.
-fn resolve_child_allowed_tools(parent: &VTCodeConfig, runtime: &ResolvedAgentRuntimeView) -> Vec<String> {
+/// tools (with subagent-internal tools removed unless nested delegation is
+/// allowed). When the spec declares nothing, the parent allow-list is
+/// inherited unchanged.
+fn resolve_child_allowed_tools(
+    parent: &VTCodeConfig,
+    runtime: &ResolvedAgentRuntimeView,
+    allow_nested_delegation: bool,
+) -> Vec<String> {
+    let blocked: &[&str] = if allow_nested_delegation {
+        CHILD_BLOCKED_BACKGROUND_TOOL_NAMES
+    } else {
+        SUBAGENT_TOOL_NAMES
+    };
     let allowed_tools = runtime.tools.clone().unwrap_or_default();
     if allowed_tools.is_empty() {
         return parent.permissions.allow.clone();
     }
     let filtered: Vec<String> = allowed_tools
         .into_iter()
-        .filter(|tool| !SUBAGENT_TOOL_NAMES.iter().any(|blocked| blocked == tool))
+        .filter(|tool| !blocked.iter().any(|blocked| blocked == tool))
         .collect();
     intersect_allowed_tools(&parent.permissions.allow, &filtered)
 }
 
 /// Resolves the child's deny-list: the parent deny-list, extended with the
-/// spec's disallowed tools and the always-blocked subagent-internal tools.
-fn resolve_child_denied_tools(parent: &VTCodeConfig, runtime: &ResolvedAgentRuntimeView) -> Vec<String> {
+/// spec's disallowed tools and the subagent-internal tools blocked at this
+/// nesting level. When nested delegation is allowed, only the
+/// background-subprocess alias stays blocked; the delegation tools are gated
+/// by the runtime depth check instead.
+fn resolve_child_denied_tools(
+    parent: &VTCodeConfig,
+    runtime: &ResolvedAgentRuntimeView,
+    allow_nested_delegation: bool,
+) -> Vec<String> {
+    let blocked: &[&str] = if allow_nested_delegation {
+        CHILD_BLOCKED_BACKGROUND_TOOL_NAMES
+    } else {
+        SUBAGENT_TOOL_NAMES
+    };
     let mut denied = parent.permissions.deny.clone();
     denied.extend(runtime.disallowed_tools.clone());
-    for tool in SUBAGENT_TOOL_NAMES {
-        if !denied.iter().any(|entry| entry == *tool) {
+    for tool in blocked {
+        if !denied.iter().any(|entry| entry == tool) {
             denied.push((*tool).to_string());
         }
     }
@@ -174,6 +205,10 @@ pub fn normalize_background_child_max_turns(max_turns: Option<usize>, background
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "All parameters are required to resolve a child runtime config (parent identity, model overrides, and nesting policy)."
+)]
 pub fn prepare_child_runtime_config(
     parent: &VTCodeConfig,
     spec: &SubagentSpec,
@@ -183,6 +218,7 @@ pub fn prepare_child_runtime_config(
     max_turns: Option<usize>,
     model_override: Option<&str>,
     reasoning_override: Option<&str>,
+    allow_nested_delegation: bool,
     resolve_model: impl FnOnce(&VTCodeConfig, &str, &str, Option<&str>, Option<&str>, &str) -> Result<ModelId>,
 ) -> Result<(ModelId, ReasoningEffortLevel, VTCodeConfig)> {
     let runtime = ResolvedAgentRuntimeView::from_spec(spec);
@@ -194,7 +230,8 @@ pub fn prepare_child_runtime_config(
         runtime.model.as_deref(),
         runtime.canonical_name.as_str(),
     )?;
-    let mut child_cfg = build_child_config_from_runtime(parent, &runtime, &resolved_model.as_str(), max_turns);
+    let mut child_cfg =
+        build_child_config_from_runtime(parent, &runtime, &resolved_model.as_str(), max_turns, allow_nested_delegation);
     let child_reasoning_effort = reasoning_override
         .and_then(ReasoningEffortLevel::parse)
         .or(runtime.reasoning_effort)
@@ -498,6 +535,7 @@ pub fn filter_child_tools(
     spec: &SubagentSpec,
     definitions: Vec<ToolDefinition>,
     read_only: bool,
+    allow_nested_delegation: bool,
 ) -> Vec<ToolDefinition> {
     let allowed = spec
         .tools
@@ -508,12 +546,17 @@ pub fn filter_child_tools(
         .iter()
         .map(|tool| tool.to_ascii_lowercase())
         .collect::<Vec<_>>();
+    let blocked: &[&str] = if allow_nested_delegation {
+        CHILD_BLOCKED_BACKGROUND_TOOL_NAMES
+    } else {
+        SUBAGENT_TOOL_NAMES
+    };
 
     definitions
         .into_iter()
         .filter(|tool| {
             let name = tool.function_name().to_ascii_lowercase();
-            if SUBAGENT_TOOL_NAMES.iter().any(|blocked| *blocked == name) {
+            if blocked.iter().any(|blocked| *blocked == name) {
                 return false;
             }
             if denied.iter().any(|entry| entry == &name) {
@@ -551,7 +594,7 @@ mod slice4_tests {
             .find(|spec| spec.name == "explorer")
             .expect("explorer");
 
-        let child = build_child_config(&parent, &spec, "small", None);
+        let child = build_child_config(&parent, &spec, "small", None, false);
         assert_eq!(child.permissions.allow, vec!["Read".to_string()]);
 
         let filtered = filter_child_tools(
@@ -563,6 +606,7 @@ mod slice4_tests {
                 definition(tools::WRITE_STDIN),
             ],
             spec.is_read_only(),
+            false,
         );
         let names = filtered.iter().map(ToolDefinition::function_name).collect::<Vec<_>>();
 
@@ -634,7 +678,7 @@ mod tests {
         parent.mcp.providers.push(McpProviderConfig::default());
 
         let spec = test_subagent_spec();
-        let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+        let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
 
         assert_eq!(
             child.agent.system_prompt_mode,
@@ -661,7 +705,7 @@ mod tests {
         parent.mcp.providers[0].name = "context7".to_string();
         spec.mcp_servers = vec![SubagentMcpServer::Named("context7".to_string())];
 
-        let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+        let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
 
         assert_eq!(child.mcp.providers.len(), 1);
         assert_eq!(child.mcp.providers[0].name, "context7");
@@ -741,7 +785,7 @@ mod tests {
             compose_system_instruction_with_report(workspace.path(), Some(&parent), Some(&ctx)).await;
 
         let spec = test_subagent_spec();
-        let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+        let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
 
         // The lightweight profile is the contract under test.
         assert_eq!(child.agent.system_prompt_mode, SystemPromptMode::Minimal);

--- a/crates/codegen/vtcode-core/src/subagents/constants.rs
+++ b/crates/codegen/vtcode-core/src/subagents/constants.rs
@@ -39,6 +39,12 @@ pub(crate) const SUBAGENT_TOOL_NAMES: &[&str] = &[
     tools::CLOSE_AGENT,
 ];
 
+/// Subagent-internal tool names that are removed from a child's toolset even
+/// when nested delegation is allowed: `spawn_background_subprocess` maps to a
+/// dedicated controller guard (`managed_background_runtime`) because it is an
+/// argument alias of the unified `agent` registration, not a separate tool.
+pub(crate) const CHILD_BLOCKED_BACKGROUND_TOOL_NAMES: &[&str] = &[tools::SPAWN_BACKGROUND_SUBPROCESS];
+
 pub(crate) const NON_MUTATING_TOOL_PREFIXES: &[&str] = &[
     tools::CODE_SEARCH,
     tools::LIST_SKILLS,

--- a/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
@@ -174,7 +174,7 @@ impl SubagentController {
         model_override: Option<String>,
         reasoning_override: Option<String>,
     ) -> Result<ChildRunResult> {
-        let (spec, session_id, bootstrap_messages, display_label, background, worktree_path) = {
+        let (spec, session_id, bootstrap_messages, display_label, background, worktree_path, existing_child_controller) = {
             let mut state = self.state.write().await;
             let record = state
                 .children
@@ -189,12 +189,19 @@ impl SubagentController {
                 record.display_label.clone(),
                 record.background,
                 record.worktree_path.clone(),
+                record.child_controller.clone(),
             )
         };
 
         // Use the worktree path as the effective workspace root if the
         // subagent was spawned with isolation=worktree.
         let effective_workspace = worktree_path.as_deref().unwrap_or(&self.config.workspace_root);
+
+        // This child may delegate further only when a grandchild (depth + 2)
+        // still fits inside `subagents.max_depth`. The depth check in
+        // `spawn_with_spec` remains the sole runtime gate; this flag just
+        // decides whether the delegation tools stay in the child's toolset.
+        let allow_nested_delegation = self.config.depth.saturating_add(2) <= self.config.vt_cfg.subagents.max_depth;
 
         let (resolved_model, child_reasoning_effort, child_cfg) = prepare_child_runtime_config(
             &self.config.vt_cfg,
@@ -205,6 +212,7 @@ impl SubagentController {
             max_turns,
             model_override.as_deref(),
             reasoning_override.as_deref(),
+            allow_nested_delegation,
             resolve_effective_subagent_model,
         )?;
         let parent_session_id = self.parent_session_id.read().await.clone();
@@ -243,6 +251,55 @@ impl SubagentController {
         .await?;
         runner.set_quiet(true);
         runner.set_subagent_mode(true);
+        // When this child may delegate further, attach a child-scoped
+        // controller so the subagent-lifecycle tools surface in its catalog
+        // and grandchild spawns inherit the incremented depth. The controller
+        // is created once and reused across resumes so grandchildren remain
+        // reachable for the child's lifetime. It is created with
+        // `managed_background_runtime: true` so the unified `agent` tool cannot
+        // launch background subprocesses from a child.
+        let child_controller = if allow_nested_delegation {
+            match existing_child_controller {
+                Some(controller) => Some(controller),
+                None => {
+                    let nested_config = SubagentControllerConfig {
+                        workspace_root: effective_workspace.to_path_buf(),
+                        parent_session_id: session_id.clone(),
+                        parent_model: child_cfg.agent.default_model.clone(),
+                        parent_provider: child_cfg.agent.provider.clone(),
+                        parent_reasoning_effort: child_reasoning_effort,
+                        api_key: self.config.api_key.clone(),
+                        vt_cfg: child_cfg.clone(),
+                        openai_chatgpt_auth: self.config.openai_chatgpt_auth.clone(),
+                        depth: self.config.depth.saturating_add(1),
+                        exec_sessions: self.config.exec_sessions.clone(),
+                        pty_manager: self.config.pty_manager.clone(),
+                        managed_background_runtime: true,
+                    };
+                    match SubagentController::new(nested_config).await {
+                        Ok(controller) => {
+                            controller.set_parent_messages(&bootstrap_messages).await;
+                            Some(std::sync::Arc::new(controller))
+                        }
+                        Err(err) => {
+                            // Fail closed: without a controller the child keeps
+                            // the current non-nested toolset and cannot delegate.
+                            tracing::warn!(
+                                child_id,
+                                error = %err,
+                                "Failed to create nested subagent controller; child delegation disabled"
+                            );
+                            None
+                        }
+                    }
+                }
+            }
+        } else {
+            None
+        };
+        if let Some(controller) = child_controller.as_ref() {
+            runner.set_subagent_controller(controller.clone());
+        }
         let thread_handle = runner.thread_handle();
         let archive_path = archive.path().to_path_buf();
 
@@ -256,6 +313,9 @@ impl SubagentController {
             record.archive_path = Some(archive_path.clone());
             record.effective_config = Some(child_cfg.clone());
             record.thread_handle = Some(thread_handle.clone());
+            if let Some(controller) = child_controller.clone() {
+                record.child_controller = Some(controller);
+            }
         }
         if let Some(hooks) = self.lifecycle_hooks.as_ref()
             && let Err(err) = hooks
@@ -277,7 +337,13 @@ impl SubagentController {
             );
         }
 
-        let filtered_tools = filter_child_tools(&spec, runner.build_universal_tools().await?, spec.is_read_only());
+        // Fail closed on tool exposure: only expose the delegation tools when
+        // the child-scoped controller is actually attached. If controller
+        // creation failed the child keeps the non-nested toolset even though
+        // its config deny-list may omit the delegation tools.
+        let nested_tools_enabled = allow_nested_delegation && child_controller.is_some();
+        let filtered_tools =
+            filter_child_tools(&spec, runner.build_universal_tools().await?, spec.is_read_only(), nested_tools_enabled);
         let allowed_tools = filtered_tools
             .iter()
             .map(|tool| tool.function_name().to_string())

--- a/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
@@ -155,6 +155,27 @@ impl SubagentController {
                 continue;
             }
 
+            // The child is terminal and no queued work remains. Tear down its
+            // child-scoped controller so any running grandchildren are aborted
+            // instead of continuing detached after the child reports done.
+            let nested = {
+                let state = self.state.read().await;
+                state.children.get(child_id).and_then(|record| {
+                    record
+                        .child_controller
+                        .clone()
+                        .map(|controller| (controller, record.session_id.clone()))
+                })
+            };
+            if let Some((controller, session_id)) = nested {
+                let ids = controller.spawn_child_ids_for_parent(&session_id).await;
+                for id in ids {
+                    if let Err(err) = controller.close(&id).await {
+                        tracing::warn!(child_id, node_id = id.as_str(), error = %err, "Failed to close nested subagent subtree on child completion");
+                    }
+                }
+            }
+
             {
                 let mut state = self.state.write().await;
                 if let Some(record) = state.children.get_mut(child_id) {

--- a/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
@@ -198,10 +198,11 @@ impl SubagentController {
         let effective_workspace = worktree_path.as_deref().unwrap_or(&self.config.workspace_root);
 
         // This child may delegate further only when a grandchild (depth + 2)
-        // still fits inside `subagents.max_depth`. The depth check in
-        // `spawn_with_spec` remains the sole runtime gate; this flag just
-        // decides whether the delegation tools stay in the child's toolset.
-        let allow_nested_delegation = self.config.depth.saturating_add(2) <= self.config.vt_cfg.subagents.max_depth;
+        // still fits inside `subagents.max_depth` AND the child is write-capable.
+        // A read-only child never receives delegation tools, so it also needs
+        // no child-scoped controller and must keep the delegation tools denied.
+        let allow_nested_delegation =
+            !spec.is_read_only() && self.config.depth.saturating_add(2) <= self.config.vt_cfg.subagents.max_depth;
 
         let (resolved_model, child_reasoning_effort, child_cfg) = prepare_child_runtime_config(
             &self.config.vt_cfg,
@@ -277,10 +278,7 @@ impl SubagentController {
                         managed_background_runtime: true,
                     };
                     match SubagentController::new(nested_config).await {
-                        Ok(controller) => {
-                            controller.set_parent_messages(&bootstrap_messages).await;
-                            Some(std::sync::Arc::new(controller))
-                        }
+                        Ok(controller) => Some(std::sync::Arc::new(controller)),
                         Err(err) => {
                             // Fail closed: without a controller the child keeps
                             // the current non-nested toolset and cannot delegate.
@@ -297,7 +295,11 @@ impl SubagentController {
         } else {
             None
         };
+        // Refresh parent context on both a newly created and a reused
+        // controller so a resumed child's grandchildren fork from the latest
+        // bootstrap messages.
         if let Some(controller) = child_controller.as_ref() {
+            controller.set_parent_messages(&bootstrap_messages).await;
             runner.set_subagent_controller(controller.clone());
         }
         let thread_handle = runner.thread_handle();

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -739,6 +739,8 @@ impl SubagentController {
                     handle.abort();
                 }
                 record.status = SubagentStatus::Closed;
+                record.completed_at = Some(Utc::now());
+                record.notify.notify_waiters();
                 if let Some(controller) = record.child_controller.clone() {
                     nested.push((controller, record.session_id.clone()));
                 }

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -252,6 +252,9 @@ impl SubagentController {
         let self_owned = self.clone();
         let target_owned = target.to_string();
         Box::pin(async move {
+            if self_owned.shutdown_requested.load(Ordering::Relaxed) {
+                bail!("Subagent controller is shutting down; cannot resume subagents");
+            }
             let subtree_ids = self_owned.collect_spawn_subtree_ids(&target_owned).await?;
             let mut restart_ids = Vec::new();
             for node_id in subtree_ids.iter() {
@@ -272,6 +275,12 @@ impl SubagentController {
                         tracing::warn!(node_id = id.as_str(), error = %err, "Failed to resume nested subagent subtree");
                     }
                 }
+            }
+            // Re-check shutdown before launching: a concurrent signal_shutdown
+            // between reopen and restart would otherwise start a child after
+            // shutdown aborted the subtree.
+            if self_owned.shutdown_requested.load(Ordering::Relaxed) {
+                bail!("Subagent controller is shutting down; cannot resume subagents");
             }
             for restart_id in restart_ids {
                 self_owned.restart_child(&restart_id).await?;

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -320,6 +320,7 @@ impl SubagentController {
             // Close the target's own subtree (deepest first) on this
             // controller. Aborting the owning child's handle first stops it
             // from spawning further descendants.
+            let subtree_ids_for_rescan = subtree_ids.clone();
             for node_id in subtree_ids.into_iter().rev() {
                 self_owned.close_single(node_id.as_str()).await?;
             }
@@ -334,6 +335,20 @@ impl SubagentController {
                 for id in ids {
                     if let Err(err) = controller.close_tree(&id).await {
                         tracing::warn!(node_id = id.as_str(), error = %err, "Failed to close nested subagent subtree");
+                    }
+                }
+            }
+            // A child may have attached a freshly created controller between
+            // the snapshot above and its handle abort. Re-scan and cascade
+            // again so no grandchild outlives the close; the second pass is a
+            // no-op in the common case because close_tree is idempotent.
+            let late = self_owned.nested_controllers_in_subtree(&subtree_ids_for_rescan).await;
+            for (controller, session_id) in late {
+                controller.begin_close().await;
+                let ids = controller.spawn_child_ids_for_parent(&session_id).await;
+                for id in ids {
+                    if let Err(err) = controller.close_tree(&id).await {
+                        tracing::warn!(node_id = id.as_str(), error = %err, "Failed to close late nested subagent subtree");
                     }
                 }
             }

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -253,7 +253,6 @@ impl SubagentController {
         let target_owned = target.to_string();
         Box::pin(async move {
             let subtree_ids = self_owned.collect_spawn_subtree_ids(&target_owned).await?;
-            let subtree_set = subtree_ids.iter().collect::<std::collections::HashSet<_>>();
             let mut restart_ids = Vec::new();
             for node_id in subtree_ids.iter() {
                 if self_owned.reopen_single(node_id.as_str()).await? {
@@ -265,20 +264,7 @@ impl SubagentController {
             // resumed subtree (mirroring close_tree's sibling isolation).
             // Grandchildren live in the child controller's state, so they are
             // reopened through that controller to keep node ownership correct.
-            let nested = {
-                let state = self_owned.state.read().await;
-                state
-                    .children
-                    .iter()
-                    .filter(|(id, _)| subtree_set.contains(id))
-                    .filter_map(|(_, record)| {
-                        record
-                            .child_controller
-                            .clone()
-                            .map(|controller| (controller, record.session_id.clone()))
-                    })
-                    .collect::<Vec<_>>()
-            };
+            let nested = self_owned.nested_controllers_in_subtree(&subtree_ids).await;
             for (controller, session_id) in nested {
                 let ids = controller.spawn_child_ids_for_parent(&session_id).await;
                 for id in ids {
@@ -316,21 +302,7 @@ impl SubagentController {
         let target_owned = target.to_string();
         Box::pin(async move {
             let subtree_ids = self_owned.collect_spawn_subtree_ids(&target_owned).await?;
-            let subtree_set = subtree_ids.iter().collect::<std::collections::HashSet<_>>();
-            let nested = {
-                let state = self_owned.state.read().await;
-                state
-                    .children
-                    .iter()
-                    .filter(|(id, _)| subtree_set.contains(id))
-                    .filter_map(|(_, record)| {
-                        record
-                            .child_controller
-                            .clone()
-                            .map(|controller| (controller, record.session_id.clone()))
-                    })
-                    .collect::<Vec<_>>()
-            };
+            let nested = self_owned.nested_controllers_in_subtree(&subtree_ids).await;
             // Mark every child-scoped controller in the subtree as closing so
             // it rejects new grandchild spawns before we start aborting.
             for (controller, _) in &nested {
@@ -458,6 +430,25 @@ impl SubagentController {
         }
 
         Ok(subtree_ids)
+    }
+
+    /// Collects the child-scoped controllers owned by records inside `subtree_ids`,
+    /// paired with each owning record's session id. Shared by `resume_tree` and
+    /// `close_tree` so subtree isolation cannot diverge between them.
+    async fn nested_controllers_in_subtree(&self, subtree_ids: &[String]) -> Vec<(Arc<SubagentController>, String)> {
+        let subtree_set = subtree_ids.iter().collect::<std::collections::HashSet<_>>();
+        let state = self.state.read().await;
+        state
+            .children
+            .iter()
+            .filter(|(id, _)| subtree_set.contains(id))
+            .filter_map(|(_, record)| {
+                record
+                    .child_controller
+                    .clone()
+                    .map(|controller| (controller, record.session_id.clone()))
+            })
+            .collect()
     }
 
     pub(super) async fn reopen_single(&self, target: &str) -> Result<bool> {

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -282,7 +282,9 @@ impl SubagentController {
             for (controller, session_id) in nested {
                 let ids = controller.spawn_child_ids_for_parent(&session_id).await;
                 for id in ids {
-                    let _ = controller.resume_tree(&id).await;
+                    if let Err(err) = controller.resume_tree(&id).await {
+                        tracing::warn!(node_id = id.as_str(), error = %err, "Failed to resume nested subagent subtree");
+                    }
                 }
             }
             for restart_id in restart_ids {
@@ -349,7 +351,9 @@ impl SubagentController {
             for (controller, session_id) in nested {
                 let ids = controller.spawn_child_ids_for_parent(&session_id).await;
                 for id in ids {
-                    let _ = controller.close_tree(&id).await;
+                    if let Err(err) = controller.close_tree(&id).await {
+                        tracing::warn!(node_id = id.as_str(), error = %err, "Failed to close nested subagent subtree");
+                    }
                 }
             }
             self_owned.status_for(&target_owned).await
@@ -753,7 +757,9 @@ impl SubagentController {
         for (controller, session_id) in nested {
             let ids = controller.spawn_child_ids_for_parent(&session_id).await;
             for id in ids {
-                let _ = controller.close_tree(&id).await;
+                if let Err(err) = controller.close_tree(&id).await {
+                    tracing::warn!(node_id = id.as_str(), error = %err, "Failed to close nested subagent subtree during shutdown");
+                }
             }
         }
     }

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -418,24 +418,33 @@ impl SubagentController {
     }
 
     pub(super) async fn reopen_single(&self, target: &str) -> Result<bool> {
-        let mut state = self.state.write().await;
-        let record = state
-            .children
-            .get_mut(target)
-            .ok_or_else(|| anyhow!("Unknown subagent id {target}"))?;
-        if matches!(record.status, SubagentStatus::Running | SubagentStatus::Queued) {
-            return Ok(false);
+        let child_controller = {
+            let mut state = self.state.write().await;
+            let record = state
+                .children
+                .get_mut(target)
+                .ok_or_else(|| anyhow!("Unknown subagent id {target}"))?;
+            if matches!(record.status, SubagentStatus::Running | SubagentStatus::Queued) {
+                return Ok(false);
+            }
+            let prompt = record
+                .last_prompt
+                .clone()
+                .unwrap_or_else(|| "Continue the delegated task from the existing context.".to_string());
+            record.status = SubagentStatus::Queued;
+            record.updated_at = Utc::now();
+            record.completed_at = None;
+            record.error = None;
+            record.summary = None;
+            record.queued_prompts.push_back(prompt);
+            record.child_controller.clone()
+        };
+        // Reopening a subtree reverses the transient `begin_close` on any
+        // child-scoped controller so a resumed child can delegate again (and
+        // its controller resumes saving background state).
+        if let Some(controller) = child_controller {
+            controller.end_close().await;
         }
-        let prompt = record
-            .last_prompt
-            .clone()
-            .unwrap_or_else(|| "Continue the delegated task from the existing context.".to_string());
-        record.status = SubagentStatus::Queued;
-        record.updated_at = Utc::now();
-        record.completed_at = None;
-        record.error = None;
-        record.summary = None;
-        record.queued_prompts.push_back(prompt);
         Ok(true)
     }
 
@@ -660,9 +669,18 @@ impl SubagentController {
     /// Marks this controller as closing so [`Self::spawn`] rejects new spawns.
     ///
     /// Used before aborting a subtree so a still-running child cannot spawn a
-    /// descendant between the descendant snapshot and the handle abort.
+    /// descendant between the descendant snapshot and the handle abort. Unlike
+    /// [`Self::signal_shutdown`] this uses the transient `closing` flag, which
+    /// is cleared again when the subtree is reopened, so a resumed child can
+    /// delegate and its controller keeps saving background state.
     pub(super) async fn begin_close(&self) {
-        self.shutdown_requested.store(true, Ordering::Relaxed);
+        self.closing.store(true, Ordering::Relaxed);
+    }
+
+    /// Clears the transient close-in-progress flag. Called when a closed
+    /// subtree is reopened so its child-scoped controller can delegate again.
+    pub(super) async fn end_close(&self) {
+        self.closing.store(false, Ordering::Relaxed);
     }
 
     /// Signal that the program is shutting down. Subsequent calls to
@@ -684,9 +702,11 @@ impl SubagentController {
             }
             nested
         };
-        // Mark every child-scoped controller as closing before enumerating
-        // descendants so a race cannot let a fresh grandchild outlive shutdown.
+        // Mark every child-scoped controller as permanently shut down (so its
+        // background state is not saved) and as closing (so a race cannot let
+        // a fresh grandchild outlive shutdown), then cascade.
         for (controller, _) in &nested {
+            controller.shutdown_requested.store(true, Ordering::Relaxed);
             controller.begin_close().await;
         }
         // Cascade shutdown to child-scoped controllers so grandchildren tasks
@@ -852,7 +872,7 @@ impl SubagentController {
         if !self.config.vt_cfg.subagents.enabled {
             bail!("Subagents are disabled by configuration");
         }
-        if self.shutdown_requested.load(Ordering::Relaxed) {
+        if self.shutdown_requested.load(Ordering::Relaxed) || self.closing.load(Ordering::Relaxed) {
             bail!("Subagent controller is shutting down; cannot spawn new subagents");
         }
         if self.config.depth.saturating_add(1) > self.config.vt_cfg.subagents.max_depth {

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -265,19 +265,16 @@ impl SubagentController {
     /// Unlike [`Self::close`] this is recursive over child-scoped controllers,
     /// so it works for arbitrary `max_depth`. The recursion is boxed to satisfy
     /// Rust's async-fn recursion requirement.
+    ///
+    /// Ordering prevents a race where a still-running child spawns a new
+    /// descendant after the descendant snapshot: each child-scoped controller
+    /// is marked as closing (which rejects new spawns via `spawn_with_spec`)
+    /// before the owning child's handle is aborted and its subtree is closed.
     fn close_tree(&self, target: &str) -> BoxFuture<'static, Result<SubagentStatusEntry>> {
         let self_owned = self.clone();
         let target_owned = target.to_string();
         Box::pin(async move {
-            // Close the target's own subtree (deepest first) on this
-            // controller...
             let subtree_ids = self_owned.collect_spawn_subtree_ids(&target_owned).await?;
-            // ...then recursively close each child-scoped controller's subtree.
-            // Grandchildren live in the child controller's state, not ours, so
-            // they are closed through that controller to keep node ownership
-            // correct. Only controllers of nodes inside the closed subtree are
-            // cascaded, so closing one subagent never kills a sibling's
-            // descendants.
             let subtree_set = subtree_ids.iter().collect::<std::collections::HashSet<_>>();
             let nested = {
                 let state = self_owned.state.read().await;
@@ -293,14 +290,28 @@ impl SubagentController {
                     })
                     .collect::<Vec<_>>()
             };
+            // Mark every child-scoped controller in the subtree as closing so
+            // it rejects new grandchild spawns before we start aborting.
+            for (controller, _) in &nested {
+                controller.begin_close().await;
+            }
+            // Close the target's own subtree (deepest first) on this
+            // controller. Aborting the owning child's handle first stops it
+            // from spawning further descendants.
+            for node_id in subtree_ids.into_iter().rev() {
+                self_owned.close_single(node_id.as_str()).await?;
+            }
+            // ...then recursively close each child-scoped controller's subtree.
+            // Grandchildren live in the child controller's state, not ours, so
+            // they are closed through that controller to keep node ownership
+            // correct. Only controllers of nodes inside the closed subtree are
+            // cascaded, so closing one subagent never kills a sibling's
+            // descendants.
             for (controller, session_id) in nested {
                 let ids = controller.spawn_child_ids_for_parent(&session_id).await;
                 for id in ids {
                     let _ = controller.close_tree(&id).await;
                 }
-            }
-            for node_id in subtree_ids.into_iter().rev() {
-                self_owned.close_single(node_id.as_str()).await?;
             }
             self_owned.status_for(&target_owned).await
         })
@@ -646,6 +657,14 @@ impl SubagentController {
         Ok(())
     }
 
+    /// Marks this controller as closing so [`Self::spawn`] rejects new spawns.
+    ///
+    /// Used before aborting a subtree so a still-running child cannot spawn a
+    /// descendant between the descendant snapshot and the handle abort.
+    pub(super) async fn begin_close(&self) {
+        self.shutdown_requested.store(true, Ordering::Relaxed);
+    }
+
     /// Signal that the program is shutting down. Subsequent calls to
     /// `save_background_state` will be skipped. All running child handles
     /// are aborted so subagent tasks do not outlive the parent session.
@@ -665,6 +684,11 @@ impl SubagentController {
             }
             nested
         };
+        // Mark every child-scoped controller as closing before enumerating
+        // descendants so a race cannot let a fresh grandchild outlive shutdown.
+        for (controller, _) in &nested {
+            controller.begin_close().await;
+        }
         // Cascade shutdown to child-scoped controllers so grandchildren tasks
         // are aborted too; otherwise their tokio tasks keep running detached.
         for (controller, session_id) in nested {
@@ -827,6 +851,9 @@ impl SubagentController {
     ) -> Result<SubagentStatusEntry> {
         if !self.config.vt_cfg.subagents.enabled {
             bail!("Subagents are disabled by configuration");
+        }
+        if self.shutdown_requested.load(Ordering::Relaxed) {
+            bail!("Subagent controller is shutting down; cannot spawn new subagents");
         }
         if self.config.depth.saturating_add(1) > self.config.vt_cfg.subagents.max_depth {
             bail!("Subagent depth limit reached (max_depth={})", self.config.vt_cfg.subagents.max_depth);

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -253,13 +253,16 @@ impl SubagentController {
         let target_owned = target.to_string();
         Box::pin(async move {
             let subtree_ids = self_owned.collect_spawn_subtree_ids(&target_owned).await?;
+            let subtree_set = subtree_ids.iter().collect::<std::collections::HashSet<_>>();
             let mut restart_ids = Vec::new();
-            for node_id in subtree_ids {
+            for node_id in subtree_ids.iter() {
                 if self_owned.reopen_single(node_id.as_str()).await? {
-                    restart_ids.push(node_id);
+                    restart_ids.push(node_id.clone());
                 }
             }
-            // Recursively resume each child-scoped controller's descendants.
+            // Recursively resume each child-scoped controller's descendants,
+            // but only for controllers whose owning record is inside the
+            // resumed subtree (mirroring close_tree's sibling isolation).
             // Grandchildren live in the child controller's state, so they are
             // reopened through that controller to keep node ownership correct.
             let nested = {
@@ -267,6 +270,7 @@ impl SubagentController {
                 state
                     .children
                     .iter()
+                    .filter(|(id, _)| subtree_set.contains(id))
                     .filter_map(|(_, record)| {
                         record
                             .child_controller
@@ -975,14 +979,14 @@ impl SubagentController {
             format!("{}-{}", sanitize_component(parent_session_id.as_str()), sanitize_component(id.as_str()));
         let display_label = subagent_display_label(&spec);
         let notify = Arc::new(Notify::new());
-        // Re-check the close gates immediately before insertion. The earlier
+        let mut state = self.state.write().await;
+        // Re-check the close gates while the write lock is held. The earlier
         // check can race with a concurrent `close_tree` that snapshots and
         // closes the subtree between this spawn's admission and its record
-        // insertion; re-checking under the write lock closes that window.
+        // insertion; checking after acquisition closes that window.
         if self.shutdown_requested.load(Ordering::Relaxed) || self.closing.load(Ordering::Relaxed) {
             bail!("Subagent controller is shutting down; cannot spawn new subagents");
         }
-        let mut state = self.state.write().await;
         let initial_messages = if fork_context {
             state.parent_messages.clone()
         } else {

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -238,19 +238,54 @@ impl SubagentController {
         self.status_for(&request.target).await
     }
 
-    /// Resumes a closed or errored subagent and its children by re-queuing their prompts.
+    /// Resumes a closed or errored subagent and its descendants by re-queuing
+    /// their prompts. Cascades recursively through child-scoped controllers so
+    /// grandchildren closed by [`Self::close_tree`] are resumed too, not merely
+    /// un-gated.
     pub async fn resume(&self, target: &str) -> Result<SubagentStatusEntry> {
-        let subtree_ids = self.collect_spawn_subtree_ids(target).await?;
-        let mut restart_ids = Vec::new();
-        for node_id in subtree_ids {
-            if self.reopen_single(node_id.as_str()).await? {
-                restart_ids.push(node_id);
+        self.resume_tree(target).await
+    }
+
+    /// Recursively reopens `target` and every descendant across the whole
+    /// delegation tree (boxed for async recursion, mirroring [`Self::close_tree`]).
+    fn resume_tree(&self, target: &str) -> BoxFuture<'static, Result<SubagentStatusEntry>> {
+        let self_owned = self.clone();
+        let target_owned = target.to_string();
+        Box::pin(async move {
+            let subtree_ids = self_owned.collect_spawn_subtree_ids(&target_owned).await?;
+            let mut restart_ids = Vec::new();
+            for node_id in subtree_ids {
+                if self_owned.reopen_single(node_id.as_str()).await? {
+                    restart_ids.push(node_id);
+                }
             }
-        }
-        for restart_id in restart_ids {
-            self.restart_child(&restart_id).await?;
-        }
-        self.status_for(target).await
+            // Recursively resume each child-scoped controller's descendants.
+            // Grandchildren live in the child controller's state, so they are
+            // reopened through that controller to keep node ownership correct.
+            let nested = {
+                let state = self_owned.state.read().await;
+                state
+                    .children
+                    .iter()
+                    .filter_map(|(_, record)| {
+                        record
+                            .child_controller
+                            .clone()
+                            .map(|controller| (controller, record.session_id.clone()))
+                    })
+                    .collect::<Vec<_>>()
+            };
+            for (controller, session_id) in nested {
+                let ids = controller.spawn_child_ids_for_parent(&session_id).await;
+                for id in ids {
+                    let _ = controller.resume_tree(&id).await;
+                }
+            }
+            for restart_id in restart_ids {
+                self_owned.restart_child(&restart_id).await?;
+            }
+            self_owned.status_for(&target_owned).await
+        })
     }
 
     /// Closes a subagent and all its descendants, aborting any in-flight work.
@@ -940,6 +975,13 @@ impl SubagentController {
             format!("{}-{}", sanitize_component(parent_session_id.as_str()), sanitize_component(id.as_str()));
         let display_label = subagent_display_label(&spec);
         let notify = Arc::new(Notify::new());
+        // Re-check the close gates immediately before insertion. The earlier
+        // check can race with a concurrent `close_tree` that snapshots and
+        // closes the subtree between this spawn's admission and its record
+        // insertion; re-checking under the write lock closes that window.
+        if self.shutdown_requested.load(Ordering::Relaxed) || self.closing.load(Ordering::Relaxed) {
+            bail!("Subagent controller is shutting down; cannot spawn new subagents");
+        }
         let mut state = self.state.write().await;
         let initial_messages = if fork_context {
             state.parent_messages.clone()

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -4,7 +4,7 @@
 )]
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::Utc;
-use futures::future::select_all;
+use futures::future::{BoxFuture, select_all};
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -255,11 +255,55 @@ impl SubagentController {
 
     /// Closes a subagent and all its descendants, aborting any in-flight work.
     pub async fn close(&self, target: &str) -> Result<SubagentStatusEntry> {
-        let subtree_ids = self.collect_spawn_subtree_ids(target).await?;
-        for node_id in subtree_ids.into_iter().rev() {
-            self.close_single(node_id.as_str()).await?;
-        }
-        self.status_for(target).await
+        // `close_tree` walks the full nesting tree (including grandchildren
+        // spawned through child-scoped controllers) and closes bottom-up.
+        self.close_tree(target).await
+    }
+
+    /// Closes `target` and every descendant across the whole delegation tree.
+    ///
+    /// Unlike [`Self::close`] this is recursive over child-scoped controllers,
+    /// so it works for arbitrary `max_depth`. The recursion is boxed to satisfy
+    /// Rust's async-fn recursion requirement.
+    fn close_tree(&self, target: &str) -> BoxFuture<'static, Result<SubagentStatusEntry>> {
+        let self_owned = self.clone();
+        let target_owned = target.to_string();
+        Box::pin(async move {
+            // Close the target's own subtree (deepest first) on this
+            // controller...
+            let subtree_ids = self_owned.collect_spawn_subtree_ids(&target_owned).await?;
+            // ...then recursively close each child-scoped controller's subtree.
+            // Grandchildren live in the child controller's state, not ours, so
+            // they are closed through that controller to keep node ownership
+            // correct. Only controllers of nodes inside the closed subtree are
+            // cascaded, so closing one subagent never kills a sibling's
+            // descendants.
+            let subtree_set = subtree_ids.iter().collect::<std::collections::HashSet<_>>();
+            let nested = {
+                let state = self_owned.state.read().await;
+                state
+                    .children
+                    .iter()
+                    .filter(|(id, _)| subtree_set.contains(id))
+                    .filter_map(|(_, record)| {
+                        record
+                            .child_controller
+                            .clone()
+                            .map(|controller| (controller, record.session_id.clone()))
+                    })
+                    .collect::<Vec<_>>()
+            };
+            for (controller, session_id) in nested {
+                let ids = controller.spawn_child_ids_for_parent(&session_id).await;
+                for id in ids {
+                    let _ = controller.close_tree(&id).await;
+                }
+            }
+            for node_id in subtree_ids.into_iter().rev() {
+                self_owned.close_single(node_id.as_str()).await?;
+            }
+            self_owned.status_for(&target_owned).await
+        })
     }
 
     /// Blocks until one of the target subagents reaches a terminal state or the timeout expires.
@@ -607,12 +651,27 @@ impl SubagentController {
     /// are aborted so subagent tasks do not outlive the parent session.
     pub async fn signal_shutdown(&self) {
         self.shutdown_requested.store(true, Ordering::Relaxed);
-        let mut state = self.state.write().await;
-        for record in state.children.values_mut() {
-            if let Some(handle) = record.handle.take() {
-                handle.abort();
+        let nested = {
+            let mut state = self.state.write().await;
+            let mut nested = Vec::new();
+            for record in state.children.values_mut() {
+                if let Some(handle) = record.handle.take() {
+                    handle.abort();
+                }
+                record.status = SubagentStatus::Closed;
+                if let Some(controller) = record.child_controller.clone() {
+                    nested.push((controller, record.session_id.clone()));
+                }
             }
-            record.status = SubagentStatus::Closed;
+            nested
+        };
+        // Cascade shutdown to child-scoped controllers so grandchildren tasks
+        // are aborted too; otherwise their tokio tasks keep running detached.
+        for (controller, session_id) in nested {
+            let ids = controller.spawn_child_ids_for_parent(&session_id).await;
+            for id in ids {
+                let _ = controller.close_tree(&id).await;
+            }
         }
     }
 
@@ -772,6 +831,14 @@ impl SubagentController {
         if self.config.depth.saturating_add(1) > self.config.vt_cfg.subagents.max_depth {
             bail!("Subagent depth limit reached (max_depth={})", self.config.vt_cfg.subagents.max_depth);
         }
+        if self.config.depth > 0 && spec.isolation == Some(vtcode_config::IsolationMode::Worktree) {
+            bail!(
+                "Subagent '{}' requests isolation=worktree, but nested worktree isolation is not supported \
+                 (child-scoped controllers operate inside the parent's worktree). Use isolation=worktree only \
+                 at the root delegation level.",
+                spec.name
+            );
+        }
         // Create a worktree for isolation if requested.
         let worktree_path = if spec.isolation == Some(vtcode_config::IsolationMode::Worktree) {
             let workspace_root = self.config.workspace_root.clone();
@@ -816,6 +883,7 @@ impl SubagentController {
             child_max_turns,
             model_override.as_deref(),
             reasoning_override.as_deref(),
+            self.config.depth.saturating_add(2) <= self.config.vt_cfg.subagents.max_depth,
             resolve_effective_subagent_model,
         )?;
 
@@ -859,6 +927,7 @@ impl SubagentController {
             handle: None,
             notify,
             worktree_path,
+            child_controller: None,
         };
         state.children.insert(id.clone(), entry);
         drop(state);

--- a/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_spawn_run.rs
@@ -429,7 +429,7 @@ impl SubagentController {
         Ok(record.build_status_entry())
     }
 
-    async fn spawn_child_ids_for_parent(&self, parent_thread_id: &str) -> Vec<String> {
+    pub(super) async fn spawn_child_ids_for_parent(&self, parent_thread_id: &str) -> Vec<String> {
         let state = self.state.read().await;
         let mut child_ids = state
             .children
@@ -992,7 +992,7 @@ impl SubagentController {
             child_max_turns,
             model_override.as_deref(),
             reasoning_override.as_deref(),
-            self.config.depth.saturating_add(2) <= self.config.vt_cfg.subagents.max_depth,
+            !spec.is_read_only() && self.config.depth.saturating_add(2) <= self.config.vt_cfg.subagents.max_depth,
             resolve_effective_subagent_model,
         )?;
 

--- a/crates/codegen/vtcode-core/src/subagents/mod.rs
+++ b/crates/codegen/vtcode-core/src/subagents/mod.rs
@@ -146,6 +146,12 @@ pub struct SubagentController {
     lifecycle_hooks: Option<LifecycleHookEngine>,
     state: Arc<RwLock<ControllerState>>,
     shutdown_requested: Arc<AtomicBool>,
+    /// Transient close-in-progress flag. Unlike `shutdown_requested` this is
+    /// cleared when a subtree is reopened via `reopen_single`, so a resumed
+    /// child can delegate again and its controller keeps saving background
+    /// state. Set only while `close_tree`/`signal_shutdown` are tearing a
+    /// subtree down.
+    closing: Arc<AtomicBool>,
 }
 
 impl SubagentController {
@@ -185,6 +191,7 @@ impl SubagentController {
                 background_children,
             })),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
+            closing: Arc::new(AtomicBool::new(false)),
         })
     }
 

--- a/crates/codegen/vtcode-core/src/subagents/tests.rs
+++ b/crates/codegen/vtcode-core/src/subagents/tests.rs
@@ -2102,6 +2102,24 @@ async fn spawn_is_rejected_after_close_begins() {
 }
 
 #[tokio::test]
+async fn resume_rejected_after_shutdown() {
+    let temp = TempDir::new().expect("tempdir");
+    let controller =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+            .await
+            .expect("controller");
+
+    controller.signal_shutdown().await;
+
+    let err = controller
+        .resume("some-agent")
+        .await
+        .expect_err("resume after shutdown must be rejected");
+
+    assert!(err.to_string().contains("shutting down"));
+}
+
+#[tokio::test]
 async fn resume_restores_closed_grandchildren() {
     let temp = TempDir::new().expect("tempdir");
     let parent = SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))

--- a/crates/codegen/vtcode-core/src/subagents/tests.rs
+++ b/crates/codegen/vtcode-core/src/subagents/tests.rs
@@ -2077,6 +2077,19 @@ async fn spawn_is_rejected_after_close_begins() {
         .expect_err("spawn after close began must be rejected");
 
     assert!(err.to_string().contains("shutting down"));
+
+    // Reopening the subtree clears the transient close flag, so a resumed
+    // child can delegate again. Permanent `shutdown_requested` stays set only
+    // for real shutdown, not for a subtree close.
+    child_controller.end_close().await;
+    child_controller
+        .spawn(SpawnAgentRequest {
+            agent_type: Some("explorer".to_string()),
+            message: Some("Inspect the codebase.".to_string()),
+            ..SpawnAgentRequest::default()
+        })
+        .await
+        .expect("spawn after end_close must be allowed again");
 }
 
 #[tokio::test]

--- a/crates/codegen/vtcode-core/src/subagents/tests.rs
+++ b/crates/codegen/vtcode-core/src/subagents/tests.rs
@@ -1857,6 +1857,11 @@ async fn spawn_from_child_controller_respects_depth_limit() {
         .expect_err("spawn at depth == max_depth should hit the depth limit");
 
     assert!(err.to_string().contains("Subagent depth limit reached (max_depth=2)"));
+
+    // Abort queued child tasks so they cannot run provider work after the
+    // temp workspace is removed.
+    child_controller.signal_shutdown().await;
+    grandchild_controller.signal_shutdown().await;
 }
 
 #[tokio::test]
@@ -2090,6 +2095,10 @@ async fn spawn_is_rejected_after_close_begins() {
         })
         .await
         .expect("spawn after end_close must be allowed again");
+
+    // Abort the queued child task so it cannot run provider work after the
+    // temp workspace is removed.
+    child_controller.signal_shutdown().await;
 }
 
 #[tokio::test]
@@ -2156,6 +2165,10 @@ async fn resume_restores_closed_grandchildren() {
         "resumed grandchild must be re-queued, got {:?}",
         resumed_grandchild.status
     );
+
+    // Abort restarted child tasks so they cannot run provider work after the
+    // temp workspace is removed.
+    parent.signal_shutdown().await;
 }
 
 #[tokio::test]
@@ -2258,6 +2271,10 @@ async fn resume_does_not_affect_sibling_grandchildren() {
         SubagentStatus::Closed,
         "resuming sibling 'a' must not reopen sibling 'b''s grandchildren"
     );
+
+    // Abort restarted child tasks so they cannot run provider work after the
+    // temp workspace is removed.
+    parent.signal_shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/codegen/vtcode-core/src/subagents/tests.rs
+++ b/crates/codegen/vtcode-core/src/subagents/tests.rs
@@ -2159,6 +2159,108 @@ async fn resume_restores_closed_grandchildren() {
 }
 
 #[tokio::test]
+async fn resume_does_not_affect_sibling_grandchildren() {
+    let temp = TempDir::new().expect("tempdir");
+    let parent = SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+        .await
+        .expect("parent controller");
+
+    let spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "explorer")
+        .expect("explorer");
+
+    // Two siblings each with their own child-scoped controller and a grandchild.
+    let controller_a =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+            .await
+            .expect("controller a");
+    {
+        let mut state = controller_a.state.write().await;
+        state.children.insert(
+            "a-grandchild".to_string(),
+            test_child_record(
+                "a-grandchild",
+                "session-a-grandchild",
+                "session-a",
+                &spec,
+                SubagentStatus::Running,
+                2,
+                None,
+            ),
+        );
+    }
+    let controller_b =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+            .await
+            .expect("controller b");
+    {
+        let mut state = controller_b.state.write().await;
+        state.children.insert(
+            "b-grandchild".to_string(),
+            test_child_record(
+                "b-grandchild",
+                "session-b-grandchild",
+                "session-b",
+                &spec,
+                SubagentStatus::Running,
+                2,
+                None,
+            ),
+        );
+    }
+    let controller_a = std::sync::Arc::new(controller_a);
+    let controller_b = std::sync::Arc::new(controller_b);
+    {
+        let mut state = parent.state.write().await;
+        state.children.insert(
+            "a".to_string(),
+            test_child_record(
+                "a",
+                "session-a",
+                "parent-session",
+                &spec,
+                SubagentStatus::Running,
+                1,
+                Some(controller_a.clone()),
+            ),
+        );
+        state.children.insert(
+            "b".to_string(),
+            test_child_record(
+                "b",
+                "session-b",
+                "parent-session",
+                &spec,
+                SubagentStatus::Running,
+                1,
+                Some(controller_b.clone()),
+            ),
+        );
+    }
+
+    // Close both siblings' grandchildren, then resume only "a": "b"'s
+    // grandchild must stay closed (resume_tree must respect subtree isolation).
+    parent.close("a").await.expect("close a");
+    parent.close("b").await.expect("close b");
+
+    parent.resume("a").await.expect("resume a");
+
+    let a_grandchild = controller_a.status_for("a-grandchild").await.expect("a-grandchild status");
+    assert!(
+        matches!(a_grandchild.status, SubagentStatus::Queued | SubagentStatus::Running),
+        "resumed 'a''s grandchild must be re-queued, got {:?}",
+        a_grandchild.status
+    );
+    let b_grandchild = controller_b.status_for("b-grandchild").await.expect("b-grandchild status");
+    assert_eq!(
+        b_grandchild.status,
+        SubagentStatus::Closed,
+        "resuming sibling 'a' must not reopen sibling 'b''s grandchildren"
+    );
+}
+
+#[tokio::test]
 async fn wait_returns_first_terminal_child() {
     let temp = TempDir::new().expect("tempdir");
     let controller =

--- a/crates/codegen/vtcode-core/src/subagents/tests.rs
+++ b/crates/codegen/vtcode-core/src/subagents/tests.rs
@@ -15,8 +15,8 @@ use tempfile::TempDir;
 use tokio::sync::Notify;
 use vtcode_config::core::permissions::{AgentPermissionsConfig, PermissionDefault};
 use vtcode_config::{
-    HookCommandConfig, HookGroupConfig, HooksConfig, SubagentMcpServer, SubagentMemoryScope, SubagentSource,
-    SubagentSpec,
+    HookCommandConfig, HookGroupConfig, HooksConfig, IsolationMode, SubagentMcpServer, SubagentMemoryScope,
+    SubagentSource, SubagentSpec,
 };
 
 fn readonly_agent_permissions() -> AgentPermissionsConfig {
@@ -79,6 +79,7 @@ fn test_child_record(
         handle: None,
         notify: Arc::new(Notify::new()),
         worktree_path: None,
+        child_controller: None,
     }
 }
 
@@ -455,7 +456,81 @@ fn filter_child_tools_keeps_public_read_tools_and_removes_mutation_tools() {
         .into_iter()
         .find(|spec| spec.name == "explorer")
         .expect("explorer");
-    let filtered = filter_child_tools(&spec, defs, true);
+    let filtered = filter_child_tools(&spec, defs, true, false);
+    let names = filtered.iter().map(ToolDefinition::function_name).collect::<Vec<_>>();
+    assert_eq!(names, vec![tools::CODE_SEARCH]);
+}
+
+#[test]
+fn filter_child_tools_keeps_delegation_tools_when_nested_delegation_allowed() {
+    let defs = vec![
+        ToolDefinition::function(tools::AGENT.to_string(), "Agent".to_string(), serde_json::json!({"type": "object"})),
+        ToolDefinition::function(
+            tools::SPAWN_AGENT.to_string(),
+            "Spawn".to_string(),
+            serde_json::json!({"type": "object"}),
+        ),
+        ToolDefinition::function(
+            tools::SEND_INPUT.to_string(),
+            "Send".to_string(),
+            serde_json::json!({"type": "object"}),
+        ),
+        ToolDefinition::function(
+            tools::WAIT_AGENT.to_string(),
+            "Wait".to_string(),
+            serde_json::json!({"type": "object"}),
+        ),
+        ToolDefinition::function(
+            tools::SPAWN_BACKGROUND_SUBPROCESS.to_string(),
+            "Bg".to_string(),
+            serde_json::json!({"type": "object"}),
+        ),
+        ToolDefinition::function(
+            tools::CODE_SEARCH.to_string(),
+            "Search".to_string(),
+            serde_json::json!({"type": "object"}),
+        ),
+    ];
+    let spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "worker")
+        .expect("worker");
+
+    let filtered = filter_child_tools(&spec, defs, false, true);
+    let names = filtered.iter().map(ToolDefinition::function_name).collect::<Vec<_>>();
+
+    assert!(names.contains(&tools::AGENT), "agent tool stays exposed when nested delegation is allowed");
+    assert!(names.contains(&tools::SPAWN_AGENT));
+    assert!(names.contains(&tools::SEND_INPUT));
+    assert!(names.contains(&tools::WAIT_AGENT));
+    assert!(
+        !names.contains(&tools::SPAWN_BACKGROUND_SUBPROCESS),
+        "background subprocess alias stays blocked for children"
+    );
+    assert!(names.contains(&tools::CODE_SEARCH));
+}
+
+#[test]
+fn filter_child_tools_removes_delegation_tools_by_default() {
+    let defs = vec![
+        ToolDefinition::function(tools::AGENT.to_string(), "Agent".to_string(), serde_json::json!({"type": "object"})),
+        ToolDefinition::function(
+            tools::SPAWN_AGENT.to_string(),
+            "Spawn".to_string(),
+            serde_json::json!({"type": "object"}),
+        ),
+        ToolDefinition::function(
+            tools::CODE_SEARCH.to_string(),
+            "Search".to_string(),
+            serde_json::json!({"type": "object"}),
+        ),
+    ];
+    let spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "worker")
+        .expect("worker");
+
+    let filtered = filter_child_tools(&spec, defs, false, false);
     let names = filtered.iter().map(ToolDefinition::function_name).collect::<Vec<_>>();
     assert_eq!(names, vec![tools::CODE_SEARCH]);
 }
@@ -501,7 +576,7 @@ fn filter_child_tools_keeps_command_session_for_shell_capable_agents() {
         tool_policy_overrides: BTreeMap::new(),
     };
 
-    let filtered = filter_child_tools(&spec, defs, spec.is_read_only());
+    let filtered = filter_child_tools(&spec, defs, spec.is_read_only(), false);
     assert_eq!(filtered.len(), 2);
     assert_eq!(filtered[0].function_name(), tools::UNIFIED_EXEC);
     assert_eq!(filtered[1].function_name(), tools::CODE_SEARCH);
@@ -527,11 +602,70 @@ fn build_child_config_intersects_allowed_tools_and_preserves_global_denies() {
         tools::READ_FILE.to_string(),
     ]);
 
-    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
     assert_eq!(child.runtime_agent_permissions.as_ref(), Some(&spec.permissions));
     assert_eq!(child.permissions.allow, vec![tools::READ_FILE.to_string(), tools::CODE_SEARCH.to_string()]);
     assert!(child.permissions.deny.contains(&tools::UNIFIED_EXEC.to_string()));
     assert!(child.permissions.deny.contains(&tools::SPAWN_AGENT.to_string()));
+}
+
+#[test]
+fn build_child_config_allows_nested_delegation_keeps_agent_tools_out_of_deny() {
+    let mut parent = VTCodeConfig::default();
+    parent.permissions.allow = vec![
+        tools::SPAWN_AGENT.to_string(),
+        tools::WAIT_AGENT.to_string(),
+        tools::CODE_SEARCH.to_string(),
+    ];
+
+    let mut spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "worker")
+        .expect("worker");
+    spec.tools = Some(parent.permissions.allow.clone());
+
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, true);
+
+    assert_eq!(
+        child.permissions.allow,
+        vec![
+            tools::SPAWN_AGENT.to_string(),
+            tools::WAIT_AGENT.to_string(),
+            tools::CODE_SEARCH.to_string()
+        ],
+        "nested delegation keeps delegation tools in the allow-list"
+    );
+    assert!(
+        !child.permissions.deny.contains(&tools::SPAWN_AGENT.to_string()),
+        "spawn_agent must not be denied when nested delegation is allowed"
+    );
+    assert!(
+        !child.permissions.deny.contains(&tools::AGENT.to_string()),
+        "agent must not be denied when nested delegation is allowed"
+    );
+    assert!(
+        child.permissions.deny.contains(&tools::SPAWN_BACKGROUND_SUBPROCESS.to_string()),
+        "background subprocess alias stays blocked for children"
+    );
+}
+
+#[test]
+fn build_child_config_default_denies_all_subagent_tools() {
+    let parent = VTCodeConfig::default();
+    let spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "worker")
+        .expect("worker");
+
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
+
+    assert!(child.permissions.deny.contains(&tools::SPAWN_AGENT.to_string()));
+    assert!(child.permissions.deny.contains(&tools::AGENT.to_string()));
+    assert!(child.permissions.deny.contains(&tools::SEND_INPUT.to_string()));
+    assert!(child.permissions.deny.contains(&tools::WAIT_AGENT.to_string()));
+    assert!(child.permissions.deny.contains(&tools::RESUME_AGENT.to_string()));
+    assert!(child.permissions.deny.contains(&tools::CLOSE_AGENT.to_string()));
+    assert!(child.permissions.deny.contains(&tools::SPAWN_BACKGROUND_SUBPROCESS.to_string()));
 }
 
 #[test]
@@ -558,7 +692,7 @@ fn build_child_config_preserves_subagent_lifecycle_stripping_and_hook_merging() 
     });
     spec.hooks = Some(hooks);
 
-    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
 
     assert_eq!(child.permissions.allow, vec![tools::CODE_SEARCH.to_string(), tools::UNIFIED_EXEC.to_string()]);
     assert!(child.permissions.deny.contains(&tools::SPAWN_AGENT.to_string()));
@@ -585,6 +719,7 @@ fn prepare_child_runtime_config_uses_shared_view_for_model_and_reasoning() {
         None,
         None,
         None,
+        false,
         |_, parent_model, parent_provider, model_override, spec_model, agent_name| {
             assert_eq!(parent_model, models::openai::GPT_5_6_SOL);
             assert_eq!(parent_provider, "openai");
@@ -638,7 +773,7 @@ fn build_child_config_preserves_matching_rule_and_exact_tool_ids() {
         tools::READ_FILE.to_string(),
     ]);
 
-    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
 
     assert_eq!(
         child.permissions.allow,
@@ -665,7 +800,7 @@ fn build_child_config_preserves_parent_rule_shaped_allowlist() {
         tools::UNIFIED_EXEC.to_string(),
     ]);
 
-    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
 
     assert_eq!(child.permissions.allow, vec!["Read".to_string()]);
 }
@@ -678,7 +813,7 @@ fn build_child_config_promotes_single_turn_budget_to_recovery_budget() {
         .find(|spec| spec.name == "worker")
         .expect("worker");
 
-    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, Some(1));
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, Some(1), false);
 
     assert_eq!(child.automation.full_auto.max_turns, SUBAGENT_MIN_MAX_TURNS);
 }
@@ -713,7 +848,7 @@ fn build_child_config_merges_inline_mcp_provider() {
         }),
     )]))];
 
-    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None);
+    let child = build_child_config(&parent, &spec, models::openai::GPT_5_6_SOL, None, false);
     let provider = child
         .mcp
         .providers
@@ -1660,6 +1795,7 @@ async fn spawn_rejects_fourth_active_subagent() {
                     handle: None,
                     notify: Arc::new(Notify::new()),
                     worktree_path: None,
+                    child_controller: None,
                 },
             );
         }
@@ -1680,6 +1816,365 @@ async fn spawn_rejects_fourth_active_subagent() {
                 SUBAGENT_HARD_CONCURRENCY_LIMIT
             )
         )));
+}
+
+#[tokio::test]
+async fn spawn_from_child_controller_respects_depth_limit() {
+    let temp = TempDir::new().expect("tempdir");
+    let mut vt_cfg = VTCodeConfig::default();
+    vt_cfg.subagents.max_depth = 2;
+
+    // Child controller runs at depth 1: it may spawn a grandchild (depth 2),
+    // but the grandchild itself (depth 2) may not spawn further.
+    let mut child_controller =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), vt_cfg.clone()))
+            .await
+            .expect("child controller");
+
+    let config = Arc::make_mut(&mut child_controller.config);
+    config.depth = 1;
+
+    child_controller
+        .spawn(SpawnAgentRequest {
+            agent_type: Some("explorer".to_string()),
+            message: Some("Inspect the codebase.".to_string()),
+            ..SpawnAgentRequest::default()
+        })
+        .await
+        .expect("grandchild spawn should be allowed at depth 1 with max_depth=2");
+
+    // Now a controller at depth 2 must refuse another spawn.
+    let mut grandchild_config = test_controller_config(temp.path().to_path_buf(), vt_cfg);
+    grandchild_config.depth = 2;
+    let grandchild_controller = SubagentController::new(grandchild_config).await.expect("grandchild controller");
+
+    let err = grandchild_controller
+        .spawn(SpawnAgentRequest {
+            agent_type: Some("explorer".to_string()),
+            message: Some("Inspect yet more.".to_string()),
+            ..SpawnAgentRequest::default()
+        })
+        .await
+        .expect_err("spawn at depth == max_depth should hit the depth limit");
+
+    assert!(err.to_string().contains("Subagent depth limit reached (max_depth=2)"));
+}
+
+#[tokio::test]
+async fn nested_spawn_rejects_worktree_isolation() {
+    let temp = TempDir::new().expect("tempdir");
+    let mut vt_cfg = VTCodeConfig::default();
+    vt_cfg.subagents.max_depth = 2;
+    let mut child_config = test_controller_config(temp.path().to_path_buf(), vt_cfg);
+    child_config.depth = 1;
+    let child_controller = SubagentController::new(child_config).await.expect("child controller");
+    child_controller
+        .set_turn_delegation_hints_from_input("delegate this task")
+        .await;
+
+    // Force the discovered "worker" spec to request worktree isolation so the
+    // nested-spawn guard can be exercised.
+    {
+        let mut state = child_controller.state.write().await;
+        if let Some(spec) = state.discovered.effective.iter_mut().find(|spec| spec.name == "worker") {
+            spec.isolation = Some(IsolationMode::Worktree);
+        }
+    }
+
+    let err = child_controller
+        .spawn(SpawnAgentRequest {
+            agent_type: Some("worker".to_string()),
+            message: Some("Implement a change.".to_string()),
+            ..SpawnAgentRequest::default()
+        })
+        .await
+        .expect_err("nested worktree isolation should be rejected");
+
+    assert!(err.to_string().contains("nested worktree isolation is not supported"));
+}
+
+#[tokio::test]
+async fn close_cascades_to_child_scoped_grandchildren() {
+    let temp = TempDir::new().expect("tempdir");
+    let parent = SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+        .await
+        .expect("parent controller");
+
+    // Child-scoped controller that already has a grandchild tracked under the
+    // child's session id.
+    let child_controller =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+            .await
+            .expect("child controller");
+    let child_session_id = "child-session".to_string();
+    let spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "explorer")
+        .expect("explorer");
+    {
+        let mut state = child_controller.state.write().await;
+        state.children.insert(
+            "grandchild".to_string(),
+            ChildRecord {
+                id: "grandchild".to_string(),
+                session_id: "session-grandchild".to_string(),
+                parent_thread_id: child_session_id.clone(),
+                spec: spec.clone(),
+                display_label: subagent_display_label(&spec),
+                status: SubagentStatus::Running,
+                background: false,
+                depth: 2,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                completed_at: None,
+                summary: None,
+                error: None,
+                archive_metadata: None,
+                archive_path: None,
+                transcript_path: None,
+                effective_config: None,
+                stored_messages: Vec::new(),
+                last_prompt: Some("Inspect.".to_string()),
+                queued_prompts: VecDeque::new(),
+                max_turns: None,
+                model_override: None,
+                reasoning_override: None,
+                thread_handle: None,
+                handle: None,
+                notify: Arc::new(Notify::new()),
+                worktree_path: None,
+                child_controller: None,
+            },
+        );
+    }
+    let child_controller = std::sync::Arc::new(child_controller);
+
+    // Register the child on the parent controller with the child-scoped
+    // controller attached, then close it and assert the grandchild is closed.
+    {
+        let mut state = parent.state.write().await;
+        state.children.insert(
+            "child".to_string(),
+            ChildRecord {
+                id: "child".to_string(),
+                session_id: child_session_id.clone(),
+                parent_thread_id: "parent-session".to_string(),
+                spec: spec.clone(),
+                display_label: subagent_display_label(&spec),
+                status: SubagentStatus::Running,
+                background: false,
+                depth: 1,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                completed_at: None,
+                summary: None,
+                error: None,
+                archive_metadata: None,
+                archive_path: None,
+                transcript_path: None,
+                effective_config: None,
+                stored_messages: Vec::new(),
+                last_prompt: Some("Inspect.".to_string()),
+                queued_prompts: VecDeque::new(),
+                max_turns: None,
+                model_override: None,
+                reasoning_override: None,
+                thread_handle: None,
+                handle: None,
+                notify: Arc::new(Notify::new()),
+                worktree_path: None,
+                child_controller: Some(child_controller.clone()),
+            },
+        );
+    }
+
+    let closed = parent.close("child").await.expect("close child");
+    assert!(closed.status.is_terminal());
+
+    let grandchild_status = child_controller.status_for("grandchild").await.expect("grandchild status");
+    assert_eq!(
+        grandchild_status.status,
+        SubagentStatus::Closed,
+        "closing the child must cascade to its grandchildren"
+    );
+}
+
+#[tokio::test]
+async fn close_does_not_affect_sibling_grandchildren() {
+    let temp = TempDir::new().expect("tempdir");
+    let parent = SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+        .await
+        .expect("parent controller");
+
+    let spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "explorer")
+        .expect("explorer");
+
+    // Two siblings each with their own child-scoped controller and a grandchild.
+    let controller_a =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+            .await
+            .expect("controller a");
+    {
+        let mut state = controller_a.state.write().await;
+        state.children.insert(
+            "a-grandchild".to_string(),
+            ChildRecord {
+                id: "a-grandchild".to_string(),
+                session_id: "session-a-grandchild".to_string(),
+                parent_thread_id: "session-a".to_string(),
+                spec: spec.clone(),
+                display_label: subagent_display_label(&spec),
+                status: SubagentStatus::Running,
+                background: false,
+                depth: 2,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                completed_at: None,
+                summary: None,
+                error: None,
+                archive_metadata: None,
+                archive_path: None,
+                transcript_path: None,
+                effective_config: None,
+                stored_messages: Vec::new(),
+                last_prompt: Some("Inspect.".to_string()),
+                queued_prompts: VecDeque::new(),
+                max_turns: None,
+                model_override: None,
+                reasoning_override: None,
+                thread_handle: None,
+                handle: None,
+                notify: Arc::new(Notify::new()),
+                worktree_path: None,
+                child_controller: None,
+            },
+        );
+    }
+    let controller_b =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+            .await
+            .expect("controller b");
+    {
+        let mut state = controller_b.state.write().await;
+        state.children.insert(
+            "b-grandchild".to_string(),
+            ChildRecord {
+                id: "b-grandchild".to_string(),
+                session_id: "session-b-grandchild".to_string(),
+                parent_thread_id: "session-b".to_string(),
+                spec: spec.clone(),
+                display_label: subagent_display_label(&spec),
+                status: SubagentStatus::Running,
+                background: false,
+                depth: 2,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                completed_at: None,
+                summary: None,
+                error: None,
+                archive_metadata: None,
+                archive_path: None,
+                transcript_path: None,
+                effective_config: None,
+                stored_messages: Vec::new(),
+                last_prompt: Some("Inspect.".to_string()),
+                queued_prompts: VecDeque::new(),
+                max_turns: None,
+                model_override: None,
+                reasoning_override: None,
+                thread_handle: None,
+                handle: None,
+                notify: Arc::new(Notify::new()),
+                worktree_path: None,
+                child_controller: None,
+            },
+        );
+    }
+    let controller_a = std::sync::Arc::new(controller_a);
+    let controller_b = std::sync::Arc::new(controller_b);
+
+    {
+        let mut state = parent.state.write().await;
+        state.children.insert(
+            "a".to_string(),
+            ChildRecord {
+                id: "a".to_string(),
+                session_id: "session-a".to_string(),
+                parent_thread_id: "parent-session".to_string(),
+                spec: spec.clone(),
+                display_label: subagent_display_label(&spec),
+                status: SubagentStatus::Running,
+                background: false,
+                depth: 1,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                completed_at: None,
+                summary: None,
+                error: None,
+                archive_metadata: None,
+                archive_path: None,
+                transcript_path: None,
+                effective_config: None,
+                stored_messages: Vec::new(),
+                last_prompt: Some("Inspect.".to_string()),
+                queued_prompts: VecDeque::new(),
+                max_turns: None,
+                model_override: None,
+                reasoning_override: None,
+                thread_handle: None,
+                handle: None,
+                notify: Arc::new(Notify::new()),
+                worktree_path: None,
+                child_controller: Some(controller_a.clone()),
+            },
+        );
+        state.children.insert(
+            "b".to_string(),
+            ChildRecord {
+                id: "b".to_string(),
+                session_id: "session-b".to_string(),
+                parent_thread_id: "parent-session".to_string(),
+                spec: spec.clone(),
+                display_label: subagent_display_label(&spec),
+                status: SubagentStatus::Running,
+                background: false,
+                depth: 1,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                completed_at: None,
+                summary: None,
+                error: None,
+                archive_metadata: None,
+                archive_path: None,
+                transcript_path: None,
+                effective_config: None,
+                stored_messages: Vec::new(),
+                last_prompt: Some("Inspect.".to_string()),
+                queued_prompts: VecDeque::new(),
+                max_turns: None,
+                model_override: None,
+                reasoning_override: None,
+                thread_handle: None,
+                handle: None,
+                notify: Arc::new(Notify::new()),
+                worktree_path: None,
+                child_controller: Some(controller_b.clone()),
+            },
+        );
+    }
+
+    parent.close("a").await.expect("close a");
+
+    let b_grandchild = controller_b.status_for("b-grandchild").await.expect("b-grandchild status");
+    assert_eq!(
+        b_grandchild.status,
+        SubagentStatus::Running,
+        "closing sibling 'a' must not affect sibling 'b''s grandchildren"
+    );
+    let a_grandchild = controller_a.status_for("a-grandchild").await.expect("a-grandchild status");
+    assert_eq!(a_grandchild.status, SubagentStatus::Closed, "closing 'a' must cascade to its own grandchildren");
 }
 
 #[tokio::test]
@@ -1727,6 +2222,7 @@ async fn wait_returns_first_terminal_child() {
                     handle: None,
                     notify: Arc::new(Notify::new()),
                     worktree_path: None,
+                    child_controller: None,
                 },
             );
         }

--- a/crates/codegen/vtcode-core/src/subagents/tests.rs
+++ b/crates/codegen/vtcode-core/src/subagents/tests.rs
@@ -2093,6 +2093,72 @@ async fn spawn_is_rejected_after_close_begins() {
 }
 
 #[tokio::test]
+async fn resume_restores_closed_grandchildren() {
+    let temp = TempDir::new().expect("tempdir");
+    let parent = SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+        .await
+        .expect("parent controller");
+
+    let spec = vtcode_config::builtin_subagents()
+        .into_iter()
+        .find(|spec| spec.name == "explorer")
+        .expect("explorer");
+
+    // Child-scoped controller that has a grandchild under the child session id.
+    let child_controller =
+        SubagentController::new(test_controller_config(temp.path().to_path_buf(), VTCodeConfig::default()))
+            .await
+            .expect("child controller");
+    let child_session_id = "child-session".to_string();
+    {
+        let mut state = child_controller.state.write().await;
+        state.children.insert(
+            "grandchild".to_string(),
+            test_child_record(
+                "grandchild",
+                "session-grandchild",
+                &child_session_id,
+                &spec,
+                SubagentStatus::Running,
+                2,
+                None,
+            ),
+        );
+    }
+    let child_controller = std::sync::Arc::new(child_controller);
+    {
+        let mut state = parent.state.write().await;
+        state.children.insert(
+            "child".to_string(),
+            test_child_record(
+                "child",
+                &child_session_id,
+                "parent-session",
+                &spec,
+                SubagentStatus::Running,
+                1,
+                Some(child_controller.clone()),
+            ),
+        );
+    }
+
+    // Closing the child cascades to the grandchild...
+    parent.close("child").await.expect("close child");
+    let closed_grandchild = child_controller.status_for("grandchild").await.expect("grandchild status");
+    assert_eq!(closed_grandchild.status, SubagentStatus::Closed, "grandchild must be closed with the child");
+
+    // ...and resuming the child must reopen the grandchild too, not just clear
+    // the close gate.
+    parent.resume("child").await.expect("resume child");
+    let resumed_grandchild = child_controller.status_for("grandchild").await.expect("grandchild status");
+    assert!(
+        matches!(resumed_grandchild.status, SubagentStatus::Queued | SubagentStatus::Running),
+        "resumed grandchild must be re-queued, got {:?}",
+        resumed_grandchild.status
+    );
+}
+
+#[tokio::test]
 async fn wait_returns_first_terminal_child() {
     let temp = TempDir::new().expect("tempdir");
     let controller =

--- a/crates/codegen/vtcode-core/src/subagents/tests.rs
+++ b/crates/codegen/vtcode-core/src/subagents/tests.rs
@@ -46,14 +46,16 @@ fn test_controller_config(workspace_root: PathBuf, vt_cfg: VTCodeConfig) -> Suba
 
 fn test_child_record(
     id: &str,
+    session_id: &str,
     parent_thread_id: &str,
     spec: &SubagentSpec,
     status: SubagentStatus,
     depth: usize,
+    child_controller: Option<Arc<SubagentController>>,
 ) -> ChildRecord {
     ChildRecord {
         id: id.to_string(),
-        session_id: format!("session-{id}"),
+        session_id: session_id.to_string(),
         parent_thread_id: parent_thread_id.to_string(),
         spec: spec.clone(),
         display_label: subagent_display_label(spec),
@@ -79,7 +81,7 @@ fn test_child_record(
         handle: None,
         notify: Arc::new(Notify::new()),
         worktree_path: None,
-        child_controller: None,
+        child_controller,
     }
 }
 
@@ -1715,14 +1717,15 @@ async fn close_and_resume_cascade_through_spawn_tree() {
         let mut state = controller.state.write().await;
         state.children.insert(
             "parent".to_string(),
-            test_child_record("parent", "session-root", &spec, SubagentStatus::Running, 1),
+            test_child_record("parent", "session-parent", "session-root", &spec, SubagentStatus::Running, 1, None),
         );
-        state
-            .children
-            .insert("child".to_string(), test_child_record("child", "parent", &spec, SubagentStatus::Running, 2));
+        state.children.insert(
+            "child".to_string(),
+            test_child_record("child", "session-child", "parent", &spec, SubagentStatus::Running, 2, None),
+        );
         state.children.insert(
             "grandchild".to_string(),
-            test_child_record("grandchild", "child", &spec, SubagentStatus::Running, 3),
+            test_child_record("grandchild", "session-grandchild", "child", &spec, SubagentStatus::Running, 3, None),
         );
     }
 
@@ -1826,13 +1829,9 @@ async fn spawn_from_child_controller_respects_depth_limit() {
 
     // Child controller runs at depth 1: it may spawn a grandchild (depth 2),
     // but the grandchild itself (depth 2) may not spawn further.
-    let mut child_controller =
-        SubagentController::new(test_controller_config(temp.path().to_path_buf(), vt_cfg.clone()))
-            .await
-            .expect("child controller");
-
-    let config = Arc::make_mut(&mut child_controller.config);
-    config.depth = 1;
+    let mut child_config = test_controller_config(temp.path().to_path_buf(), vt_cfg.clone());
+    child_config.depth = 1;
+    let child_controller = SubagentController::new(child_config).await.expect("child controller");
 
     child_controller
         .spawn(SpawnAgentRequest {
@@ -1915,36 +1914,15 @@ async fn close_cascades_to_child_scoped_grandchildren() {
         let mut state = child_controller.state.write().await;
         state.children.insert(
             "grandchild".to_string(),
-            ChildRecord {
-                id: "grandchild".to_string(),
-                session_id: "session-grandchild".to_string(),
-                parent_thread_id: child_session_id.clone(),
-                spec: spec.clone(),
-                display_label: subagent_display_label(&spec),
-                status: SubagentStatus::Running,
-                background: false,
-                depth: 2,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                completed_at: None,
-                summary: None,
-                error: None,
-                archive_metadata: None,
-                archive_path: None,
-                transcript_path: None,
-                effective_config: None,
-                stored_messages: Vec::new(),
-                last_prompt: Some("Inspect.".to_string()),
-                queued_prompts: VecDeque::new(),
-                max_turns: None,
-                model_override: None,
-                reasoning_override: None,
-                thread_handle: None,
-                handle: None,
-                notify: Arc::new(Notify::new()),
-                worktree_path: None,
-                child_controller: None,
-            },
+            test_child_record(
+                "grandchild",
+                "session-grandchild",
+                &child_session_id,
+                &spec,
+                SubagentStatus::Running,
+                2,
+                None,
+            ),
         );
     }
     let child_controller = std::sync::Arc::new(child_controller);
@@ -1955,36 +1933,15 @@ async fn close_cascades_to_child_scoped_grandchildren() {
         let mut state = parent.state.write().await;
         state.children.insert(
             "child".to_string(),
-            ChildRecord {
-                id: "child".to_string(),
-                session_id: child_session_id.clone(),
-                parent_thread_id: "parent-session".to_string(),
-                spec: spec.clone(),
-                display_label: subagent_display_label(&spec),
-                status: SubagentStatus::Running,
-                background: false,
-                depth: 1,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                completed_at: None,
-                summary: None,
-                error: None,
-                archive_metadata: None,
-                archive_path: None,
-                transcript_path: None,
-                effective_config: None,
-                stored_messages: Vec::new(),
-                last_prompt: Some("Inspect.".to_string()),
-                queued_prompts: VecDeque::new(),
-                max_turns: None,
-                model_override: None,
-                reasoning_override: None,
-                thread_handle: None,
-                handle: None,
-                notify: Arc::new(Notify::new()),
-                worktree_path: None,
-                child_controller: Some(child_controller.clone()),
-            },
+            test_child_record(
+                "child",
+                &child_session_id,
+                "parent-session",
+                &spec,
+                SubagentStatus::Running,
+                1,
+                Some(child_controller.clone()),
+            ),
         );
     }
 
@@ -2020,36 +1977,15 @@ async fn close_does_not_affect_sibling_grandchildren() {
         let mut state = controller_a.state.write().await;
         state.children.insert(
             "a-grandchild".to_string(),
-            ChildRecord {
-                id: "a-grandchild".to_string(),
-                session_id: "session-a-grandchild".to_string(),
-                parent_thread_id: "session-a".to_string(),
-                spec: spec.clone(),
-                display_label: subagent_display_label(&spec),
-                status: SubagentStatus::Running,
-                background: false,
-                depth: 2,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                completed_at: None,
-                summary: None,
-                error: None,
-                archive_metadata: None,
-                archive_path: None,
-                transcript_path: None,
-                effective_config: None,
-                stored_messages: Vec::new(),
-                last_prompt: Some("Inspect.".to_string()),
-                queued_prompts: VecDeque::new(),
-                max_turns: None,
-                model_override: None,
-                reasoning_override: None,
-                thread_handle: None,
-                handle: None,
-                notify: Arc::new(Notify::new()),
-                worktree_path: None,
-                child_controller: None,
-            },
+            test_child_record(
+                "a-grandchild",
+                "session-a-grandchild",
+                "session-a",
+                &spec,
+                SubagentStatus::Running,
+                2,
+                None,
+            ),
         );
     }
     let controller_b =
@@ -2060,36 +1996,15 @@ async fn close_does_not_affect_sibling_grandchildren() {
         let mut state = controller_b.state.write().await;
         state.children.insert(
             "b-grandchild".to_string(),
-            ChildRecord {
-                id: "b-grandchild".to_string(),
-                session_id: "session-b-grandchild".to_string(),
-                parent_thread_id: "session-b".to_string(),
-                spec: spec.clone(),
-                display_label: subagent_display_label(&spec),
-                status: SubagentStatus::Running,
-                background: false,
-                depth: 2,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                completed_at: None,
-                summary: None,
-                error: None,
-                archive_metadata: None,
-                archive_path: None,
-                transcript_path: None,
-                effective_config: None,
-                stored_messages: Vec::new(),
-                last_prompt: Some("Inspect.".to_string()),
-                queued_prompts: VecDeque::new(),
-                max_turns: None,
-                model_override: None,
-                reasoning_override: None,
-                thread_handle: None,
-                handle: None,
-                notify: Arc::new(Notify::new()),
-                worktree_path: None,
-                child_controller: None,
-            },
+            test_child_record(
+                "b-grandchild",
+                "session-b-grandchild",
+                "session-b",
+                &spec,
+                SubagentStatus::Running,
+                2,
+                None,
+            ),
         );
     }
     let controller_a = std::sync::Arc::new(controller_a);
@@ -2099,69 +2014,27 @@ async fn close_does_not_affect_sibling_grandchildren() {
         let mut state = parent.state.write().await;
         state.children.insert(
             "a".to_string(),
-            ChildRecord {
-                id: "a".to_string(),
-                session_id: "session-a".to_string(),
-                parent_thread_id: "parent-session".to_string(),
-                spec: spec.clone(),
-                display_label: subagent_display_label(&spec),
-                status: SubagentStatus::Running,
-                background: false,
-                depth: 1,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                completed_at: None,
-                summary: None,
-                error: None,
-                archive_metadata: None,
-                archive_path: None,
-                transcript_path: None,
-                effective_config: None,
-                stored_messages: Vec::new(),
-                last_prompt: Some("Inspect.".to_string()),
-                queued_prompts: VecDeque::new(),
-                max_turns: None,
-                model_override: None,
-                reasoning_override: None,
-                thread_handle: None,
-                handle: None,
-                notify: Arc::new(Notify::new()),
-                worktree_path: None,
-                child_controller: Some(controller_a.clone()),
-            },
+            test_child_record(
+                "a",
+                "session-a",
+                "parent-session",
+                &spec,
+                SubagentStatus::Running,
+                1,
+                Some(controller_a.clone()),
+            ),
         );
         state.children.insert(
             "b".to_string(),
-            ChildRecord {
-                id: "b".to_string(),
-                session_id: "session-b".to_string(),
-                parent_thread_id: "parent-session".to_string(),
-                spec: spec.clone(),
-                display_label: subagent_display_label(&spec),
-                status: SubagentStatus::Running,
-                background: false,
-                depth: 1,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                completed_at: None,
-                summary: None,
-                error: None,
-                archive_metadata: None,
-                archive_path: None,
-                transcript_path: None,
-                effective_config: None,
-                stored_messages: Vec::new(),
-                last_prompt: Some("Inspect.".to_string()),
-                queued_prompts: VecDeque::new(),
-                max_turns: None,
-                model_override: None,
-                reasoning_override: None,
-                thread_handle: None,
-                handle: None,
-                notify: Arc::new(Notify::new()),
-                worktree_path: None,
-                child_controller: Some(controller_b.clone()),
-            },
+            test_child_record(
+                "b",
+                "session-b",
+                "parent-session",
+                &spec,
+                SubagentStatus::Running,
+                1,
+                Some(controller_b.clone()),
+            ),
         );
     }
 
@@ -2175,6 +2048,35 @@ async fn close_does_not_affect_sibling_grandchildren() {
     );
     let a_grandchild = controller_a.status_for("a-grandchild").await.expect("a-grandchild status");
     assert_eq!(a_grandchild.status, SubagentStatus::Closed, "closing 'a' must cascade to its own grandchildren");
+}
+
+#[tokio::test]
+async fn spawn_is_rejected_after_close_begins() {
+    let temp = TempDir::new().expect("tempdir");
+    let mut vt_cfg = VTCodeConfig::default();
+    vt_cfg.subagents.max_depth = 2;
+    let mut child_config = test_controller_config(temp.path().to_path_buf(), vt_cfg);
+    child_config.depth = 1;
+    let child_controller = SubagentController::new(child_config).await.expect("child controller");
+    child_controller
+        .set_turn_delegation_hints_from_input("delegate this task")
+        .await;
+
+    // Mark the controller as closing: this is exactly what `close_tree` does
+    // to a child-scoped controller before aborting its subtree, so a still-
+    // running child cannot spawn a grandchild after the descendant snapshot.
+    child_controller.begin_close().await;
+
+    let err = child_controller
+        .spawn(SpawnAgentRequest {
+            agent_type: Some("explorer".to_string()),
+            message: Some("Inspect the codebase.".to_string()),
+            ..SpawnAgentRequest::default()
+        })
+        .await
+        .expect_err("spawn after close began must be rejected");
+
+    assert!(err.to_string().contains("shutting down"));
 }
 
 #[tokio::test]

--- a/crates/codegen/vtcode-core/src/subagents/types.rs
+++ b/crates/codegen/vtcode-core/src/subagents/types.rs
@@ -253,6 +253,11 @@ pub struct ChildRecord {
     /// Optional worktree path for isolated subagents. When set, the child
     /// agent runs in this worktree instead of the parent workspace root.
     pub(crate) worktree_path: Option<PathBuf>,
+    /// Child-scoped subagent controller used to enable nested delegation.
+    /// Created once on the first nested-capable run and reused across resumes
+    /// so grandchildren spawned by this child remain reachable for the child's
+    /// lifetime.
+    pub(crate) child_controller: Option<Arc<super::SubagentController>>,
 }
 
 pub(crate) struct ChildRunRequest {

--- a/docs/config/CONFIG_FIELD_REFERENCE.md
+++ b/docs/config/CONFIG_FIELD_REFERENCE.md
@@ -751,7 +751,7 @@ python3 scripts/generate_config_field_reference.py
 | `subagents.default_timeout_seconds` | `integer` | no | `300` | - |
 | `subagents.enabled` | `boolean` | no | `true` | - |
 | `subagents.max_concurrent` | `integer` | no | `3` | - |
-| `subagents.max_depth` | `integer` | no | `1` | - |
+| `subagents.max_depth` | `integer` | no | `1` | Maximum delegation depth. `1` disables nested delegation (children cannot spawn); `2` allows one level of nesting (root → child → grandchild), `3` two levels, etc. |
 | `syntax_highlighting.cache_themes` | `boolean` | no | `true` | Enable theme caching for better performance |
 | `syntax_highlighting.enabled` | `boolean` | no | `true` | Enable syntax highlighting for tool output |
 | `syntax_highlighting.enabled_languages` | `array` | no | `[]` | Languages to enable syntax highlighting for |

--- a/docs/user-guide/subagents.md
+++ b/docs/user-guide/subagents.md
@@ -43,7 +43,7 @@ Notes:
 
 - `explorer` also matches `explore`
 - `worker` also matches `general` and `general-purpose`
-- child threads do not spawn more subagents
+- child threads spawn more subagents only when `subagents.max_depth` allows another nesting level (read-only children and background subprocesses stay excluded)
 
 Completed child threads are expected to return a fixed Markdown handoff that VT Code can merge back into the parent session memory:
 

--- a/docs/user-guide/subagents.md
+++ b/docs/user-guide/subagents.md
@@ -286,7 +286,7 @@ When one or more child threads are active, VT Code shows each active agent name 
 - Prefer the exact VT Code tool ids returned by `vtcode schema tools`.
 - For new VT Code-native agent files, do not use Claude-style tool names such as `Read`, `Grep`, `Glob`, `Write`, `Edit`, or `Bash`.
 - Use the narrowest VT Code tool set that fits the job instead of granting broad umbrella access by default.
-- VT Code always strips child access to `spawn_agent`, `send_input`, `wait_agent`, `resume_agent`, and `close_agent`.
+- Delegation tools (`spawn_agent`, `send_input`, `wait_agent`, `resume_agent`, `close_agent`) are available to a child only while `subagents.max_depth` permits deeper nesting; read-only children never receive them. `spawn_background_subprocess` stays unavailable to children at any depth.
 - If the agent is effectively read-only, VT Code strips mutating tools at runtime even if they are listed.
 
 ### Permissions

--- a/docs/user-guide/subagents.md
+++ b/docs/user-guide/subagents.md
@@ -381,9 +381,30 @@ auto_delegate_read_only = true
 
 Key behaviors:
 
-- `max_depth = 1` keeps nested delegation off by default
-- `max_concurrent` limits simultaneous child threads
+- `max_depth = 1` keeps nested delegation off by default; set `max_depth = 2` or higher to allow delegated child agents to spawn their own children
+- `max_concurrent` limits simultaneous child threads at each nesting level
 - `auto_delegate_read_only` controls whether VT Code may proactively launch read-only agents without an explicit user delegation request
+
+### Nested Delegation
+
+`max_depth` controls how deep the delegation tree may grow. A value of `1`
+(the default) means the root agent may delegate to children, but children
+cannot spawn their own subagents. Set it to `2` for one level of nesting
+(root → child → grandchild), `3` for two levels, and so on. A value of `0`
+disables delegation entirely (equivalent to `subagents.enabled = false`).
+
+Nested delegation is governed by the same depth check that limits the root
+session: a child agent may call `spawn_agent` (and the other `agent`
+lifecycle actions) only while `depth + 1 <= max_depth` still holds. When the
+limit is reached the child's toolset omits the delegation tools entirely, so
+the depth gate is enforced both at tool exposure and at spawn time.
+
+Background subprocesses (`spawn_background_subprocess`) stay unavailable to
+delegated children at any depth. Read-only agents never receive delegation
+tools, so a read-only child cannot widen its own permissions by spawning a
+write-capable grandchild. Nested worktree isolation is not supported: an
+`isolation = worktree` subagent at depth > 0 is rejected at spawn time, since
+a child-scoped controller already runs inside the parent's worktree.
 
 ## Work With Subagents
 
@@ -604,7 +625,7 @@ Prefer subagents when:
 - you want a tighter tool or permission boundary
 - you want to inspect delegated runs or keep a long-lived helper available without leaving the main session
 
-If you need nested delegation or long-lived parallel teams, VT Code subagents are not the right primitive yet. The current build keeps child depth at one level by default.
+Nested delegation is controlled by `subagents.max_depth`. The default `max_depth = 1` keeps child depth at one level; raise it when you need deeper delegation. For long-lived parallel teams that outlive a single task, managed background subprocesses (via `spawn_background_subprocess`) remain the dedicated primitive, and nested delegation within child agents is scoped by the same depth limit as the root session.
 
 ## Related Guides
 


### PR DESCRIPTION
## Description

`subagents.max_depth > 1` was dead configuration. Three code paths
unconditionally stripped every subagent-lifecycle tool (`agent`, `spawn_agent`,
`send_input`, `wait_agent`, `resume_agent`, `close_agent`,
`spawn_background_subprocess`) from a child's toolset regardless of the
configured depth, and children never received a `SubagentController`, so
grandchildren could not be spawned even when `max_depth` allowed them.

This change makes the documented behavior real: the depth check in
`spawn_with_spec` is now the sole runtime gate (as the config docs always
claimed), and `max_depth >= 2` actually enables nested delegation.

Fixes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include any relevant details for your test configuration.

- [x] Rust tests: `cargo nextest run -p vtcode-core --locked` (95 subagent tests pass; the one failing `resolves_project_scoped_memory_directory` test also fails on a clean checkout and is unrelated)
- [x] Linting: `cargo clippy -p vtcode-core --all-targets -- -D warnings`
- [x] Formatting: `cargo fmt --all -- --check`
- [x] Build: `cargo check --workspace`

**Test Configuration**:
* Rust version: 1.93.0
* Operating system: Linux
* Toolchain: stable

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to ensure proper formatting
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the `CHANGELOG.md` if this change affects the user-facing behavior (changelog is generated from Conventional Commits via git-cliff at release time)

## Additional Context

### What changed

- **Depth-aware tool filtering**: `resolve_child_allowed_tools`,
  `resolve_child_denied_tools`, `filter_child_tools`, `build_child_config`, and
  `prepare_child_runtime_config` now take an `allow_nested_delegation` flag.
  When nesting is allowed only the background-subprocess alias stays blocked;
  the depth check in `spawn_with_spec` remains the sole runtime gate.
- **Child-scoped controller**: `run_child_once` attaches a `SubagentController`
  with `depth + 1` and `managed_background_runtime: true` when a grandchild
  still fits inside `max_depth`. It is persisted on `ChildRecord` so it
  survives resumes. Background subprocesses stay unavailable to children at any
  depth; read-only children never receive delegation tools (no permission
  escalation).
- **Clean teardown**: `close`/`signal_shutdown` cascade recursively through
  child-scoped controllers so grandchild tasks are aborted instead of leaking
  as detached tokio tasks. Sibling isolation is preserved.
- **Nested worktree isolation rejected** at spawn (a child-scoped controller
  already runs inside the parent's worktree).
- **Fail-closed tool exposure**: if controller creation fails, the child keeps
  the non-nested toolset.

### Behavior

`max_depth = 1` (default) is byte-identical to today. `max_depth = 2` enables
root → child → grandchild; `max_depth = 3` adds one more level, etc.
`max_concurrent` still bounds each nesting level.

### Tests

8 new unit tests: tool filtering (nested vs default), deny-list composition,
depth math (off-by-one at the limit), sibling isolation on cascade close, and
the nested-worktree guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nested subagent delegation with configurable depth limits.
  * Preserved delegation capabilities across resumed child runs.
  * Added cascading closure and shutdown handling for nested subagents.

* **Bug Fixes**
  * Prevented new nested tasks during shutdown or temporary closure.
  * Restricted unsupported nested worktree isolation and background subprocess access.
  * Preserved sibling isolation and enforced read-only restrictions.

* **Documentation**
  * Documented nested delegation behavior and `subagents.max_depth` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->