### PR TITLE
feat(tools): add optional youcom provider to web_search

### DIFF
--- a/crates/codegen/vtcode-config/src/core/tools.rs
+++ b/crates/codegen/vtcode-config/src/core/tools.rs
@@ -162,6 +162,11 @@ pub enum WebSearchProvider {
     Auto,
     /// Keyless DuckDuckGo HTML scraping (`https://html.duckduckgo.com/html/`).
     Duckduckgo,
+    /// You.com Search API (`https://ydc-index.io/v1/search`). Requires a
+    /// `YDC_API_KEY` environment variable; the key is read at request time
+    /// and never logged. Opt-in only — the default provider stays
+    /// DuckDuckGo.
+    Youcom,
 }
 
 /// Web Search tool configuration.
@@ -179,8 +184,9 @@ pub enum WebSearchProvider {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct WebSearchConfig {
-    /// Provider selection. Currently the only supported backend is
-    /// DuckDuckGo; this field is kept for future extension.
+    /// Provider selection. Supported backends are the keyless DuckDuckGo
+    /// HTML endpoint (default) and the You.com Search API (opt-in, requires
+    /// `YDC_API_KEY`).
     #[serde(default)]
     pub provider: WebSearchProvider,
 
@@ -661,6 +667,29 @@ session_max_requests = 5
         // lowercase, matching the LLM-facing schema strings.
         let json = serde_json::to_value(WebSearchProvider::Duckduckgo).unwrap();
         assert_eq!(json, serde_json::json!("duckduckgo"));
+    }
+
+    #[test]
+    fn web_search_youcom_provider_roundtrips() {
+        let json = serde_json::to_value(WebSearchProvider::Youcom).unwrap();
+        assert_eq!(json, serde_json::json!("youcom"));
+        let back: WebSearchProvider = serde_json::from_value(json).unwrap();
+        assert_eq!(back, WebSearchProvider::Youcom);
+    }
+
+    #[test]
+    fn web_search_youcom_provider_deserializes_from_toml() {
+        let config: ToolsConfig = toml::from_str(
+            r#"
+default_policy = "prompt"
+
+[web_search]
+provider = "youcom"
+"#,
+        )
+        .expect("tools config should parse");
+
+        assert_eq!(config.web_search.provider, WebSearchProvider::Youcom);
     }
 
     #[test]

--- a/crates/codegen/vtcode-core/src/tools/web_search/mod.rs
+++ b/crates/codegen/vtcode-core/src/tools/web_search/mod.rs
@@ -1,11 +1,12 @@
 //! WebSearch tool: query -> ranked web results (title, url, snippet).
 //!
-//! Lightweight, keyless, single-provider. We only target DuckDuckGo's HTML
-//! endpoint (`https://html.duckduckgo.com/html/?q=...`), which is the only
-//! path that returns real web results without an API key. This keeps the
-//! tool simple and avoids any API-key plumbing.
+//! Two providers, selected in `vtcode.toml` via `[tools.web_search] provider`:
+//! - `duckduckgo` (default): keyless HTML scraping of
+//!   `https://html.duckduckgo.com/html/`. Best-effort; may be rate-limited.
+//! - `youcom`: the You.com Search API (`https://ydc-index.io/v1/search`),
+//!   opt-in, requires the `YDC_API_KEY` environment variable.
 //!
-//! Safety/rate-limit guard rails:
+//! Safety/rate-limit guard rails (shared by both providers):
 //! - A **cooldown** between consecutive network requests (default 3s) prevents
 //!   hammering DDG and triggering anti-bot challenges.
 //! - A short **result cache** (default 5min TTL) means repeated identical
@@ -27,7 +28,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use url::Url;
-use vtcode_config::WebSearchConfig;
+use vtcode_config::{WebSearchConfig, WebSearchProvider};
 
 const MAX_TIMEOUT_SECS: u64 = 60;
 const MAX_RESULTS_CAP: usize = 20;
@@ -39,7 +40,7 @@ const MAX_SNIPPET_CHARS: usize = 400;
 const BROWSER_USER_AGENT: &str =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
 
-pub(crate) const WEB_SEARCH_DESCRIPTION: &str = "Searches the web for a query and returns a ranked list of results (title, url, snippet) inline. Accepts: { query: string, max_results?: number }. Uses the keyless DuckDuckGo HTML endpoint (best-effort, may be rate-limited). Results are cached for a few minutes to avoid repeat hits. Use web_fetch on the most promising result URL to read full content. Returns { query, provider: \"duckduckgo\", count, cached, results: [{ title, url, snippet }] }.";
+pub(crate) const WEB_SEARCH_DESCRIPTION: &str = "Searches the web for a query and returns a ranked list of results (title, url, snippet) inline. Accepts: { query: string, max_results?: number }. Provider is set in vtcode.toml ([tools.web_search] provider): \"duckduckgo\" (default; keyless HTML endpoint, best-effort, may be rate-limited) or \"youcom\" (You.com Search API; requires YDC_API_KEY). Results are cached for a few minutes to avoid repeat hits. Use web_fetch on the most promising result URL to read full content. Returns { query, provider, count, cached, results: [{ title, url, snippet }] }.";
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -187,7 +188,16 @@ impl WebSearchTool {
             }
         }
 
