### PR TITLE
fix(subagents): pass workspace_gated to nested controller config

### DIFF
--- a/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
+++ b/crates/codegen/vtcode-core/src/subagents/controller_child_loop.rs
@@ -294,6 +294,7 @@ impl SubagentController {
                         vt_cfg: child_cfg.clone(),
                         openai_chatgpt_auth: self.config.openai_chatgpt_auth.clone(),
                         depth: self.config.depth.saturating_add(1),
+                        workspace_gated: self.config.workspace_gated,
                         exec_sessions: self.config.exec_sessions.clone(),
                         pty_manager: self.config.pty_manager.clone(),
                         managed_background_runtime: true,


### PR DESCRIPTION
The merge of #751 added a required `workspace_gated: bool` field to `SubagentControllerConfig` (introduced for gating workspace lifecycle hooks in subagent contexts), but the nested-controller constructor in `controller_child_loop.rs` was not updated, breaking the release build with E0063.

Inherit the parent controller's gate status so nested (grandchild) controllers stay consistent with the workspace-gated state of the session.

Verified:
- cargo check --locked -p vtcode-core
- cargo nextest run -p vtcode-core -E 'test(subagents)' (99 passed)
- cargo clippy --locked -p vtcode-core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nested subagents now consistently follow the parent controller’s workspace access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->