### PR TITLE
docs(providers): document llmman as Ollama-compatible local runner

### DIFF
--- a/crates/codegen/vtcode-config/data/network_allowlist.toml
+++ b/crates/codegen/vtcode-config/data/network_allowlist.toml
@@ -224,6 +224,13 @@ protocol = "http"
 notes    = "Ollama REST API"
 
 [[ai_providers.local]]
+name     = "llmman"
+host     = "localhost"
+port     = 17434
+protocol = "http"
+notes    = "Ollama-compatible REST API served by llmman (https://github.com/llmmanorg/llmman)"
+
+[[ai_providers.local]]
 name     = "LlamaCpp"
 host     = "localhost"
 port     = 8080

--- a/docs/providers/local-servers.md
+++ b/docs/providers/local-servers.md
@@ -26,6 +26,10 @@ VT Code manages local LLM inference servers through the `/local` command. Contro
 | **LM Studio** | `http://localhost:1234/v1` | `lms` | https://lmstudio.ai/download |
 | **llama.cpp** | `http://localhost:8080/v1` | `llama-server` | https://llama.app |
 
+[llmman](https://github.com/llmmanorg/llmman) serves the Ollama API on port
+`17434` and works through the `ollama` provider; see
+[Using llmman](#using-llmman) below.
+
 ---
 
 ## Running Ollama
@@ -111,6 +115,36 @@ cat ~/.ollama/logs/server.log
 /local configure ollama    Show environment config
 /local troubleshoot ollama Diagnose connection issues
 ```
+
+### Using llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that
+serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port
+`17434`. Models are pulled as OCI artifacts or straight from Hugging Face
+(`hf.co/org/model`) and served by upstream `llama.cpp`, `vllm`, or `mlx-lm`.
+Because the API is the same, VT Code's `ollama` provider works unchanged; only
+the base URL differs.
+
+```bash
+# Install and start
+curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+llmman serve
+
+# Pull a model
+llmman pull gemma4
+llmman pull hf.co/unsloth/Qwen3.5-0.8B-GGUF
+
+# Point VT Code's ollama provider at llmman
+export OLLAMA_BASE_URL=http://localhost:17434
+vtcode --provider ollama --model gemma4
+```
+
+Override the listen address on the llmman side with `LLMMAN_HOST`
+(`[host][:port]`), then set `OLLAMA_BASE_URL` to match.
+
+llmman does not serve `/api/embed`; embeddings are only available via its
+OpenAI-compatible `/v1/embeddings` route. `/local start ollama` manages the
+`ollama` binary, not `llmman`, so start `llmman serve` yourself.
 
 ---
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -31,7 +31,7 @@ Ollama can serve models locally on your machine or proxy larger releases through
 
 ### Environment Variables
 
-- `OLLAMA_BASE_URL` (optional): Custom Ollama endpoint (defaults to `http://localhost:11434`). Set to `https://ollama.com` to send requests directly to Ollama Cloud.
+- `OLLAMA_BASE_URL` (optional): Custom Ollama endpoint (defaults to `http://localhost:11434`). Set to `https://ollama.com` to send requests directly to Ollama Cloud, or to `http://localhost:17434` to use [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the same Ollama API (see [Using llmman](local-servers.md#using-llmman)).
 - `OLLAMA_API_KEY` (optional): Required when connecting to Ollama Cloud. Not needed for purely local workloads.
 
 ### VT Code Configuration


### PR DESCRIPTION
## Description

Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves
the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434.

- **No new `Provider` variant.** llmman speaks the exact Ollama wire protocol (`/api/chat`, `/api/tags`, `/api/pull`, `/api/show`, ...), so the existing `ollama` provider already works against it once `OLLAMA_BASE_URL=http://localhost:17434` is set. Adding a first-class enum variant would have meant touching ~20 exhaustive `match` sites, model constants, presets and `LocalProvider` for zero functional gain, so this PR documents the existing path instead.
- `docs/providers/local-servers.md`: new "Using llmman" subsection under "Running Ollama" (install, `llmman serve`, `llmman pull`, `OLLAMA_BASE_URL`), plus a pointer under the Supported Providers table. It also notes that `/local start ollama` manages the `ollama` binary, not `llmman`, and that llmman does not serve `/api/embed` (embeddings are only on its OpenAI-compatible `/v1/embeddings`).
- `docs/providers/ollama.md`: one-line mention next to the `OLLAMA_BASE_URL` description.
- `crates/codegen/vtcode-config/data/network_allowlist.toml`: `[[ai_providers.local]]` entry for `localhost:17434`, modelled on the Ollama entry, so the endpoint is catalogued like the other local servers.

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Rust tests: `cargo test -p vtcode-config --lib network_allowlist` (5 passed, 0 failed) - verifies the embedded allowlist TOML still parses and stays within the expected entry-count bounds.
- [ ] Linting: `cargo clippy` - not run; no Rust source changed
- [ ] Formatting: `cargo fmt` - not applicable; no Rust source changed
- [ ] Build: `cargo build` - only `vtcode-config` (and its deps) compiled as part of the test above

**Test Configuration**:
* Rust version: 1.93.0 (from `rust-toolchain.toml`)
* Operating system: macOS
* Toolchain: stable

Not verified: no run against a live llmman server from VT Code; the `OLLAMA_BASE_URL` override path was confirmed by reading `crates/codegen/vtcode-llm/src/providers/ollama.rs` (`override_base_url(urls::OLLAMA_API_BASE, base_url, Some(env_vars::OLLAMA_BASE_URL))`), not by end-to-end execution.

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (`cargo test -p vtcode-config --lib network_allowlist`)
- [ ] I have updated the `CHANGELOG.md` - not done; the changelog is generated from commits via git-cliff
- [x] I have checked my code and corrected any misspellings

> AI-assisted, reviewed before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to the local llmman model server through the Ollama-compatible provider.
  - Enabled local network access at `localhost:17434` over HTTP.

- **Documentation**
  - Added setup instructions covering installation, startup, model downloads, configuration, and limitations.
  - Updated Ollama provider guidance with llmman’s local server URL and setup reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->