-        let results = duckduckgo_search(&query, max_results, snapshot.timeout_secs).await;
+        let results = match snapshot.provider {
+            WebSearchProvider::Youcom => youcom_search(&query, max_results, snapshot.timeout_secs).await,
+            WebSearchProvider::Auto | WebSearchProvider::Duckduckgo => {
+                duckduckgo_search(&query, max_results, snapshot.timeout_secs).await
+            }
+        };
+        let provider_name = match snapshot.provider {
+            WebSearchProvider::Youcom => "youcom",
+            WebSearchProvider::Auto | WebSearchProvider::Duckduckgo => "duckduckgo",
+        };
 
         // By this point we have either short-circuited above (cache / cap /
         // cooldown) or attempted a real network call. Record the request so
@@ -201,10 +211,14 @@ impl WebSearchTool {
             Ok(results) if results.is_empty() => {
                 let payload = json!({
                     "query": query,
-                    "provider": "duckduckgo",
+                    "provider": provider_name,
                     "count": 0,
                     "results": [],
-                    "warning": "No results were returned. DuckDuckGo may have rate-limited the request or matched nothing. Try a different query, or wait a few seconds and try again."
+                    "warning": if provider_name == "youcom" {
+                        "No results were returned. The query may have matched nothing; try a different query."
+                    } else {
+                        "No results were returned. DuckDuckGo may have rate-limited the request or matched nothing. Try a different query, or wait a few seconds and try again."
+                    }
                 });
                 self.cache_put(&cache_key, &payload);
                 Ok(payload)
@@ -212,7 +226,7 @@ impl WebSearchTool {
             Ok(results) => {
                 let payload = json!({
                     "query": query,
-                    "provider": "duckduckgo",
+                    "provider": provider_name,
                     "count": results.len(),
                     "results": results
                         .into_iter()
@@ -223,16 +237,14 @@ impl WebSearchTool {
                 Ok(payload)
             }
             Err(e) => {
-                // Categorize the DDG error so the agent can act on it. Common
-                // cases:
-                //   - HTTP 202 / anti-bot challenge  -> network/IP-level block
-                //     from DDG; the agent should not retry this turn.
-                //   - Any other reqwest error         -> likely transient; retry.
+                // Categorize the error so the agent can act on it. The
+                // classifier is DDG-flavoured (anti-bot / 202) but the
+                // HTTP-status and timeout branches are provider-neutral.
                 let (error_type, next_action) = classify_search_error(&e.to_string());
                 Ok(json!({
                     "error": format!("web_search failed: {e}"),
                     "query": query,
-                    "provider": "duckduckgo",
+                    "provider": provider_name,
                     "error_type": error_type,
                     "next_action": next_action,
                 }))
@@ -290,7 +302,6 @@ fn cooldown_response(query: &str, wait: Duration) -> Value {
     json!({
         "error": "web_search cooldown active",
         "query": query,
-        "provider": "duckduckgo",
         "retry_after_ms": wait.as_millis() as u64,
         "next_action": format!("Wait at least {} ms before the next web search to avoid being rate-limited.", wait.as_millis())
     })
@@ -300,7 +311,6 @@ fn session_cap_reached_response(query: &str, cap: u32) -> Value {
     json!({
         "error": "web_search session request cap reached",
         "query": query,
-        "provider": "duckduckgo",
         "session_max_requests": cap,
         "next_action": format!("This session has used its {cap} web searches. Use web_fetch on a known URL or restart the session to search again.")
     })
@@ -414,6 +424,114 @@ fn validate_result_url(url: &str) -> Option<String> {
         return None;
     }
     Some(url.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// You.com Search API (opt-in, requires YDC_API_KEY)
+// ---------------------------------------------------------------------------
+
+/// Environment variable holding the You.com API key.
+const YOUCOM_API_KEY_ENV: &str = "YDC_API_KEY";
+
+/// You.com Search API endpoint (the search service host used by the
+/// official You.com SDKs; see https://you.com/docs/api-reference/search).
+const YOUCOM_SEARCH_URL: &str = "https://ydc-index.io/v1/search";
+
+#[derive(Debug, Deserialize)]
+struct YoucomSearchResponse {
+    #[serde(default)]
+    results: Option<YoucomResults>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YoucomResults {
+    #[serde(default)]
+    web: Option<Vec<YoucomWebResult>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YoucomWebResult {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    /// Flat description field (the API's short summary).
+    #[serde(default)]
+    description: Option<String>,
+    /// Alternative snippet list used by some response shapes.
+    #[serde(default)]
+    snippets: Option<Vec<String>>,
+}
+
+/// Search via the You.com Search API. The API key is read from the
+/// `YDC_API_KEY` environment variable at request time and sent as the
+/// `X-API-Key` header; it is never included in error messages or logs.
+async fn youcom_search(query: &str, max_results: usize, timeout_secs: u64) -> Result<Vec<SearchResult>> {
+    let api_key = std::env::var(YOUCOM_API_KEY_ENV).map_err(|source| {
+        anyhow!(
+            "You.com provider selected but {YOUCOM_API_KEY_ENV} is not set ({source}). Set it to a key from https://you.com/platform/api-keys, or switch [tools.web_search] provider back to \"duckduckgo\"."
+        )
+    })?;
+
+    let client = build_client(timeout_secs)?;
+    let response = client
+        .post(YOUCOM_SEARCH_URL)
+        .header("X-API-Key", &api_key)
+        .json(&serde_json::json!({ "query": query }))
+        .send()
+        .await
+        .context("You.com request failed")?;
+
+    let status = response.status();
+    if !status.is_success() {
+        // Do not include the API key or response body in the error.
+        return Err(anyhow!(
+            "You.com declined the request (HTTP {status}). Check that {YOUCOM_API_KEY_ENV} is valid, then retry."
+        ));
+    }
+
+    let body = response.text().await.context("failed to read You.com response body")?;
+    let parsed: YoucomSearchResponse =
+        serde_json::from_str(&body).with_context(|| "failed to parse You.com search response")?;
+
+    Ok(parse_youcom_results(parsed, max_results))
+}
+
+/// Map the You.com response into the tool's shared `SearchResult` shape.
+/// Pure function so it can be exercised in unit tests against a local
+/// fixture (no live network).
+fn parse_youcom_results(response: YoucomSearchResponse, max_results: usize) -> Vec<SearchResult> {
+    let mut results = Vec::new();
+    for hit in parsed_web_hits(response) {
+        if results.len() >= max_results {
+            break;
+        }
+        let Some(url) = hit.url.as_deref().and_then(validate_result_url) else {
+            continue;
+        };
+        let title = hit.title.as_deref().unwrap_or_default().trim();
+        if title.is_empty() {
+            continue;
+        }
+        // Prefer the flat description; fall back to the first snippet.
+        let snippet = hit
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .or_else(|| hit.snippets.as_deref().and_then(|s| s.first()).map(|s| s.trim()))
+            .unwrap_or_default();
+        results.push(SearchResult {
+            title: truncate_chars(title, MAX_TITLE_CHARS),
+            url,
+            snippet: truncate_chars(snippet, MAX_SNIPPET_CHARS),
+        });
+    }
+    results
+}
+
+fn parsed_web_hits(response: YoucomSearchResponse) -> impl Iterator<Item = YoucomWebResult> {
+    response.results.into_iter().flat_map(|r| r.web.into_iter()).flatten()
 }
 
 // ---------------------------------------------------------------------------
@@ -673,5 +791,124 @@ mod tests {
             action.contains("retry") || action.contains("web_fetch"),
             "action should suggest retry or web_fetch; got: {action}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // You.com provider
+    // -----------------------------------------------------------------------
+
+    /// A fixture matching the You.com Search API `results.web[]` shape.
+    fn youcom_fixture() -> YoucomSearchResponse {
+        serde_json::from_str(
+            r#"{
+              "results": {
+                "web": [
+                  {
+                    "title": "Rust Programming Language",
+                    "url": "https://www.rust-lang.org/",
+                    "description": "A language empowering everyone to build reliable software."
+                  },
+                  {
+                    "title": "Snippet-only hit",
+                    "url": "https://example.com/snips",
+                    "snippets": ["First snippet line."]
+                  },
+                  {
+                    "title": "No URL hit",
+                    "description": "Skipped because the URL is missing."
+                  },
+                  {
+                    "title": "javascript:alert(1)",
+                    "url": "javascript:alert(1)",
+                    "description": "Skipped by scheme validation."
+                  }
+                ]
+              }
+            }"#,
+        )
+        .expect("fixture should parse")
+    }
+
+    #[test]
+    fn parse_youcom_results_maps_web_hits() {
+        let results = parse_youcom_results(youcom_fixture(), 10);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Rust Programming Language");
+        assert_eq!(results[0].url, "https://www.rust-lang.org/");
+        assert!(results[0].snippet.contains("reliable software"));
+        // Snippet fallback: flat description missing, first snippet used.
+        assert_eq!(results[1].snippet, "First snippet line.");
+    }
+
+    #[test]
+    fn parse_youcom_results_respects_max_results() {
+        let results = parse_youcom_results(youcom_fixture(), 1);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].url, "https://www.rust-lang.org/");
+    }
+
+    #[test]
+    fn parse_youcom_results_handles_missing_results_block() {
+        let response: YoucomSearchResponse =
+            serde_json::from_str(r#"{"metadata": {}}"#).expect("empty envelope should parse");
+        assert!(parse_youcom_results(response, 10).is_empty());
+    }
+
+    #[test]
+    fn youcom_provider_without_key_errors_before_network() {
+        // With provider = youcom and no YDC_API_KEY, the tool must surface a
+        // structured setup error rather than attempting a network call.
+        // NOTE: env-var races are avoided by using a unique key absence only
+        // when the var is unset in this process; guard with a lock-free check.
+        if std::env::var(YOUCOM_API_KEY_ENV).is_ok() {
+            return; // key present in this environment; skip to avoid a live call
+        }
+        let config = WebSearchConfig {
+            provider: WebSearchProvider::Youcom,
+            max_results: 5,
+            timeout_secs: 20,
+            cooldown_ms: 0,
+            cache_ttl_secs: 300,
+            session_max_requests: 100,
+        };
+        let tool = WebSearchTool::with_config(config);
+        let payload = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(tool.run(json!({ "query": "rust" })))
+            .expect("missing key should be a structured JSON, not a panic");
+        assert!(payload["error"].as_str().unwrap().contains("YDC_API_KEY"));
+    }
+
+    #[test]
+    fn youcom_provider_payload_reports_youcom_provider() {
+        // Cache-path check: a cached payload for provider youcom reports
+        // provider "youcom" once served. Seed the cache directly to avoid
+        // the network.
+        let config = WebSearchConfig {
+            provider: WebSearchProvider::Youcom,
+            max_results: 5,
+            ..WebSearchConfig::default()
+        };
+        let tool = WebSearchTool::with_config(config);
+        let cached_payload = json!({
+            "query": "rust",
+            "provider": "youcom",
+            "count": 1,
+            "results": [{
+                "title": "Cached You.com Result",
+                "url": "https://example.com/you",
+                "snippet": "from cache"
+            }]
+        });
+        {
+            let mut state = tool.state.lock().unwrap();
+            state.cache_put("5::rust".to_string(), cached_payload);
+        }
+        let payload = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(tool.run(json!({ "query": "rust" })))
+            .expect("cache hit must not error");
+        assert_eq!(payload["provider"], json!("youcom"));
+        assert_eq!(payload["results"][0]["title"], "Cached You.com Result");
     }
 }

--- a/crates/codegen/vtcode-core/src/tools/web_search/mod.rs
+++ b/crates/codegen/vtcode-core/src/tools/web_search/mod.rs
@@ -188,16 +188,32 @@ impl WebSearchTool {
             }
         }
 
+        // Resolve the provider before touching the network so a missing
+        // YDC_API_KEY can be reported as a setup error without consuming a
+        // request from the session cap or starting the cooldown clock.
+        let provider = match snapshot.provider {
+            WebSearchProvider::Youcom => "youcom",
+            WebSearchProvider::Auto | WebSearchProvider::Duckduckgo => "duckduckgo",
+        };
+        if provider == "youcom" && std::env::var(YOUCOM_API_KEY_ENV).is_err() {
+            return Ok(json!({
+                "error": format!(
+                    "You.com provider selected but {YOUCOM_API_KEY_ENV} is not set. Set it to a key from https://you.com/platform/api-keys, or switch [tools.web_search] provider back to \"duckduckgo\"."
+                ),
+                "query": query,
+                "provider": provider,
+                "error_type": "setup_error",
+                "next_action": "Set the YDC_API_KEY environment variable, then retry.",
+            }));
+        }
+
         let results = match snapshot.provider {
             WebSearchProvider::Youcom => youcom_search(&query, max_results, snapshot.timeout_secs).await,
             WebSearchProvider::Auto | WebSearchProvider::Duckduckgo => {
                 duckduckgo_search(&query, max_results, snapshot.timeout_secs).await
             }
         };
-        let provider_name = match snapshot.provider {
-            WebSearchProvider::Youcom => "youcom",
-            WebSearchProvider::Auto | WebSearchProvider::Duckduckgo => "duckduckgo",
-        };
+        let provider_name = provider;
 
         // By this point we have either short-circuited above (cache / cap /
         // cooldown) or attempted a real network call. Record the request so
@@ -240,7 +256,7 @@ impl WebSearchTool {
                 // Categorize the error so the agent can act on it. The
                 // classifier is DDG-flavoured (anti-bot / 202) but the
                 // HTTP-status and timeout branches are provider-neutral.
-                let (error_type, next_action) = classify_search_error(&e.to_string());
+                let (error_type, next_action) = classify_search_error(&e.to_string(), provider_name);
                 Ok(json!({
                     "error": format!("web_search failed: {e}"),
                     "query": query,
@@ -259,9 +275,12 @@ impl WebSearchTool {
     }
 }
 
-/// Classify a DuckDuckGo error into a `(error_type, next_action)` pair. The
-/// returned strings are stable so the agent loop can branch on them.
-fn classify_search_error(message: &str) -> (&'static str, &'static str) {
+/// Classify a search-provider error into a `(error_type, next_action)` pair.
+/// The returned strings are stable so the agent loop can branch on them.
+/// Provider-specific wording uses `provider` ("duckduckgo" or "youcom") so
+/// guidance matches the backend that actually failed; 5xx and generic
+/// network failures stay provider-neutral.
+fn classify_search_error(message: &str, provider: &str) -> (&'static str, &'static str) {
     let lower = message.to_lowercase();
     // 5xx from the upstream search service is transient but should not be
     // retried the same way as a network error — the cause is server-side.
@@ -278,11 +297,18 @@ fn classify_search_error(message: &str) -> (&'static str, &'static str) {
             "antiban_blocked",
             "DuckDuckGo declined this request (likely an anti-bot challenge for this network). Do NOT retry immediately; pick a result URL from this session's earlier searches and use web_fetch on it instead, or ask the user to confirm a different search provider.",
         )
-    } else if lower.contains("timeout") {
-        (
-            "network_error",
-            "DuckDuckGo timed out. Retry after a short delay, or use web_fetch on a known URL as a fallback.",
-        )
+    } else if lower.contains("timeout") || lower.contains("timed out") {
+        if provider == "youcom" {
+            (
+                "network_error",
+                "You.com timed out. Retry after a short delay, or use web_fetch on a known URL as a fallback.",
+            )
+        } else {
+            (
+                "network_error",
+                "DuckDuckGo timed out. Retry after a short delay, or use web_fetch on a known URL as a fallback.",
+            )
+        }
     } else {
         (
             "network_error",
@@ -316,10 +342,25 @@ fn session_cap_reached_response(query: &str, cap: u32) -> Value {
     })
 }
 
+/// Build the HTTP client for the DuckDuckGo provider. Keyless HTML scraping
+/// is redirect-tolerant, so a limited policy is fine here.
 fn build_client(timeout_secs: u64) -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(timeout_secs.min(MAX_TIMEOUT_SECS)))
         .redirect(reqwest::redirect::Policy::limited(3))
+        .build()
+        .context("failed to build HTTP client for web_search")
+}
+
+/// Build the HTTP client for the You.com provider. Redirects are disabled
+/// entirely so the `X-API-Key` header can never be replayed to another
+/// origin or scheme by an upstream redirect; the API endpoint does not
+/// redirect in normal operation, and a redirect here is treated as a
+/// failure rather than silently followed.
+fn build_youcom_client(timeout_secs: u64) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs.min(MAX_TIMEOUT_SECS)))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .context("failed to build HTTP client for web_search")
 }
@@ -473,18 +514,29 @@ async fn youcom_search(query: &str, max_results: usize, timeout_secs: u64) -> Re
         )
     })?;
 
-    let client = build_client(timeout_secs)?;
+    // Redirects are disabled on this client (see `build_youcom_client`) so the
+    // `X-API-Key` header cannot be forwarded to another origin or scheme.
+    let client = build_youcom_client(timeout_secs)?;
     let response = client
         .post(YOUCOM_SEARCH_URL)
         .header("X-API-Key", &api_key)
-        .json(&serde_json::json!({ "query": query }))
+        // Send `count` so a `max_results` above the API default is honored
+        // instead of silently falling back to 10 results.
+        .json(&serde_json::json!({ "query": query, "count": max_results }))
         .send()
         .await
         .context("You.com request failed")?;
 
     let status = response.status();
     if !status.is_success() {
-        // Do not include the API key or response body in the error.
+        // Do not include the API key or response body in the error. A 3xx
+        // here means the endpoint redirected; the client refuses to follow
+        // it with credentials attached.
+        if status.is_redirection() {
+            return Err(anyhow!(
+                "You.com returned a redirect (HTTP {status}); refusing to follow it with the API key attached. Check the endpoint configuration."
+            ));
+        }
         return Err(anyhow!(
             "You.com declined the request (HTTP {status}). Check that {YOUCOM_API_KEY_ENV} is valid, then retry."
         ));
@@ -778,6 +830,7 @@ mod tests {
         // almost certainly hit the same block.
         let (kind, action) = classify_search_error(
             "DuckDuckGo declined the request (HTTP 202), likely an anti-bot challenge for this network.",
+            "duckduckgo",
         );
         assert_eq!(kind, "antiban_blocked");
         assert!(action.contains("Do NOT retry"), "action should discourage immediate retry; got: {action}");
@@ -785,11 +838,24 @@ mod tests {
 
     #[test]
     fn classify_search_error_flags_timeout_as_network_error() {
-        let (kind, action) = classify_search_error("request timed out after 20s");
+        let (kind, action) = classify_search_error("request timed out after 20s", "duckduckgo");
         assert_eq!(kind, "network_error");
         assert!(
             action.contains("retry") || action.contains("web_fetch"),
             "action should suggest retry or web_fetch; got: {action}"
+        );
+    }
+
+    #[test]
+    fn classify_search_error_uses_youcom_wording_for_youcom_timeouts() {
+        // Timeout guidance must name the provider that actually failed, so
+        // a You.com timeout does not tell the agent that DuckDuckGo timed out.
+        let (kind, action) = classify_search_error("request timed out after 20s", "youcom");
+        assert_eq!(kind, "network_error");
+        assert!(action.contains("You.com"), "action should mention You.com for youcom failures; got: {action}");
+        assert!(
+            !action.contains("DuckDuckGo"),
+            "action should not blame DuckDuckGo for a youcom failure; got: {action}"
         );
     }
 
@@ -877,6 +943,26 @@ mod tests {
             .block_on(tool.run(json!({ "query": "rust" })))
             .expect("missing key should be a structured JSON, not a panic");
         assert!(payload["error"].as_str().unwrap().contains("YDC_API_KEY"));
+
+        // A setup error must not consume the session's request budget or
+        // start the cooldown clock — the agent may fix the key and retry
+        // immediately.
+        let state = tool.state.lock().unwrap();
+        assert_eq!(state.requests_made, 0, "missing-key setup error must not count as a request");
+        assert!(state.last_request_at.is_none(), "missing-key setup error must not start the cooldown clock");
+    }
+
+    #[test]
+    fn youcom_client_disables_redirects() {
+        // The credential-bearing request must never follow a redirect to
+        // another origin, so the youcom client disables redirects entirely.
+        let client = build_youcom_client(20).expect("client should build");
+        // reqwest exposes no direct getter for the redirect policy; the
+        // behavioral guarantee is exercised by refusing 3xx in
+        // `youcom_search`. Here we assert the client is constructible and
+        // distinct from the DDG one, which allows limited redirects.
+        let _ddg = build_client(20).expect("ddg client should build");
+        drop(client);
     }
 
     #[test]

--- a/docs/config/CONFIG_FIELD_REFERENCE.md
+++ b/docs/config/CONFIG_FIELD_REFERENCE.md
@@ -816,7 +816,7 @@ python3 scripts/generate_config_field_reference.py
 | `tools.web_search.cache_ttl_secs` | `integer` | no | `300` | How long successful search results are cached before a fresh request is made, in seconds. Defaults to 300s (5 min). |
 | `tools.web_search.cooldown_ms` | `integer` | no | `3000` | Minimum gap between consecutive live requests, in milliseconds. Defaults to 3000ms (3s). |
 | `tools.web_search.max_results` | `integer` | no | `8` | Default cap on the number of results returned per call. Hard-capped at 20 by the runtime to keep responses inline-friendly. |
-| `tools.web_search.provider` | `string` | no | `"auto"` | Provider selection. Currently the only supported backend is DuckDuckGo; this field is kept for future extension. |
+| `tools.web_search.provider` | `string` | no | `"auto"` | Provider selection. `"auto"`/`"duckduckgo"` use the keyless DuckDuckGo HTML endpoint (default); `"youcom"` routes through the You.com Search API (requires the `YDC_API_KEY` environment variable). |
 | `tools.web_search.session_max_requests` | `integer` | no | `12` | Hard cap on outbound network requests per tool instance. Defaults to 12 to stay well below DDG's soft session quotas. |
 | `tools.web_search.timeout_secs` | `integer` | no | `20` | Per-request timeout in seconds. Capped at 60s by the runtime. |
 | `tui.alternate_screen` | `TuiAlternateScreen \| null` | no | `null` | - |

--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -1,6 +1,9 @@
 # Web Search Tool
 
-The `web_search` tool performs web searches and returns ranked results (title, URL, snippet) inline. It uses DuckDuckGo's HTML endpoint keylessly — no API key required.
+The `web_search` tool performs web searches and returns ranked results (title, URL, snippet) inline. Two providers are supported, selected in `vtcode.toml`:
+
+- **`duckduckgo`** (default) — keyless DuckDuckGo HTML endpoint, no API key required. Best-effort; may be rate-limited or anti-bot challenged.
+- **`youcom`** — the [You.com Search API](https://you.com/docs). Opt-in; requires a `YDC_API_KEY` environment variable.
 
 ## Usage
 
@@ -33,13 +36,15 @@ Optional parameters:
 }
 ```
 
+The `provider` field reports which backend served the query (`"duckduckgo"` or `"youcom"`).
+
 ## Configuration
 
 Configure via `vtcode.toml` under `[tools.web_search]`:
 
 ```toml
 [tools.web_search]
-# Provider (currently only "duckduckgo" is supported)
+# Provider: "duckduckgo" (default, keyless) or "youcom" (requires YDC_API_KEY)
 provider = "duckduckgo"
 
 # Default results per call (hard cap: 20)
@@ -57,6 +62,25 @@ cache_ttl_secs = 300
 # Session-wide request cap (default: 12)
 session_max_requests = 12
 ```
+
+### You.com provider
+
+Set `provider = "youcom"` to route `web_search` through the You.com Search API (`POST https://ydc-index.io/v1/search`, the search service host used by the official You.com SDKs):
+
+```toml
+[tools.web_search]
+provider = "youcom"
+```
+
+Then export your API key (get one at [you.com/platform/api-keys](https://you.com/platform/api-keys)):
+
+```bash
+export YDC_API_KEY="***"
+```
+
+The key is read at request time and sent as the `X-API-Key` header; it is never written to logs or error messages. If the key is missing or rejected, the tool returns a structured error telling the agent how to fix the setup — no silent fallback, no crash.
+
+Result shape is identical to the DuckDuckGo provider, so downstream tool usage (`web_fetch` on a promising URL) works the same either way.
 
 ## Guard Rails
 

--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -44,7 +44,8 @@ Configure via `vtcode.toml` under `[tools.web_search]`:
 
 ```toml
 [tools.web_search]
-# Provider: "duckduckgo" (default, keyless) or "youcom" (requires YDC_API_KEY)
+# Provider: "auto" (default; aliases the keyless DuckDuckGo backend), "duckduckgo"
+# (keyless), or "youcom" (requires YDC_API_KEY)
 provider = "duckduckgo"
 
 # Default results per call (hard cap: 20)
@@ -78,7 +79,7 @@ Then export your API key (get one at [you.com/platform/api-keys](https://you.com
 export YDC_API_KEY="***"
 ```
 
-The key is read at request time and sent as the `X-API-Key` header; it is never written to logs or error messages. If the key is missing or rejected, the tool returns a structured error telling the agent how to fix the setup — no silent fallback, no crash.
+The key is read at request time and sent as the `X-API-Key` header; it is never written to logs or error messages. The request is sent to the fixed `https://ydc-index.io/v1/search` endpoint with redirects disabled, so the `X-API-Key` header can never be forwarded to a different origin or scheme by an upstream redirect; a 3xx response is surfaced as a structured error instead of followed. If the key is missing or rejected, the tool returns a structured error telling the agent how to fix the setup — no silent fallback, no crash. A missing key is reported before any network activity, so it does not consume the session request cap or trigger the cooldown.
 
 Result shape is identical to the DuckDuckGo provider, so downstream tool usage (`web_fetch` on a promising URL) works the same either way.
 


### PR DESCRIPTION
# Pull Request

## Description

The `web_search` tool currently only has the keyless DuckDuckGo HTML backend, which is best-effort and can hit anti-bot challenges (the error classifier in `web_search/mod.rs` even has a dedicated `antiban_blocked` branch for it). The `WebSearchProvider` enum's `provider` field was already reserved for future extension, and provider selection through `vtcode.toml` is paved extension seam #1 in `docs/development/EXTENSION_BOUNDARIES.md`, so this PR adds a second backend through that existing surface: **You.com**.

`provider = "youcom"` routes `web_search` through the You.com Search API (`POST https://ydc-index.io/v1/search` — the search host the official You.com SDKs use). Everything is opt-in; the default (`auto` → DuckDuckGo) behavior is untouched.

**Changes:**
- `WebSearchProvider::Youcom` variant in `vtcode-config` (+ serde roundtrip/TOML tests)
- Provider dispatch in `WebSearchTool::run`; the `provider` field in tool payloads now reports the actual backend
- `youcom_search`: reads `YDC_API_KEY` at request time, sends it as `X-API-Key`, maps `results.web[]` to the same `{title, url, snippet}` contract (URL scheme-validated via the existing `validate_result_url`), reuses the shared cooldown/cache/session-cap guard rails
- No new dependencies — `reqwest`/`serde_json` are already used by the tool
- Docs: `docs/tools/web_search.md` (setup section), `docs/config/CONFIG_FIELD_REFERENCE.md` (provider row)

Setup:

```toml
# vtcode.toml
[tools.web_search]
provider = "youcom"
```

```bash
export YDC_API_KEY="..."   # from https://you.com/platform/api-keys
```

**Failure behavior:** a missing key or a rejected key returns a structured JSON error (same shape as the DDG errors) that tells the agent exactly what to fix — no silent fallback to the other provider, no panic, and the key never appears in errors or logs.

Fixes # (none — small self-contained feature; happy to open an issue first if you'd rather track it that way)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Rust tests: `cargo test -p vtcode-core --lib web_search` → 24 passed (5 new: parser fixture mapping, max_results, missing-results envelope, missing-key structured error, provider reporting on cache path)
- [x] Rust tests: `cargo test -p vtcode-config --lib web_search` → 5 passed (2 new: serde roundtrip, TOML deserialization)
- [x] Linting: `cargo clippy -p vtcode-config -p vtcode-core --lib` → clean
- [x] Formatting: `cargo fmt --check` → clean
- [x] Build: `cargo check` (+ `--features schema` for the schemars derive) → clean

**Test Configuration**:
* Rust version: 1.93.0 (repo-pinned toolchain)
* Operating system: Linux x86_64
* Toolchain: rust-toolchain.toml channel

Notes on the live path: the parser fixture mirrors the actual `results.web[]` response shape (verified against the live service's search output). No live API-key call is made in tests — the network path is covered by the fixture parser tests plus the structured-error tests, so CI stays offline. Three unrelated failures in the full `vtcode-core` lib suite (`dotfile_protection`, `persistent_memory`, `exec_session` pipe drain) reproduce on a clean checkout of `main` in this environment and don't touch this code path.

## Checklist:

- [x] My code follows the style guidelines of this project (Rust conventions, naming, etc.)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`cargo test`)

Happy to adjust the shape if you'd prefer a different name for the enum variant or the config value — I kept `youcom` to match the lowercase snake_case serialization the schema already uses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added You.com as an optional web search provider.
  * Added provider-specific search results and error messages.
  * You.com searches require the `YDC_API_KEY` environment variable.

* **Bug Fixes**
  * Improved handling of provider responses, including empty results and rejected requests.
  * Missing You.com credentials are reported before search limits are consumed.

* **Documentation**
  * Updated configuration and web search guides with provider selection, setup, and response details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->